### PR TITLE
Translate the message displayed when SOME is not installed

### DIFF
--- a/OpenUtau.Core/Analysis/Some.cs
+++ b/OpenUtau.Core/Analysis/Some.cs
@@ -184,7 +184,7 @@ namespace OpenUtau.Core.Analysis.Some {
             string yamlpath = Path.Combine(Location, "some.yaml");
             if (!File.Exists(yamlpath)) {
                 //TODO: onnx download site
-                throw new FileNotFoundException($"Error loading SOME. Please download SOME from\nhttps://github.com/xunmengshe/OpenUtau/releases/0.0.0.0");
+                throw new MessageCustomizableException("SOME not found", "<translate:errors.failed.transcribe>", new FileNotFoundException(), false, new string[]{ "https://github.com/xunmengshe/OpenUtau/releases/0.0.0.0" });
             }
 
             var config = Yaml.DefaultDeserializer.Deserialize<SomeConfig>(

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -98,6 +98,7 @@ OpenUtau aims to be an open source editing environment for UTAU community, with 
   <system:String x:Key="errors.failed.searchsinger">Failed to search singers</system:String>
   <system:String x:Key="errors.failed.synth.cutoffbeforeoffset">Oto error: cutoff before offset</system:String>
   <system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>
+  <system:String x:Key="errors.failed.transcribe">Error loading SOME. Please download SOME from {0}</system:String>
   <system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>

--- a/OpenUtau/ThemeManager.cs
+++ b/OpenUtau/ThemeManager.cs
@@ -261,14 +261,8 @@ namespace OpenUtau.App {
         }
 
         public static string GetString(string key) {
-            if (Application.Current == null) {
-                return key;
-            }
-            IResourceDictionary resDict = Application.Current.Resources;
-            if (resDict.TryGetResource(key, ThemeVariant.Default, out var outVar) && outVar is string s) {
-                return s;
-            }
-            return key;
+            TryGetString(key, out string value);
+            return value;
         }
 
         public static bool TryGetString(string key, out string value) {

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -1217,8 +1217,9 @@ namespace OpenUtau.App.Views {
                     transcribeTask.ContinueWith(task => {
                         msgbox?.Close();
                         if (task.IsFaulted) {
-                            Log.Error(task.Exception, $"Failed to transcribe part {part.name}");
-                            MessageBox.ShowError(this, task.Exception);
+                            var ex = task.Exception?.InnerExceptions.Count == 1 ? task.Exception.InnerExceptions[0] : task.Exception;
+                            Log.Error(ex, $"Failed to transcribe part {part.name}");
+                            MessageBox.ShowError(this, ex);
                             return;
                         }
                         var voicePart = task.Result;

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -1217,9 +1217,8 @@ namespace OpenUtau.App.Views {
                     transcribeTask.ContinueWith(task => {
                         msgbox?.Close();
                         if (task.IsFaulted) {
-                            var ex = task.Exception?.InnerExceptions.Count == 1 ? task.Exception.InnerExceptions[0] : task.Exception;
-                            Log.Error(ex, $"Failed to transcribe part {part.name}");
-                            MessageBox.ShowError(this, ex);
+                            Log.Error(task.Exception, $"Failed to transcribe part {part.name}");
+                            MessageBox.ShowError(this, task.Exception);
                             return;
                         }
                         var voicePart = task.Result;


### PR DESCRIPTION
- Fixed an issue where error messages were not displayed correctly.
- Translate the message displayed when SOME is not installed.
- Hid the stack trace.
<img width="382" height="236" alt="image" src="https://github.com/user-attachments/assets/d43e893f-daef-46b4-8c7a-253aa14cdcbe" />
