### PR TITLE
[WIP] Add Singer Selection Dialog

### DIFF
--- a/OpenUtau.Core/Classic/ClassicSingerLoader.cs
+++ b/OpenUtau.Core/Classic/ClassicSingerLoader.cs
@@ -17,11 +17,7 @@ namespace OpenUtau.Classic {
         }
         public static IEnumerable<USinger> FindAllSingers() {
             List<USinger> singers = new List<USinger>();
-            foreach (var path in new string[] {
-                PathManager.Inst.SingersPathOld,
-                PathManager.Inst.SingersPath,
-                PathManager.Inst.AdditionalSingersPath,
-            }) {
+            foreach (var path in PathManager.Inst.SingersPaths) {
                 var loader = new VoicebankLoader(path);
                 singers.AddRange(loader.SearchAll()
                     .Select(AdjustSingerType));

--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using Serilog;
 
 namespace OpenUtau.Classic {
@@ -43,7 +44,14 @@ namespace OpenUtau.Classic {
             if (!Directory.Exists(basePath)) {
                 return result;
             }
-            result.AddRange(Directory.EnumerateFiles(basePath, kCharTxt, SearchOption.AllDirectories)
+            IEnumerable<string> files;
+            if (Preferences.Default.LoadDeepFolderSinger) {
+                files = Directory.EnumerateFiles(basePath, kCharTxt, SearchOption.AllDirectories);
+            } else {
+                files = Directory.GetDirectories(basePath) // TopDirectoryOnly
+                    .SelectMany(path => Directory.EnumerateFiles(path, kCharTxt));
+            }
+            result.AddRange(files
                 .Select(filePath => {
                     try {
                         var voicebank = new Voicebank();

--- a/OpenUtau.Core/SingerManager.cs
+++ b/OpenUtau.Core/SingerManager.cs
@@ -32,7 +32,8 @@ namespace OpenUtau.Core {
                 Directory.CreateDirectory(PathManager.Inst.SingersPath);
                 var stopWatch = Stopwatch.StartNew();
                 var singers = ClassicSingerLoader.FindAllSingers()
-                    .Concat(Vogen.VogenSingerLoader.FindAllSingers());
+                    .Concat(Vogen.VogenSingerLoader.FindAllSingers())
+                    .Distinct();
                 Singers = singers
                     .ToLookup(s => s.Id)
                     .ToDictionary(g => g.Key, g => g.First());

--- a/OpenUtau.Core/Ustx/UTrack.cs
+++ b/OpenUtau.Core/Ustx/UTrack.cs
@@ -85,7 +85,7 @@ namespace OpenUtau.Core.Ustx {
         [YamlIgnore] public Phonemizer Phonemizer { get; set; } = PhonemizerFactory.Get(typeof(DefaultPhonemizer)).Create();
         [YamlIgnore] public string PhonemizerTag => Phonemizer.Tag;
 
-        [YamlIgnore] public string SingerName => Singer != null ? Singer.DisplayName : "[No Singer]";
+        [YamlIgnore] public string SingerName => Singer != null ? Singer.LocalizedName : "[No Singer]";
         [YamlIgnore] public int TrackNo { set; get; }
         public string TrackName { get; set; } = "New Track";
         public string TrackColor { get; set; } = "Blue";

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -119,6 +119,7 @@ namespace OpenUtau.Core.Util {
             public int Theme;
             public int DegreeStyle;
             public bool UseTrackColor = false;
+            public int SingerSelectionMode = 0;
             public bool ClearCacheOnQuit = false;
             public bool PreRender = true;
             public int NumRenderThreads = 2;

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -12,6 +12,12 @@ namespace OpenUtau.Core.Util {
 
         static Preferences() {
             Load();
+            if(Default != null && !string.IsNullOrEmpty(Default.AdditionalSingerPath)) {
+                if (!Default.AdditionalSingerPaths.Contains(Default.AdditionalSingerPath)) {
+                    Default.AdditionalSingerPaths.Insert(0, Default.AdditionalSingerPath);
+                }
+                Default.AdditionalSingerPath = string.Empty;
+            }
         }
 
         public static void Save() {
@@ -29,12 +35,12 @@ namespace OpenUtau.Core.Util {
             Save();
         }
 
-        public static List<string> GetSingerSearchPaths() {
-            return new List<string>(Default.SingerSearchPaths);
-        }
-
         public static void SetSingerSearchPaths(List<string> paths) {
-            Default.SingerSearchPaths = new List<string>(paths);
+            var list = new List<string>(paths);
+            list.Remove(PathManager.Inst.SingersPath);
+            list.Remove(PathManager.Inst.SingersPathOld);
+            list.RemoveAll(path => !Directory.Exists(path));
+            Default.AdditionalSingerPaths = list;
             Save();
         }
 
@@ -105,7 +111,6 @@ namespace OpenUtau.Core.Util {
             public bool MainMaximized;
             public bool MidiMaximized;
             public int UndoLimit = 100;
-            public List<string> SingerSearchPaths = new List<string>();
             public string PlaybackDevice = string.Empty;
             public int PlaybackDeviceNumber;
             public int? PlaybackDeviceIndex;
@@ -127,11 +132,14 @@ namespace OpenUtau.Core.Util {
             public string SortingOrder = string.Empty;
             public List<string> RecentFiles = new List<string>();
             public string SkipUpdate = string.Empty;
-            public string AdditionalSingerPath = string.Empty;
-            public bool InstallToAdditionalSingersPath = true;
+            public string AdditionalSingerPath = string.Empty; // legacy
+            public List<string> AdditionalSingerPaths = new List<string>();
+            public bool LoadDeepFolderSinger = true;
+            public bool InstallToAdditionalSingersPath = true; // Use AdditionalSingerPaths.First()
             public bool PreferCommaSeparator = false;
             public bool ResamplerLogging = false;
             public List<string> RecentSingers = new List<string>();
+            public List<string> FavoriteSingers = new List<string>();
             public Dictionary<string, string> SingerPhonemizers = new Dictionary<string, string>();
             public List<string> RecentPhonemizers = new List<string>();
             public bool PreferPortAudio = false;

--- a/OpenUtau.Core/Vogen/VogenSingerLoader.cs
+++ b/OpenUtau.Core/Vogen/VogenSingerLoader.cs
@@ -30,11 +30,7 @@ namespace OpenUtau.Core.Vogen {
 
         public static IEnumerable<USinger> FindAllSingers() {
             List<USinger> singers = new List<USinger>();
-            foreach (var path in new string[] {
-                PathManager.Inst.SingersPathOld,
-                PathManager.Inst.SingersPath,
-                PathManager.Inst.AdditionalSingersPath,
-            }) {
+            foreach (var path in PathManager.Inst.SingersPaths) {
                 var loader = new VogenSingerLoader(path);
                 singers.AddRange(loader.SearchAll());
             }
@@ -50,7 +46,14 @@ namespace OpenUtau.Core.Vogen {
             if (!Directory.Exists(basePath)) {
                 return result;
             }
-            result.AddRange(Directory.EnumerateFiles(basePath, "*.vogeon", SearchOption.AllDirectories)
+            IEnumerable<string> files;
+            if (Preferences.Default.LoadDeepFolderSinger) {
+                files = Directory.EnumerateFiles(basePath, "*.vogeon", SearchOption.AllDirectories);
+            } else {
+                files = Directory.GetDirectories(basePath) // TopDirectoryOnly
+                    .SelectMany(path => Directory.EnumerateFiles(path, "*.vogeon"));
+            }
+            result.AddRange(files
                 .Select(filePath => {
                     try {
                         return LoadSinger(filePath);

--- a/OpenUtau/Controls/TrackHeader.axaml.cs
+++ b/OpenUtau/Controls/TrackHeader.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using ReactiveUI;
 
 namespace OpenUtau.App.Controls {
@@ -83,7 +84,10 @@ namespace OpenUtau.App.Controls {
         }
 
         void SingerButtonClicked(object sender, RoutedEventArgs args) {
-            if (VisualRoot is Window window) {
+            if (SingerManager.Inst.Singers.Count > 0 && Preferences.Default.SingerSelectionMode == 1) {
+                ViewModel?.RefreshSingers();
+                SingersMenu.Open();
+            } else if (VisualRoot is Window window) {
                 var dialog = new Views.SingerSelectionDialog(track != null ? track.TrackNo : 0);
                 dialog.onFinish = singer => ViewModel?.ChangeSinger(singer);
                 dialog.ShowDialog(window);

--- a/OpenUtau/Controls/TrackHeader.axaml.cs
+++ b/OpenUtau/Controls/TrackHeader.axaml.cs
@@ -83,9 +83,10 @@ namespace OpenUtau.App.Controls {
         }
 
         void SingerButtonClicked(object sender, RoutedEventArgs args) {
-            if (SingerManager.Inst.Singers.Count > 0) {
-                ViewModel?.RefreshSingers();
-                SingersMenu.Open();
+            if (VisualRoot is Window window) {
+                var dialog = new Views.SingerSelectionDialog(track != null ? track.TrackNo : 0);
+                dialog.onFinish = singer => ViewModel?.ChangeSinger(singer);
+                dialog.ShowDialog(window);
             }
             args.Handled = true;
         }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -353,6 +353,11 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="progress.saved">Project saved. {0}</system:String>
   <system:String x:Key="progress.waitingrendering">Waiting Rendering</system:String>
 
+  <system:String x:Key="singerlocation.add">Add</system:String>
+  <system:String x:Key="singerlocation.remove">Remove</system:String>
+  <system:String x:Key="singerlocation.set">Set Singer Locations</system:String>
+  <system:String x:Key="singerlocation.where">Where to install new singers:</system:String>
+  
   <system:String x:Key="singers.caption">Singers</system:String>
   <system:String x:Key="singers.editoto.editinvlabeler">Edit In vLabeler</system:String>
   <system:String x:Key="singers.editoto.gotosource">Goto Source File</system:String>
@@ -395,6 +400,11 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="singers.subbanks.tone">Tone</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Tone Ranges</system:String>
   <system:String x:Key="singers.visitwebsite">Visit Website</system:String>
+
+  <system:String x:Key="singerselection.foldersettings">Folder Settings</system:String>
+  <system:String x:Key="singerselection.loaddeepfolders">Load all depth folders</system:String>
+  <system:String x:Key="singerselection.reload">Reload</system:String>
+  <system:String x:Key="singerselection.search">Search singer</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>
   <system:String x:Key="singersetup.archivefileencoding.prompt">Choose an encoding that make file names look right.</system:String>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -308,7 +308,6 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.otoeditor.select">Default Oto Editor</system:String>
   <system:String x:Key="prefs.paths">Paths</system:String>
   <system:String x:Key="prefs.paths.addlsinger">Additional Singer Path</system:String>
-  <system:String x:Key="prefs.paths.addlsinger.install">Install to Additional Singer Path</system:String>
   <system:String x:Key="prefs.paths.reset">Reset</system:String>
   <system:String x:Key="prefs.paths.select">Select</system:String>
   <system:String x:Key="prefs.playback">Playback</system:String>
@@ -348,6 +347,10 @@ Warning: this option removes custom presets.</system:String>
   </system:String>
   <system:String x:Key="prefs.rendering.threads.numthreads">Maximum Render Threads</system:String>
   <system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>
+  <system:String x:Key="prefs.singer">Singer</system:String>
+  <system:String x:Key="prefs.singer.extension">Extension</system:String>
+  <system:String x:Key="prefs.singer.select">Singer selection mode</system:String>
+  <system:String x:Key="prefs.singer.simple">Simple</system:String>
 
   <system:String x:Key="progress.loadingsingers">Loading Singers...</system:String>
   <system:String x:Key="progress.saved">Project saved. {0}</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -307,7 +307,6 @@
   <system:String x:Key="prefs.otoeditor.select">デフォルトの原音設定エディタ</system:String>
   <system:String x:Key="prefs.paths">ファイルの場所</system:String>
   <system:String x:Key="prefs.paths.addlsinger">シンガーの場所（追加）</system:String>
-  <system:String x:Key="prefs.paths.addlsinger.install">シンガーの場所(追加)にインストール</system:String>
   <system:String x:Key="prefs.paths.reset">リセット</system:String>
   <system:String x:Key="prefs.paths.select">選択</system:String>
   <system:String x:Key="prefs.playback">再生</system:String>
@@ -347,6 +346,10 @@
   </system:String>-->
   <!--<system:String x:Key="prefs.rendering.threads.numthreads">Maximum Render Threads</system:String>-->
   <!--<system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>-->
+  <system:String x:Key="prefs.singer">シンガー</system:String>
+  <system:String x:Key="prefs.singer.extension">拡張</system:String>
+  <system:String x:Key="prefs.singer.select">シンガーの選択画面</system:String>
+  <system:String x:Key="prefs.singer.simple">シンプル</system:String>
 
   <system:String x:Key="progress.loadingsingers">シンガー読み込み中...</system:String>
   <system:String x:Key="progress.saved">プロジェクトが保存されました。 {0}</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -352,6 +352,11 @@
   <system:String x:Key="progress.saved">プロジェクトが保存されました。 {0}</system:String>
   <system:String x:Key="progress.waitingrendering">レンダリング中</system:String>
 
+  <system:String x:Key="singerlocation.add">追加</system:String>
+  <system:String x:Key="singerlocation.remove">削除</system:String>
+  <system:String x:Key="singerlocation.set">シンガーの場所を設定</system:String>
+  <system:String x:Key="singerlocation.where">シンガーを新たにインストールする場所：</system:String>
+
   <system:String x:Key="singers.caption">シンガー</system:String>
   <system:String x:Key="singers.editoto.editinvlabeler">vLabelerで編集</system:String>
   <system:String x:Key="singers.editoto.gotosource">原音の場所を開く</system:String>
@@ -394,6 +399,11 @@
   <system:String x:Key="singers.subbanks.tone">音程</system:String>
   <system:String x:Key="singers.subbanks.toneranges">音域</system:String>
   <system:String x:Key="singers.visitwebsite">ウェブサイトを開く</system:String>
+
+  <system:String x:Key="singerselection.foldersettings">フォルダ設定</system:String>
+  <system:String x:Key="singerselection.loaddeepfolders">深い階層のフォルダも読み込む</system:String>
+  <system:String x:Key="singerselection.reload">再読み込み</system:String>
+  <system:String x:Key="singerselection.search">シンガーを検索</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">アーカイブファイルのエンコード</system:String>
   <system:String x:Key="singersetup.archivefileencoding.prompt">ファイル名が文字化けしないエンコードを選択してください。</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -27,10 +27,11 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int PlaybackAutoScroll { get; set; }
         [Reactive] public double PlayPosMarkerMargin { get; set; }
         [Reactive] public int LockStartTime { get; set; }
+        [Reactive] public int SingerSelectionMode { get; set; }
+        public string CachePath => PathManager.Inst.CachePath;
         [Reactive] public bool PreRender { get; set; }
         public List<string> DefaultRendererOptions { get; set; }
         [Reactive] public string DefaultRenderer { get; set; }
-        public string CachePath => PathManager.Inst.CachePath;
         [Reactive] public int NumRenderThreads { get; set; }
         public List<string> OnnxRunnerOptions { get; set; }
         [Reactive] public string OnnxRunner { get; set; }
@@ -146,6 +147,7 @@ namespace OpenUtau.App.ViewModels {
             RememberUst = Preferences.Default.RememberUst;
             RememberVsqx = Preferences.Default.RememberVsqx;
             ClearCacheOnQuit = Preferences.Default.ClearCacheOnQuit;
+            SingerSelectionMode = Preferences.Default.SingerSelectionMode;
 
             this.WhenAnyValue(vm => vm.AudioOutputDevice)
                 .WhereNotNull()
@@ -291,6 +293,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.DiffSingerDepth)
                 .Subscribe(index => {
                     Preferences.Default.DiffSingerDepth = index;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.SingerSelectionMode)
+                .Subscribe(index => {
+                    Preferences.Default.SingerSelectionMode = index;
                     Preferences.Save();
                 });
         }

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -27,8 +27,6 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int PlaybackAutoScroll { get; set; }
         [Reactive] public double PlayPosMarkerMargin { get; set; }
         [Reactive] public int LockStartTime { get; set; }
-        public string AdditionalSingersPath => PathManager.Inst.AdditionalSingersPath;
-        [Reactive] public bool InstallToAdditionalSingersPath { get; set; }
         [Reactive] public bool PreRender { get; set; }
         public List<string> DefaultRendererOptions { get; set; }
         [Reactive] public string DefaultRenderer { get; set; }
@@ -109,7 +107,6 @@ namespace OpenUtau.App.ViewModels {
             PlaybackAutoScroll = Preferences.Default.PlaybackAutoScroll;
             PlayPosMarkerMargin = Preferences.Default.PlayPosMarkerMargin;
             LockStartTime = Preferences.Default.LockStartTime;
-            InstallToAdditionalSingersPath = Preferences.Default.InstallToAdditionalSingersPath;
             ToolsManager.Inst.Initialize();
             var pattern = new Regex(@"Strings\.([\w-]+)\.axaml");
             Languages = App.GetLanguages().Keys
@@ -180,11 +177,6 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.LockStartTime)
                 .Subscribe(lockStartTime => {
                     Preferences.Default.LockStartTime = lockStartTime;
-                    Preferences.Save();
-                });
-            this.WhenAnyValue(vm => vm.InstallToAdditionalSingersPath)
-                .Subscribe(additionalSingersPath => {
-                    Preferences.Default.InstallToAdditionalSingersPath = additionalSingersPath;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.PreRender)
@@ -315,12 +307,6 @@ namespace OpenUtau.App.ViewModels {
             } catch (Exception e) {
                 DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(e));
             }
-        }
-
-        public void SetAddlSingersPath(string path) {
-            Preferences.Default.AdditionalSingerPath = path;
-            Preferences.Save();
-            this.RaisePropertyChanged(nameof(AdditionalSingersPath));
         }
 
         public void SetVLabelerPath(string path) {

--- a/OpenUtau/ViewModels/SingerSelectionViewModel.cs
+++ b/OpenUtau/ViewModels/SingerSelectionViewModel.cs
@@ -15,8 +15,6 @@ namespace OpenUtau.App.ViewModels {
     public class SingerSelectionViewModel : ViewModelBase {
         [Reactive] public ObservableCollection<string> Categories { get; set; } = new ObservableCollection<string>();
         [Reactive] public int SelectedCategory { get; set; } = 0;
-        [Reactive] public USinger? SelectedSinger { get; set; }
-        [Reactive] public string SelectedSingerPath { get; set; } = string.Empty;
         [Reactive] public string Search { get; set; } = string.Empty;
         public bool LoadDeepFolders { get => Preferences.Default.LoadDeepFolderSinger; }
         private int trackNo;
@@ -26,14 +24,6 @@ namespace OpenUtau.App.ViewModels {
 
         public SingerSelectionViewModel() { }
         public SingerSelectionViewModel(int trackNo, SingerSelectionDialog dialog) {
-            this.WhenAnyValue(x => x.SelectedSinger)
-                .Subscribe(value => {
-                    if (value != null) {
-                        SelectedSingerPath = value.Name + " [" + value.Location + "]";
-                    } else {
-                        SelectedSingerPath = "";
-                    }
-                });
             this.WhenAnyValue(x => x.Search)
                 .Subscribe(value => SortSingers());
             this.WhenAnyValue(x => x.SelectedCategory)
@@ -43,7 +33,6 @@ namespace OpenUtau.App.ViewModels {
             this.dialog = dialog;
 
             SetCategories();
-            SelectedSinger = DocManager.Inst.Project.tracks[trackNo].Singer;
         }
 
         private void SetCategories() {
@@ -76,7 +65,7 @@ namespace OpenUtau.App.ViewModels {
                     SingerManager.Inst.SingerGroups.ForEach(type => SortedSingers.Add(type.Key,
                         type.Value.Where(singer => Preferences.Default.FavoriteSingers.Contains(singer.Id)).ToList()));
                     break;
-                default: //directries
+                default: //directories
                     string dir = Categories[SelectedCategory];
                     SingerManager.Inst.SingerGroups.ForEach(type => SortedSingers.Add(type.Key,
                         type.Value.Where(singer => singer.BasePath == dir).ToList()));
@@ -91,7 +80,6 @@ namespace OpenUtau.App.ViewModels {
         public async Task Reload() {
             await Task.Run(() => SingerManager.Inst.SearchAllSingers());
             SetCategories();
-            SelectedSinger = DocManager.Inst.Project.tracks[trackNo].Singer;
         }
 
         public void ToggleLoadAllFolders() {

--- a/OpenUtau/ViewModels/SingerSelectionViewModel.cs
+++ b/OpenUtau/ViewModels/SingerSelectionViewModel.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using OpenUtau.App.Views;
+using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using SharpCompress;
+
+namespace OpenUtau.App.ViewModels {
+    public class SingerSelectionViewModel : ViewModelBase {
+        [Reactive] public ObservableCollection<string> Categories { get; set; } = new ObservableCollection<string>();
+        [Reactive] public int SelectedCategory { get; set; } = 0;
+        [Reactive] public USinger? SelectedSinger { get; set; }
+        [Reactive] public string SelectedSingerPath { get; set; } = string.Empty;
+        [Reactive] public string Search { get; set; } = string.Empty;
+        public bool LoadDeepFolders { get => Preferences.Default.LoadDeepFolderSinger; }
+        private int trackNo;
+        private SingerSelectionDialog? dialog;
+
+        public Dictionary<USingerType, List<USinger>> SortedSingers { get; private set; } = new Dictionary<USingerType, List<USinger>>();
+
+        public SingerSelectionViewModel() { }
+        public SingerSelectionViewModel(int trackNo, SingerSelectionDialog dialog) {
+            this.WhenAnyValue(x => x.SelectedSinger)
+                .Subscribe(value => {
+                    if (value != null) {
+                        SelectedSingerPath = value.Name + " [" + value.Location + "]";
+                    } else {
+                        SelectedSingerPath = "";
+                    }
+                });
+            this.WhenAnyValue(x => x.Search)
+                .Subscribe(value => SortSingers());
+            this.WhenAnyValue(x => x.SelectedCategory)
+                .Subscribe(value => SortSingers());
+
+            this.trackNo = trackNo;
+            this.dialog = dialog;
+
+            SetCategories();
+            SelectedSinger = DocManager.Inst.Project.tracks[trackNo].Singer;
+        }
+
+        private void SetCategories() {
+            Categories.Clear();
+            Categories.Add("Recents");
+            Categories.Add("All");
+            Categories.Add("Favs");
+            foreach (string path in PathManager.Inst.SingersPaths) {
+                Categories.Add(path);
+            }
+            SelectedCategory = 0;
+        }
+
+        public void SortSingers() {
+            if (dialog == null || dialog.DataContext == null || SelectedCategory == -1) return;
+
+            SortedSingers.Clear();
+            switch (SelectedCategory) {
+                case 0: //recents
+                    SingerManager.Inst.SingerGroups.ForEach(type => SortedSingers.Add(type.Key,
+                        Preferences.Default.RecentSingers
+                        .Select(id => type.Value.FirstOrDefault(singer => singer.Id == id))
+                        .OfType<USinger>()
+                        .ToList()));
+                    break;
+                case 1: //all
+                    SingerManager.Inst.SingerGroups.ForEach(type => SortedSingers.Add(type.Key, new List<USinger>(type.Value)));
+                    break;
+                case 2: //favs
+                    SingerManager.Inst.SingerGroups.ForEach(type => SortedSingers.Add(type.Key,
+                        type.Value.Where(singer => Preferences.Default.FavoriteSingers.Contains(singer.Id)).ToList()));
+                    break;
+                default: //directries
+                    string dir = Categories[SelectedCategory];
+                    SingerManager.Inst.SingerGroups.ForEach(type => SortedSingers.Add(type.Key,
+                        type.Value.Where(singer => singer.BasePath == dir).ToList()));
+                    break;
+            }
+            if (!string.IsNullOrWhiteSpace(Search)) {
+                SortedSingers.ForEach(type => type.Value.RemoveAll(singer => !singer.Name.Contains(Search)));
+            }
+            dialog.RefreshSingers();
+        }
+
+        public async Task Reload() {
+            await Task.Run(() => SingerManager.Inst.SearchAllSingers());
+            SetCategories();
+            SelectedSinger = DocManager.Inst.Project.tracks[trackNo].Singer;
+        }
+
+        public void ToggleLoadAllFolders() {
+            Preferences.Default.LoadDeepFolderSinger = !Preferences.Default.LoadDeepFolderSinger;
+            Preferences.Save();
+            this.RaisePropertyChanged(nameof(LoadDeepFolders));
+        }
+    }
+}

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -27,7 +27,6 @@ namespace OpenUtau.App.ViewModels {
         public string PhonemizerTag => track.Phonemizer.Tag;
         public Core.Render.IRenderer Renderer => track.RendererSettings.Renderer;
         public IReadOnlyList<MenuItemViewModel>? SingerMenuItems { get; set; }
-        public ReactiveCommand<USinger, Unit> SelectSingerCommand { get; }
         public IReadOnlyList<MenuItemViewModel>? PhonemizerMenuItems { get; set; }
         public ReactiveCommand<PhonemizerFactory, Unit> SelectPhonemizerCommand { get; }
         public IReadOnlyList<MenuItemViewModel>? RenderersMenuItems { get; set; }
@@ -48,7 +47,6 @@ namespace OpenUtau.App.ViewModels {
 
         // Parameterless constructor for Avalonia preview only.
         public TrackHeaderViewModel() {
-            SelectSingerCommand = ReactiveCommand.Create<USinger>(_ => { });
             SelectPhonemizerCommand = ReactiveCommand.Create<PhonemizerFactory>(_ => { });
             SelectRendererCommand = ReactiveCommand.Create<string>(_ => { });
             Activator = new ViewModelActivator();
@@ -57,41 +55,6 @@ namespace OpenUtau.App.ViewModels {
 
         public TrackHeaderViewModel(UTrack track) {
             this.track = track;
-            SelectSingerCommand = ReactiveCommand.Create<USinger>(singer => {
-                if (track.Singer != singer) {
-                    DocManager.Inst.StartUndoGroup();
-                    DocManager.Inst.ExecuteCmd(new TrackChangeSingerCommand(DocManager.Inst.Project, track, singer));
-                    if (!string.IsNullOrEmpty(singer?.Id) &&
-                        Preferences.Default.SingerPhonemizers.TryGetValue(Singer.Id, out var phonemizerName) &&
-                        TryChangePhonemizer(phonemizerName)) {
-                    } else if (!string.IsNullOrEmpty(singer?.DefaultPhonemizer)) {
-                        TryChangePhonemizer(singer.DefaultPhonemizer);
-                    }
-                    if (singer == null || !singer.Found) {
-                        var settings = new URenderSettings();
-                        DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, track, settings));
-                    } else if (singer.SingerType != track.RendererSettings.Renderer?.SingerType) {
-                        var settings = new URenderSettings {
-                            renderer = Core.Render.Renderers.GetDefaultRenderer(singer.SingerType),
-                        };
-                        DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, track, settings));
-                    }
-                    DocManager.Inst.ExecuteCmd(new VoiceColorRemappingNotification(track.TrackNo, true));
-                    DocManager.Inst.EndUndoGroup();
-                    if (!string.IsNullOrEmpty(singer?.Id) && singer.Found) {
-                        Preferences.Default.RecentSingers.Remove(singer.Id);
-                        Preferences.Default.RecentSingers.Insert(0, singer.Id);
-                        if (Preferences.Default.RecentSingers.Count > 16) {
-                            Preferences.Default.RecentSingers.RemoveRange(
-                                16, Preferences.Default.RecentSingers.Count - 16);
-                        }
-                    }
-                    Preferences.Save();
-                }
-                this.RaisePropertyChanged(nameof(Singer));
-                this.RaisePropertyChanged(nameof(Renderer));
-                RefreshAvatar();
-            });
             SelectPhonemizerCommand = ReactiveCommand.Create<PhonemizerFactory>(factory => {
                 if (track.Phonemizer.GetType() != factory.type) {
                     DocManager.Inst.StartUndoGroup();
@@ -242,31 +205,40 @@ namespace OpenUtau.App.ViewModels {
             return false;
         }
 
-        public void RefreshSingers() {
-            var items = new List<MenuItemViewModel>();
-            items.AddRange(Preferences.Default.RecentSingers
-                .Select(id => SingerManager.Inst.Singers.Values.FirstOrDefault(singer => singer.Id == id))
-                .OfType<USinger>()
-                .LocalizedOrderBy(singer => singer.LocalizedName)
-                .Select(singer => new MenuItemViewModel() {
-                    Header = singer.LocalizedName,
-                    Command = SelectSingerCommand,
-                    CommandParameter = singer,
-                }));
-            var keys = SingerManager.Inst.SingerGroups.Keys.OrderBy(k => k);
-            foreach (var key in keys) {
-                items.Add(new MenuItemViewModel() {
-                    Header = $"{key} ...",
-                    Items = SingerManager.Inst.SingerGroups[key]
-                        .Select(singer => new MenuItemViewModel() {
-                            Header = singer.LocalizedName,
-                            Command = SelectSingerCommand,
-                            CommandParameter = singer,
-                        }).ToArray(),
-                });
+        public void ChangeSinger(USinger singer) {
+            if (track.Singer != singer) {
+                DocManager.Inst.StartUndoGroup();
+                DocManager.Inst.ExecuteCmd(new TrackChangeSingerCommand(DocManager.Inst.Project, track, singer));
+                if (!string.IsNullOrEmpty(singer?.Id) &&
+                    Preferences.Default.SingerPhonemizers.TryGetValue(Singer.Id, out var phonemizerName) &&
+                    TryChangePhonemizer(phonemizerName)) {
+                } else if (!string.IsNullOrEmpty(singer?.DefaultPhonemizer)) {
+                    TryChangePhonemizer(singer.DefaultPhonemizer);
+                }
+                if (singer == null || !singer.Found) {
+                    var settings = new URenderSettings();
+                    DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, track, settings));
+                } else if (singer.SingerType != track.RendererSettings.Renderer?.SingerType) {
+                    var settings = new URenderSettings {
+                        renderer = Core.Render.Renderers.GetDefaultRenderer(singer.SingerType),
+                    };
+                    DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, track, settings));
+                }
+                DocManager.Inst.ExecuteCmd(new VoiceColorRemappingNotification(track.TrackNo, true));
+                DocManager.Inst.EndUndoGroup();
+                if (!string.IsNullOrEmpty(singer?.Id) && singer.Found) {
+                    Preferences.Default.RecentSingers.Remove(singer.Id);
+                    Preferences.Default.RecentSingers.Insert(0, singer.Id);
+                    if (Preferences.Default.RecentSingers.Count > 16) {
+                        Preferences.Default.RecentSingers.RemoveRange(
+                            16, Preferences.Default.RecentSingers.Count - 16);
+                    }
+                }
+                Preferences.Save();
             }
-            SingerMenuItems = items;
-            this.RaisePropertyChanged(nameof(SingerMenuItems));
+            this.RaisePropertyChanged(nameof(Singer));
+            this.RaisePropertyChanged(nameof(Renderer));
+            RefreshAvatar();
         }
 
         public void RefreshPhonemizers() {

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -76,18 +76,8 @@
         <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.paths}">
           <StackPanel>
             <TextBlock Text="{DynamicResource prefs.paths.addlsinger}"/>
-            <TextBlock HorizontalAlignment="Stretch" Margin="4"
-                       TextWrapping="Wrap" FontSize="11" Text="{Binding AdditionalSingersPath}"/>
-            <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
-              <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
-                      HorizontalAlignment="Stretch" Click="ResetAddlSingersPath"/>
-              <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
-                      HorizontalAlignment="Stretch" Click="SelectAddlSingersPath"/>
-            </Grid>
-            <Grid Margin="0,5,0,0">
-              <TextBlock Text="{DynamicResource prefs.paths.addlsinger.install}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding InstallToAdditionalSingersPath}"/>
-            </Grid>
+            <Button Content="{DynamicResource singerlocation.set}" Margin="0,10"
+                    HorizontalAlignment="Stretch" Click="SelectAddlSingersPath"/>
           </StackPanel>
         </HeaderedContentControl>
         <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.cache}">

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -73,11 +73,16 @@
             </Grid>
           </StackPanel>
         </HeaderedContentControl>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.paths}">
+        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.singer}">
           <StackPanel>
             <TextBlock Text="{DynamicResource prefs.paths.addlsinger}"/>
             <Button Content="{DynamicResource singerlocation.set}" Margin="0,10"
                     HorizontalAlignment="Stretch" Click="SelectAddlSingersPath"/>
+            <TextBlock Text="{DynamicResource prefs.singer.select}" />
+            <ComboBox  SelectedIndex="{Binding SingerSelectionMode}">
+              <ComboBoxItem Content="{DynamicResource prefs.singer.extension}"/>
+              <ComboBoxItem Content="{DynamicResource prefs.singer.simple}"/>
+            </ComboBox>
           </StackPanel>
         </HeaderedContentControl>
         <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.cache}">

--- a/OpenUtau/Views/PreferencesDialog.axaml.cs
+++ b/OpenUtau/Views/PreferencesDialog.axaml.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using OpenUtau.App.ViewModels;
@@ -10,18 +9,9 @@ namespace OpenUtau.App.Views {
             InitializeComponent();
         }
 
-        void ResetAddlSingersPath(object sender, RoutedEventArgs e) {
-            ((PreferencesViewModel)DataContext!).SetAddlSingersPath(string.Empty);
-        }
-
         async void SelectAddlSingersPath(object sender, RoutedEventArgs e) {
-            var path = await FilePicker.OpenFolder(this, "prefs.paths.addlsinger");
-            if (string.IsNullOrEmpty(path)) {
-                return;
-            }
-            if (Directory.Exists(path)) {
-                ((PreferencesViewModel)DataContext!).SetAddlSingersPath(path);
-            }
+            var dialog = new SingerLocationDialog();
+            await dialog.ShowDialog(this);
         }
 
         void ResetVLabelerPath(object sender, RoutedEventArgs e) {

--- a/OpenUtau/Views/SingerLocationDialog.axaml
+++ b/OpenUtau/Views/SingerLocationDialog.axaml
@@ -1,0 +1,40 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="400"
+        x:Class="OpenUtau.App.Views.SingerLocationDialog"
+        Icon="/Assets/open-utau.ico"
+        Title="{DynamicResource singerlocation.set}" Width="500" Height="400" MinWidth="400" MinHeight="400"
+        WindowStartupLocation="CenterOwner">
+  <Window.Styles>
+    <Style Selector="RadioButton">
+      <Setter Property="FontSize" Value="12" />
+    </Style>
+  </Window.Styles>
+  <Grid RowDefinitions="*, Auto">
+    <Grid Grid.Row="0" ColumnDefinitions="*, Auto">
+      <ListBox Name="PathListBox" ItemsSource="{Binding}" SelectionMode="Multiple"
+               Grid.Column="0" Margin="10" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+      <StackPanel Spacing="20" Grid.Column="1" Margin="10" VerticalAlignment="Center">
+        <Button Content="{DynamicResource singerlocation.add}" Click="AddLocation" Width="100" />
+        <Button Content="{DynamicResource singerlocation.remove}" Click="RemoveLocation" Width="100" />
+      </StackPanel>
+    </Grid>
+
+    <StackPanel Grid.Row="1" Margin="10" Spacing="5" HorizontalAlignment="Stretch">
+      <TextBlock Text="{DynamicResource singerlocation.where}" />
+      <RadioButton Name="UseOriginalPath" GroupName="InstallLocation" >
+        <TextBlock Name="OriginalPath" TextWrapping="Wrap" VerticalAlignment="Center" />
+      </RadioButton>
+      <RadioButton Name="UseAdditionalPath" GroupName="InstallLocation">
+        <TextBlock Name="AdditionalPath" TextWrapping="Wrap" VerticalAlignment="Center" />
+      </RadioButton>
+      
+      <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+        <Button Content="{DynamicResource dialogs.messagebox.cancel}" Click="Close" MinWidth="60" />
+        <Button Content="{DynamicResource lyrics.apply}" Click="Apply" MinWidth="60" />
+      </StackPanel>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/OpenUtau/Views/SingerLocationDialog.axaml.cs
+++ b/OpenUtau/Views/SingerLocationDialog.axaml.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using OpenUtau.Core;
+using OpenUtau.Core.Util;
+using ReactiveUI.Fody.Helpers;
+
+namespace OpenUtau.App.Views {
+    public partial class SingerLocationDialog : Window {
+        [Reactive] public ObservableCollection<string> locations { get; set; }
+
+        public SingerLocationDialog() {
+            InitializeComponent();
+
+            var list = new List<string>();
+            list.AddRange(Preferences.Default.AdditionalSingerPaths);
+            list.RemoveAll(path => !Directory.Exists(path));
+            locations = new ObservableCollection<string>(list);
+            DataContext = locations;
+
+            OriginalPath.Text = PathManager.Inst.SingersPath;
+            if (Preferences.Default.InstallToAdditionalSingersPath) {
+                UseAdditionalPath.IsChecked = true;
+            } else {
+                UseOriginalPath.IsChecked = true;
+            }
+            SetAdditionalPath();
+        }
+
+        private void SetAdditionalPath() {
+            if (locations.Count > 0) {
+                AdditionalPath.Text = locations.First();
+                UseAdditionalPath.IsEnabled = true;
+            } else {
+                UseOriginalPath.IsChecked = true;
+                AdditionalPath.Text = string.Empty;
+                UseAdditionalPath.IsEnabled = false;
+            }
+        }
+
+        private async void AddLocation(object sender, RoutedEventArgs args) {
+            var path = await FilePicker.OpenFolder(this, "prefs.paths.addlsinger");
+            if (string.IsNullOrEmpty(path)) {
+                return;
+            }
+            if (Directory.Exists(path)) {
+                locations.Add(path);
+                locations.Distinct();
+                SetAdditionalPath();
+            }
+        }
+
+        private void RemoveLocation(object sender, RoutedEventArgs args) {
+            if (PathListBox.SelectedItems != null && PathListBox.SelectedItems.Count > 0) {
+                var list = PathListBox.SelectedItems.Cast<string>().ToList();
+                foreach (string path in list) {
+                    locations.Remove(path);
+                }
+                SetAdditionalPath();
+            }
+        }
+
+        private void Apply(object sender, RoutedEventArgs args) {
+            if (locations.Count > 0) {
+                Preferences.Default.InstallToAdditionalSingersPath = (UseAdditionalPath.IsChecked == true);
+            } else {
+                Preferences.Default.InstallToAdditionalSingersPath = false;
+            }
+            Preferences.SetSingerSearchPaths(locations.ToList()); // set and save
+            Close();
+        }
+        private void Close(object sender, RoutedEventArgs args) {
+            Close();
+        }
+    }
+}

--- a/OpenUtau/Views/SingerSelectionDialog.axaml
+++ b/OpenUtau/Views/SingerSelectionDialog.axaml
@@ -5,7 +5,7 @@
         mc:Ignorable="d"
         x:Class="OpenUtau.App.Views.SingerSelectionDialog"
         Icon="/Assets/open-utau.ico"
-        Title="{DynamicResource tracks.selectsinger}" Width="1000" Height="600" MinWidth="600" MinHeight="400"
+        Title="{DynamicResource tracks.selectsinger}" Width="800" Height="600" MinWidth="600" MinHeight="400"
         WindowStartupLocation="CenterScreen">
   <Window.Styles>
     <Style Selector="Expander">
@@ -22,7 +22,7 @@
       <Setter Property="ItemTemplate">
         <DataTemplate>
           <DockPanel ToolTip.Tip="{Binding Location}" MinHeight="18">
-            <TextBlock Text="{Binding LocalizedName}" HorizontalAlignment="Left"/>
+            <TextBlock Text="{Binding LocalizedName}" HorizontalAlignment="Stretch"/>
             <ToggleButton Classes="Fav" IsChecked="{Binding Favored}" HorizontalAlignment="Right" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
           </DockPanel>
         </DataTemplate>
@@ -48,7 +48,7 @@
     </Style>
   </Window.Styles>
   
-  <Grid RowDefinitions="Auto,*,Auto" Margin="10" Name="grid">
+  <Grid RowDefinitions="Auto,*" Margin="10" Name="grid">
     <StackPanel Orientation="Horizontal" Spacing="12">
       <TextBox Text="{Binding Search}" Watermark="{DynamicResource singerselection.search}" MinWidth="100" VerticalAlignment="Center"/>
       <Button Content="{DynamicResource singerselection.reload}" Click="Reload" VerticalAlignment="Center" />
@@ -59,7 +59,7 @@
       </StackPanel>
     </StackPanel>
     
-    <Grid ColumnDefinitions="1*,2,2*" Grid.Row="1" >
+    <Grid ColumnDefinitions="2*,2,3*" Grid.Row="1" >
       <Border BorderThickness="1" BorderBrush="{DynamicResource NeutralAccentBrush}" Grid.Column="0" >
         <ListBox ItemsSource="{Binding Categories}" SelectedIndex="{Binding SelectedCategory}" ScrollViewer.VerticalScrollBarVisibility="Auto">
           <ListBox.ItemTemplate>
@@ -78,11 +78,6 @@
           <StackPanel Name="SingersPanel"/>
         </ScrollViewer>
       </Border>
-    </Grid>
-
-    <Grid ColumnDefinitions="*, Auto" Grid.Row="2">
-      <TextBlock Text="{Binding SelectedSingerPath}" ToolTip.Tip="{Binding SelectedSingerPath}" VerticalAlignment="Center"/>
-      <Button Content="{StaticResource lyrics.apply}" Click="OnFinish" Grid.Column="1"/>
     </Grid>
   </Grid>
 </Window>

--- a/OpenUtau/Views/SingerSelectionDialog.axaml
+++ b/OpenUtau/Views/SingerSelectionDialog.axaml
@@ -1,0 +1,88 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        x:Class="OpenUtau.App.Views.SingerSelectionDialog"
+        Icon="/Assets/open-utau.ico"
+        Title="{DynamicResource tracks.selectsinger}" Width="1000" Height="600" MinWidth="600" MinHeight="400"
+        WindowStartupLocation="CenterScreen">
+  <Window.Styles>
+    <Style Selector="Expander">
+      <Setter Property="BorderThickness" Value="0"/>
+      <Setter Property="HorizontalAlignment" Value="Stretch"/>
+      <Setter Property="CornerRadius" Value="0"/>
+      <Setter Property="Padding" Value="0"/>
+    </Style>
+    <Style Selector="ListBox">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="SelectionMode" Value="Single" />
+    </Style>
+    <Style Selector="ListBox.singers">
+      <Setter Property="ItemTemplate">
+        <DataTemplate>
+          <DockPanel ToolTip.Tip="{Binding Location}" MinHeight="18">
+            <TextBlock Text="{Binding LocalizedName}" HorizontalAlignment="Left"/>
+            <ToggleButton Classes="Fav" IsChecked="{Binding Favored}" HorizontalAlignment="Right" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
+          </DockPanel>
+        </DataTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="ToggleButton.Fav">
+      <Setter Property="Padding" Value="0"/>
+      <Setter Property="Margin" Value="20,0"/>
+      <Setter Property="Content" Value="♡"/>
+      <Setter Property="Foreground" Value="{DynamicResource AccentBrush3}"/>
+      <Setter Property="Background" Value="Transparent"/>
+      <Style Selector="^:checked">
+        <Setter Property="Content" Value="♥"/>
+      </Style>
+      <Style Selector="^:checked /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush3}" />
+        <Setter Property="Background" Value="Transparent"/>
+      </Style>
+      <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush3}" />
+        <Setter Property="Background" Value="Transparent"/>
+      </Style>
+    </Style>
+  </Window.Styles>
+  
+  <Grid RowDefinitions="Auto,*,Auto" Margin="10" Name="grid">
+    <StackPanel Orientation="Horizontal" Spacing="12">
+      <TextBox Text="{Binding Search}" Watermark="{DynamicResource singerselection.search}" MinWidth="100" VerticalAlignment="Center"/>
+      <Button Content="{DynamicResource singerselection.reload}" Click="Reload" VerticalAlignment="Center" />
+      <Button Content="{DynamicResource singerselection.foldersettings}" Click="FolderSettings" VerticalAlignment="Center" />
+      <StackPanel Orientation="Horizontal" Spacing="5">
+        <TextBlock Text="{DynamicResource singerselection.loaddeepfolders}" VerticalAlignment="Center" />
+        <ToggleSwitch IsChecked="{Binding LoadDeepFolders, Mode=OneWay}" Click="ToggleLoadAllFolders" VerticalAlignment="Center" />
+      </StackPanel>
+    </StackPanel>
+    
+    <Grid ColumnDefinitions="1*,2,2*" Grid.Row="1" >
+      <Border BorderThickness="1" BorderBrush="{DynamicResource NeutralAccentBrush}" Grid.Column="0" >
+        <ListBox ItemsSource="{Binding Categories}" SelectedIndex="{Binding SelectedCategory}" ScrollViewer.VerticalScrollBarVisibility="Auto">
+          <ListBox.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Text="{Binding}" ToolTip.Tip="{Binding}" />
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+      </Border>
+      
+      <GridSplitter Grid.Column="1" ResizeDirection="Columns"
+                    Background="{DynamicResource NeutralAccentBrush}" />
+
+      <Border BorderThickness="1" BorderBrush="{DynamicResource NeutralAccentBrush}" Grid.Column="2" >
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+          <StackPanel Name="SingersPanel"/>
+        </ScrollViewer>
+      </Border>
+    </Grid>
+
+    <Grid ColumnDefinitions="*, Auto" Grid.Row="2">
+      <TextBlock Text="{Binding SelectedSingerPath}" ToolTip.Tip="{Binding SelectedSingerPath}" VerticalAlignment="Center"/>
+      <Button Content="{StaticResource lyrics.apply}" Click="OnFinish" Grid.Column="1"/>
+    </Grid>
+  </Grid>
+</Window>

--- a/OpenUtau/Views/SingerSelectionDialog.axaml.cs
+++ b/OpenUtau/Views/SingerSelectionDialog.axaml.cs
@@ -8,7 +8,6 @@ using OpenUtau.Core.Ustx;
 namespace OpenUtau.App.Views {
     public partial class SingerSelectionDialog : Window {
         private SingerSelectionViewModel viewModel;
-        private Dictionary<string, ListBox> listBoxes = new Dictionary<string, ListBox>();
 
         public Action<USinger>? onFinish;
 
@@ -24,38 +23,22 @@ namespace OpenUtau.App.Views {
 
         public void RefreshSingers() {
             SingersPanel.Children.Clear();
-            listBoxes.Clear();
 
             foreach (var type in viewModel.SortedSingers) {
                 var singersListBox = new ListBox { ItemsSource = type.Value };
                 singersListBox.Classes.Add("singers");
                 singersListBox.SelectionChanged += SingerSelectionChanged;
-                listBoxes.Add(type.Key.ToString(), singersListBox);
                 var expander = new Expander {
                     Header = type.Key.ToString() + ": " + type.Value.Count + " singers",
                     Content = singersListBox
                 };
                 SingersPanel.Children.Add(expander);
             }
-            SelectionRefresh();
         }
 
         private void SingerSelectionChanged(object? sender, SelectionChangedEventArgs e) {
-            if(e.AddedItems.Count > 0) {
-                viewModel.SelectedSinger = e.AddedItems[0] as USinger;
-            }
-            SelectionRefresh();
-        }
-
-        public void SelectionRefresh() {
-            foreach (ListBox list in listBoxes.Values) {
-                if (list.Items.Contains(viewModel.SelectedSinger)) {
-                    if (list.SelectedItem != viewModel.SelectedSinger) {
-                        list.SelectedItem = viewModel.SelectedSinger;
-                    }
-                } else {
-                    list.UnselectAll();
-                }
+            if(e.AddedItems.Count > 0 && e.AddedItems[0] is USinger singer && singer.Found) {
+                OnFinish(singer);
             }
         }
 
@@ -81,9 +64,9 @@ namespace OpenUtau.App.Views {
             Reload(sender, e);
         }
 
-        void OnFinish(object? sender, RoutedEventArgs args) {
-            if (onFinish != null && viewModel.SelectedSinger != null && viewModel.SelectedSinger.Found) {
-                onFinish.Invoke(viewModel.SelectedSinger);
+        void OnFinish(USinger singer) {
+            if (onFinish != null) {
+                onFinish.Invoke(singer);
             }
             Close();
         }

--- a/OpenUtau/Views/SingerSelectionDialog.axaml.cs
+++ b/OpenUtau/Views/SingerSelectionDialog.axaml.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using OpenUtau.App.ViewModels;
+using OpenUtau.Core.Ustx;
+
+namespace OpenUtau.App.Views {
+    public partial class SingerSelectionDialog : Window {
+        private SingerSelectionViewModel viewModel;
+        private Dictionary<string, ListBox> listBoxes = new Dictionary<string, ListBox>();
+
+        public Action<USinger>? onFinish;
+
+        public SingerSelectionDialog() {
+            InitializeComponent();
+            viewModel = new SingerSelectionViewModel();
+        }
+        public SingerSelectionDialog(int trackNo) {
+            InitializeComponent();
+            DataContext = viewModel = new SingerSelectionViewModel(trackNo, this);
+            viewModel.SortSingers();
+        }
+
+        public void RefreshSingers() {
+            SingersPanel.Children.Clear();
+            listBoxes.Clear();
+
+            foreach (var type in viewModel.SortedSingers) {
+                var singersListBox = new ListBox { ItemsSource = type.Value };
+                singersListBox.Classes.Add("singers");
+                singersListBox.SelectionChanged += SingerSelectionChanged;
+                listBoxes.Add(type.Key.ToString(), singersListBox);
+                var expander = new Expander {
+                    Header = type.Key.ToString() + ": " + type.Value.Count + " singers",
+                    Content = singersListBox
+                };
+                SingersPanel.Children.Add(expander);
+            }
+            SelectionRefresh();
+        }
+
+        private void SingerSelectionChanged(object? sender, SelectionChangedEventArgs e) {
+            if(e.AddedItems.Count > 0) {
+                viewModel.SelectedSinger = e.AddedItems[0] as USinger;
+            }
+            SelectionRefresh();
+        }
+
+        public void SelectionRefresh() {
+            foreach (ListBox list in listBoxes.Values) {
+                if (list.Items.Contains(viewModel.SelectedSinger)) {
+                    if (list.SelectedItem != viewModel.SelectedSinger) {
+                        list.SelectedItem = viewModel.SelectedSinger;
+                    }
+                } else {
+                    list.UnselectAll();
+                }
+            }
+        }
+
+        private async void Reload(object? sender, RoutedEventArgs e) {
+            grid.IsEnabled = false;
+            SingersPanel.Children.Clear();
+            SingersPanel.Children.Add(new TextBlock {
+                Text = ThemeManager.GetString("progress.loadingsingers"),
+                Margin = Avalonia.Thickness.Parse("30")
+            });
+            await viewModel.Reload();
+            grid.IsEnabled = true;
+        }
+
+        private async void FolderSettings(object? sender, RoutedEventArgs e) {
+            var dialog = new SingerLocationDialog();
+            await dialog.ShowDialog(this);
+            Reload(sender, e);
+        }
+
+        private void ToggleLoadAllFolders(object? sender, RoutedEventArgs e) {
+            viewModel.ToggleLoadAllFolders();
+            Reload(sender, e);
+        }
+
+        void OnFinish(object? sender, RoutedEventArgs args) {
+            if (onFinish != null && viewModel.SelectedSinger != null && viewModel.SelectedSinger.Found) {
+                onFinish.Invoke(viewModel.SelectedSinger);
+            }
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
### Overview:
This is a huge modification.
For some time now, users who own many voice banks have had difficulty managing them.
This PR will improve the following two points: 
- Allow to set multiple paths for singers, and make it easier to manage directories.
- Display a dialog to select a singer and allow users to filter and search singers.

https://discord.com/channels/551606189386104834/1131900332092436611

### New Features:
- Singer Selection Dialog
![image](https://github.com/stakira/OpenUtau/assets/130257355/4186a853-0f38-456d-95f8-4999fbe162b1)
  - This appears instead of the context menu when selecting a track's singer.
  - Categorize singers by recently used, favorites, and directories.
Users can easily pin their favorites by pressing the heart icon next to their name.
Recently used singers are sorted by date, all others by localized name.
  - Categorize singers by type, such as classic, enunu, etc. These can be expanded.
  - Easily reload singers.
  - Allows setting the range of folders to be used.
  Previously, all directories within singer's locations were searched, but now there is an option to search only top directories as in OG UTAU.
- Singer Location Dialog
![image](https://github.com/stakira/OpenUtau/assets/130257355/4f4b40a4-5de8-417f-8574-1ec9b1f20de7)
  - Allows users to set up additional singer paths and locations where new singers are to be installed.
  - This can be called from Singer Selection Dialog and Preferences.

### Internal Changes:
- From now on, AdditionalSingerPath"s" will be used instead of AdditionalSingerPath in preferences.
- Singers with the same folder name are considered the same. If the same folder exists in different locations, only one of them will be loaded.
This follows the previous specification that treated folder names as IDs, but this remains controversial.
Technically, USinger implements IEquatable.
- Favorites are saved in preferences as well as recently used ones.