### PR TITLE
Fix bug in voicebank error checker

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankErrorChecker.cs
+++ b/OpenUtau.Core/Classic/VoicebankErrorChecker.cs
@@ -72,7 +72,6 @@ namespace OpenUtau.Classic {
                     }
                     if (fileDuration <= 0) {
                         Errors.Add(new VoicebankError() {
-                            trace = oto.FileTrace,
                             soundFile = filePath,
                             messageKey = "singererror.invalidduration",
                             strings = new string[] { fileDuration.ToString() }
@@ -120,21 +119,18 @@ namespace OpenUtau.Classic {
                     var waveFormat = wav.ToSampleProvider().WaveFormat;
                     if (waveFormat.SampleRate != 44100) {
                         Errors.Add(new VoicebankError() {
-                            trace = oto.FileTrace,
                             soundFile = filePath,
                             messageKey = "singererror.samplerate"
                         });
                     }
                     if (waveFormat.Channels != 1) {
                         Infos.Add(new VoicebankError() {
-                            trace = oto.FileTrace,
                             soundFile = filePath,
                             messageKey = "singererror.mono"
                         });
                     }
                     if (waveFormat.BitsPerSample != 16) {
                         Errors.Add(new VoicebankError() {
-                            trace = oto.FileTrace,
                             soundFile = filePath,
                             messageKey = "singererror.bitdepth"
                         });
@@ -142,7 +138,6 @@ namespace OpenUtau.Classic {
                 }
             } catch (Exception e) {
                 Errors.Add(new VoicebankError() {
-                    trace = oto.FileTrace,
                     soundFile = filePath,
                     messageKey = "singererror.soundnotopened",
                     e = e,
@@ -165,8 +160,7 @@ namespace OpenUtau.Classic {
             if (oto.Offset > fileDuration) {
                 Errors.Add(new VoicebankError() {
                     trace = oto.FileTrace,
-                    messageKey = "singererror.offsetoutofduration",
-                    strings = new string[] { fileDuration.ToString() }
+                    messageKey = "singererror.offsetoutofduration"
                 });
                 valid = false;
             }
@@ -180,8 +174,7 @@ namespace OpenUtau.Classic {
             if (oto.Preutter + oto.Offset > fileDuration) {
                 Errors.Add(new VoicebankError() {
                     trace = oto.FileTrace,
-                    messageKey = "singererror.preutteroutofduration",
-                    strings = new string[] { fileDuration.ToString() }
+                    messageKey = "singererror.preutteroutofduration"
                 });
                 valid = false;
             }
@@ -195,16 +188,14 @@ namespace OpenUtau.Classic {
             if (oto.Consonant + oto.Offset > fileDuration) {
                 Errors.Add(new VoicebankError() {
                     trace = oto.FileTrace,
-                    messageKey = "singererror.consonantoutofduration",
-                    strings = new string[] { fileDuration.ToString() }
+                    messageKey = "singererror.consonantoutofduration"
                 });
                 valid = false;
             }
             if (oto.Overlap + oto.Offset > fileDuration) {
                 Errors.Add(new VoicebankError() {
                     trace = oto.FileTrace,
-                    messageKey = "singererror.overlapoutofduration",
-                    strings = new string[] { fileDuration.ToString() }
+                    messageKey = "singererror.overlapoutofduration"
                 });
                 valid = false;
             }
@@ -227,6 +218,13 @@ namespace OpenUtau.Classic {
                 Errors.Add(new VoicebankError() {
                     trace = oto.FileTrace,
                     messageKey = "singererror.cutoffconsonant",
+                });
+                valid = false;
+            }
+            if (cutoff > fileDuration) {
+                Errors.Add(new VoicebankError() {
+                    trace = oto.FileTrace,
+                    messageKey = "singererror.cutoffoutofduration"
                 });
                 valid = false;
             }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -494,9 +494,10 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="singererror.aliasmultiplespaces">Alias contains multiple spaces.</system:String>
   <system:String x:Key="singererror.aliasstartwithspace">Alias starts or ends with a space.</system:String>
   <system:String x:Key="singererror.bitdepth">Bit depth of the sound file is not 16bit.</system:String>
-  <system:String x:Key="singererror.consonantoutofduration">Consonant out of sound file duration {fileDuration}.</system:String>
+  <system:String x:Key="singererror.consonantoutofduration">Consonant out of sound file duration.</system:String>
   <system:String x:Key="singererror.consonantshort">Consonant must be >= 0.</system:String>
   <system:String x:Key="singererror.cutoffconsonant">Cutoff must be to the right of consonant.</system:String>
+  <system:String x:Key="singererror.cutoffoutofduration">Cutoff out of sound file duration.</system:String>
   <system:String x:Key="singererror.cutoffoverlap">Cutoff must be to the right of overlap.</system:String>
   <system:String x:Key="singererror.cutoffpreutter">Cutoff must be to the right of preutter.</system:String>
   <system:String x:Key="singererror.duplicatealias">There are duplicate aliases.{0}</system:String>
@@ -506,10 +507,10 @@ The voicebank may not work on another OS with case-sensitivity.</system:String>
   <system:String x:Key="singererror.invalidduration">Invalid duration {0}.</system:String>
   <system:String x:Key="singererror.invalidoto">Invalid oto format.</system:String>
   <system:String x:Key="singererror.mono">Sound file is not mono channel.</system:String>
-  <system:String x:Key="singererror.offsetoutofduration">Offset out of sound file duration {fileDuration}.</system:String>
+  <system:String x:Key="singererror.offsetoutofduration">Offset out of sound file duration.</system:String>
   <system:String x:Key="singererror.offsetshort">Offset must be >= 0.</system:String>
-  <system:String x:Key="singererror.overlapoutofduration">Overlap out of sound file duration {fileDuration}.</system:String>
-  <system:String x:Key="singererror.preutteroutofduration">Preutter out of sound file duration {fileDuration}.</system:String>
+  <system:String x:Key="singererror.overlapoutofduration">Overlap out of sound file duration.</system:String>
+  <system:String x:Key="singererror.preutteroutofduration">Preutter out of sound file duration.</system:String>
   <system:String x:Key="singererror.preuttershort">Preutter must be >= 0.</system:String>
   <system:String x:Key="singererror.samplerate">Sample rate of the sound file is not 44100Hz.</system:String>
   <system:String x:Key="singererror.soundmissing">Sound file missing</system:String>


### PR DESCRIPTION
- Fixed a bug where error reports were not output when the oto parameter exceeded the file duration.
- Removed the unnecessary oto lines mentioned in wav errors.
- Check whether the cutoff exceeds the file duration.