### PR TITLE
Enlarge the “Waiting Rendering”

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -370,9 +370,9 @@
           </c:PartsCanvas>
           <Border Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent"
                   BoxShadow="inset 0 0 5 1 #3F000000" ClipToBounds="True" IsHitTestVisible="False">
-            <Border HorizontalAlignment="Center" VerticalAlignment="Center"
-                    IsVisible="{Binding TracksViewModel.PlayPosWaitingRendering}">
-              <TextBlock Text="{DynamicResource progress.waitingrendering}"/>
+            <Border HorizontalAlignment="Center" VerticalAlignment="Center" Padding="10,5"
+                    IsVisible="{Binding TracksViewModel.PlayPosWaitingRendering}" Background="{DynamicResource BackgroundBrushSemi}">
+              <TextBlock Text="{DynamicResource progress.waitingrendering}" FontSize="15"/>
             </Border>
           </Border>
           <Border Grid.Row="1" Grid.Column="2" Background="Transparent" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="0" Height="24" PointerWheelChanged="ViewScalerPointerWheelChanged">

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -663,9 +663,9 @@
                    IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
             <TextBlock Classes="tips" Text="{DynamicResource tip.notes.zoomy}"/>
           </Border>
-          <Border HorizontalAlignment="Center" VerticalAlignment="Center"
-                IsVisible="{Binding NotesViewModel.PlayPosWaitingRendering}">
-            <TextBlock Text="{DynamicResource progress.waitingrendering}"/>
+          <Border HorizontalAlignment="Center" VerticalAlignment="Center" Padding="10,5"
+                IsVisible="{Binding NotesViewModel.PlayPosWaitingRendering}" Background="{DynamicResource BackgroundBrushSemi}">
+            <TextBlock Text="{DynamicResource progress.waitingrendering}" FontSize="15"/>
           </Border>
         </Grid>
       </Border>


### PR DESCRIPTION
To improve visibility, I increased the font size and displayed a faint background.

<img width="1324" height="778" alt="image" src="https://github.com/user-attachments/assets/6f99fb56-3f98-4a4f-9eb1-09a15fa2ffa1" />
