### PR TITLE
Fix the left-aligned track number

### DIFF
--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -43,7 +43,7 @@
         <Border Background="{Binding TrackAccentColor}" Height="16" Width="22" CornerRadius="1,0,2,0"
                 HorizontalAlignment="Left" VerticalAlignment="Top">
           <TextBlock TextAlignment="Center" FontWeight="Bold"
-                     Text="{Binding TrackNo}" Foreground="White" VerticalAlignment="Center"/>
+                     Text="{Binding TrackNo}" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center"/>
         </Border>
       </Grid>
       <Button Classes="clear" Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2" Margin="1" Padding="2,1,0,0" Height="18"


### PR DESCRIPTION
Fixed a bug where numbers would shift to the left when performing specific operations, such as rearranging the order of tracks.
<img width="548" height="442" alt="image" src="https://github.com/user-attachments/assets/fa69eea1-350f-4493-a30c-fc8d2d278be8" />
