### PR TITLE
Add text to the Singer Setup Dialog

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -546,12 +546,15 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>
   <system:String x:Key="singersetup.archivefileencoding.prompt">Choose an encoding that make file names look right.</system:String>
   <system:String x:Key="singersetup.back">Back</system:String>
+  <system:String x:Key="singersetup.failed">Installation failed.</system:String>
   <system:String x:Key="singersetup.install">Install</system:String>
   <system:String x:Key="singersetup.missinginfo">Please add the following settings to this voicebank's character.yaml.</system:String>
   <system:String x:Key="singersetup.next">Next</system:String>
   <system:String x:Key="singersetup.singertype">Singer Type</system:String>
+  <system:String x:Key="singersetup.succeeded">Installation succeeded.</system:String>
   <system:String x:Key="singersetup.textfileencoding">Text File Encoding</system:String>
   <system:String x:Key="singersetup.textfileencoding.prompt">Choose an encoding that make file contents look right.</system:String>
+  <system:String x:Key="singersetup.title">Singer Setup</system:String>
 
   <system:String x:Key="tip.aliasbox">Override Alias</system:String>
   <system:String x:Key="tip.exps">Numerical,Options Type

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -546,7 +546,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>
   <system:String x:Key="singersetup.archivefileencoding.prompt">Choose an encoding that make file names look right.</system:String>
   <system:String x:Key="singersetup.back">Back</system:String>
-  <system:String x:Key="singersetup.failed">Installation failed.</system:String>
+  <system:String x:Key="singersetup.failed">Failed to install singer.</system:String>
   <system:String x:Key="singersetup.install">Install</system:String>
   <system:String x:Key="singersetup.missinginfo">Please add the following settings to this voicebank's character.yaml.</system:String>
   <system:String x:Key="singersetup.next">Next</system:String>

--- a/OpenUtau/ViewModels/SingerSetupViewModel.cs
+++ b/OpenUtau/ViewModels/SingerSetupViewModel.cs
@@ -172,6 +172,7 @@ namespace OpenUtau.App.ViewModels {
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ThemeManager.GetString("singersetup.failed")));
                         DocManager.Inst.ExecuteCmd(new SingersChangedNotification());
                     }).Start(DocManager.Inst.MainScheduler);
+                    throw;
                 }
             });
         }

--- a/OpenUtau/ViewModels/SingerSetupViewModel.cs
+++ b/OpenUtau/ViewModels/SingerSetupViewModel.cs
@@ -162,9 +162,14 @@ namespace OpenUtau.App.ViewModels {
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(progress, info));
                     }, archiveEncoding, textEncoding);
                     installer.Install(archiveFilePath, SingerType);
-                } finally {
+
                     new Task(() => {
-                        DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ""));
+                        DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ThemeManager.GetString("singersetup.succeeded")));
+                        DocManager.Inst.ExecuteCmd(new SingersChangedNotification());
+                    }).Start(DocManager.Inst.MainScheduler);
+                } catch {
+                    new Task(() => {
+                        DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ThemeManager.GetString("singersetup.failed")));
                         DocManager.Inst.ExecuteCmd(new SingersChangedNotification());
                     }).Start(DocManager.Inst.MainScheduler);
                 }

--- a/OpenUtau/Views/SingerSetupDialog.axaml
+++ b/OpenUtau/Views/SingerSetupDialog.axaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d" Width="600" Height="400" MinWidth="600" MinHeight="400"
         x:Class="OpenUtau.App.Views.SingerSetupDialog"
         Icon="/Assets/open-utau.ico"
-        Title="Singer Setup"
+        Title="{DynamicResource singersetup.title}"
         WindowStartupLocation="CenterScreen">
   <Window.Resources>
     <vm:EncodingNameConverter x:Key="encodingNameConverter"/>

--- a/OpenUtau/Views/SingerSetupDialog.axaml.cs
+++ b/OpenUtau/Views/SingerSetupDialog.axaml.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
-using Serilog;
+using OpenUtau.Core;
 
 namespace OpenUtau.App.Views {
     public partial class SingerSetupDialog : Window {
@@ -20,10 +20,7 @@ namespace OpenUtau.App.Views {
             var task = viewModel.Install();
             task.ContinueWith((task) => {
                 if (task.IsFaulted) {
-                    Log.Error(task.Exception, "Failed to install singer");
-                    if (Parent is Window window) {
-                        MessageBox.ShowError(window, task.Exception);
-                    }
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(new MessageCustomizableException("Failed to install singer.", "<translate:singersetup.failed>", task.Exception)));
                 }
             }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, scheduler);
             Close();


### PR DESCRIPTION
- Translate window title
- After execution, display success status at the bottom
- Fixed a bug where no dialog appeared when the singer installation failed