### PR TITLE
Add to the list of expressions that lock editing

### DIFF
--- a/OpenUtau.Core/Format/USTx.cs
+++ b/OpenUtau.Core/Format/USTx.cs
@@ -35,7 +35,7 @@ namespace OpenUtau.Core.Format {
         public const string TENC = "tenc";
         public const string VOIC = "voic";
 
-        public static readonly string[] required = { DYN, PITD, CLR, ENG, VEL, VOL, ATK, DEC };
+        public static readonly string[] required = { DYN, PITD, CLR, ENG, VEL, VOL, ATK, DEC, GEN, GENC, BRE, BREC, LPF, NORM, MOD, MODP, ALT, DIR, SHFT, SHFC, TENC, VOIC };
 
         public static void AddDefaultExpressions(UProject project) {
             project.RegisterExpression(new UExpressionDescriptor("dynamics (curve)", DYN, -240, 120, 0) { type = UExpressionType.Curve });


### PR DESCRIPTION
The project's default expressions must be locked to prevent editing of elements like abbr, type, min, max, etc.
For example, if the abbr is edited, there is a risk that the same expression will be added after applying it, causing a conflict.

Previously, only some expressions were locked.
Now, all default expressions will be added to this list.