### PR TITLE
Fix VoiceColorRemapping Crash

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -61,6 +61,7 @@
   <system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>
   <system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>
   <system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>
+  <system:String x:Key="dialogs.voicecolorremapping.error">This singer has no voice color</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>
 
   <system:String x:Key="errors.caption">Error</system:String>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -1384,10 +1384,11 @@ namespace OpenUtau.App.Views {
                     ValidateTracksVoiceColor();
                 } else {
                     UTrack track = DocManager.Inst.Project.tracks[voicecolorNotif.TrackNo];
-                    if (!voicecolorNotif.Validate) {
-                        VoiceColorRemapping(track, track.VoiceColorNames, track.VoiceColorExp.options);
-                    } else if (track.ValidateVoiceColor(out var oldColors, out var newColors)) {
+                    if (track.ValidateVoiceColor(out var oldColors, out var newColors)) {
                         VoiceColorRemapping(track, oldColors, newColors);
+                    } else if (!voicecolorNotif.Validate) {
+                        // Cases where this function was intentionally invoked
+                        MessageBox.Show(this, ThemeManager.GetString("dialogs.voicecolorremapping.error"), ThemeManager.GetString("errors.caption"), MessageBox.MessageBoxButtons.Ok);
                     }
                 }
             }


### PR DESCRIPTION
Fixed to display an error instead of crashing when a track singer has no voice color.
<img width="712" height="432" alt="image" src="https://github.com/user-attachments/assets/e461a59b-7deb-42ac-a15c-2069d1de7498" />
