### PR TITLE
Fix VoicebankErrorChecker could not correctly detect bit depth

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankErrorChecker.cs
+++ b/OpenUtau.Core/Classic/VoicebankErrorChecker.cs
@@ -116,7 +116,7 @@ namespace OpenUtau.Classic {
             try {
                 using (var wav = Core.Format.Wave.OpenFile(filePath)) {
                     fileDuration = wav.TotalTime.TotalMilliseconds;
-                    var waveFormat = wav.ToSampleProvider().WaveFormat;
+                    var waveFormat = wav.WaveFormat;
                     if (waveFormat.SampleRate != 44100) {
                         Errors.Add(new VoicebankError() {
                             soundFile = filePath,


### PR DESCRIPTION
ToSampleProvider() automatically converted the WaveStream to 32-bit float.