### PR TITLE
Apply 'Load all depth folders' to resamplers, wavtools, dll phonemizers and UTAU plugins too.

### DIFF
--- a/OpenUtau.Core/Classic/PluginLoader.cs
+++ b/OpenUtau.Core/Classic/PluginLoader.cs
@@ -5,15 +5,23 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Serilog;
+using OpenUtau.Core.Util;
 
 namespace OpenUtau.Classic {
     class PluginLoader {
         public static Plugin[] LoadAll(string basePath) {
             Directory.CreateDirectory(basePath);
             var encoding = Encoding.GetEncoding("shift_jis");
-            return Directory.EnumerateFiles(basePath, "plugin.txt", SearchOption.AllDirectories)
-                .Select(filePath => ParsePluginTxt(filePath, encoding))
-                .ToArray();
+            if (Preferences.Default.LoadDeepFolderSinger) {
+                return Directory.EnumerateFiles(basePath, "plugin.txt", SearchOption.AllDirectories)
+                    .Select(filePath => ParsePluginTxt(filePath, encoding))
+                    .ToArray();
+            } else {
+                return Directory.GetDirectories(basePath)
+                    .Where(dir => File.Exists(Path.Combine(dir, "plugin.txt")))
+                    .Select(dir => ParsePluginTxt(Path.Combine(dir, "plugin.txt"), encoding))
+                    .ToArray();
+            }
         }
 
         private static Plugin ParsePluginTxt(string filePath, Encoding encoding) {

--- a/OpenUtau.Core/Classic/ToolsManager.cs
+++ b/OpenUtau.Core/Classic/ToolsManager.cs
@@ -81,8 +81,9 @@ namespace OpenUtau.Classic {
             string basePath = PathManager.Inst.ResamplersPath;
             try {
                 Directory.CreateDirectory(basePath);
+                
                 foreach (var file in Directory.EnumerateFiles(basePath, "*", new EnumerationOptions() {
-                    RecurseSubdirectories = true
+                    RecurseSubdirectories = Preferences.Default.LoadDeepFolderSinger
                 })) {
                     var driver = LoadResampler(file, basePath);
                     if (driver != null) {
@@ -107,7 +108,7 @@ namespace OpenUtau.Classic {
             try {
                 Directory.CreateDirectory(basePath);
                 foreach (var file in Directory.EnumerateFiles(basePath, "*", new EnumerationOptions() {
-                    RecurseSubdirectories = true
+                    RecurseSubdirectories = Preferences.Default.LoadDeepFolderSinger
                 })) {
                     var driver = LoadWavtool(file, basePath);
                     if (driver != null) {

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -76,7 +76,11 @@ namespace OpenUtau.Core {
                 if (File.Exists(oldBuiltin)) {
                     File.Delete(oldBuiltin);
                 }
-                files.AddRange(Directory.EnumerateFiles(PathManager.Inst.PluginsPath, "*.dll", SearchOption.AllDirectories));
+                if (Preferences.Default.LoadDeepFolderSinger) {
+                    files.AddRange(Directory.EnumerateFiles(PathManager.Inst.PluginsPath, "*.dll", SearchOption.AllDirectories));
+                } else {
+                    files.AddRange(Directory.EnumerateFiles(PathManager.Inst.PluginsPath, "*.dll"));
+                }
             } catch (Exception e) {
                 Log.Error(e, "Failed to search plugins.");
             }


### PR DESCRIPTION
related issue: #1518

After this PR, the "Load all depth folders" setting item will also be applied to resamplers, wavtools, dll phonemizers and UTAU plugins. This will greatly increase OpenUtau's startup speed if the user has plugins or resamplers with many DLLs and complex path structure, such as hifisampler

I don't know if this should be a separate setting item from the current "Load all depth folders" for singers. feel free to share your idea.