### PR TITLE
Store MainWindow and PianorollWindow Size

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -133,12 +133,8 @@ namespace OpenUtau.Core.Util {
 
         [Serializable]
         public class SerializablePreferences {
-            public const int MidiWidth = 1024;
-            public const int MidiHeight = 768;
-            public int MainWidth = 1024;
-            public int MainHeight = 768;
-            public bool MainMaximized;
-            public bool MidiMaximized;
+            public WindowSize MainWindowSize = new WindowSize();
+            public WindowSize PianorollWindowSize = new WindowSize();
             public int UndoLimit = 100;
             public List<string> SingerSearchPaths = new List<string>();
             public string PlaybackDevice = string.Empty;

--- a/OpenUtau.Core/Util/WindowSize.cs
+++ b/OpenUtau.Core/Util/WindowSize.cs
@@ -1,0 +1,23 @@
+﻿namespace OpenUtau.Core.Util {
+    public class WindowSize {
+        public double Width { get; set; } = 1200;
+        public double Height { get; set; } = 650;
+        public int? PositionX { get; set; }
+        public int? PositionY { get; set; }
+        public int State { get; set; }
+
+        public bool TryGetPosition(out int x, out int y) {
+            x = PositionX ?? 0;
+            y = PositionY ?? 0;
+            return PositionX != null && PositionY != null;
+        }
+
+        public void Set(double width, double height, int posX, int posY, int state) {
+            Width = width;
+            Height = height;
+            PositionX = posX;
+            PositionY = posY;
+            State = state == 1 ? 0 : state; // Ignore minimized state
+        }
+    }
+}

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -232,6 +232,7 @@ OpenUtau aims to be an open source editing environment for UTAU community, with 
   <system:String x:Key="menu.tools.layout.vsplit12">Vertical 1:2</system:String>
   <system:String x:Key="menu.tools.layout.vsplit13">Vertical 1:3</system:String>
   <system:String x:Key="menu.tools.prefs">Preferences...</system:String>
+  <system:String x:Key="menu.tools.resetscreen">Reset Screen</system:String>
   <system:String x:Key="menu.tools.singer.install">Install Singer...</system:String>
   <system:String x:Key="menu.tools.singer.installadv">Install Singer (Advanced)...</system:String>
   <system:String x:Key="menu.tools.singers">Singers...</system:String>

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -47,7 +47,9 @@ namespace OpenUtau.App.ViewModels {
         public string Title => !ProjectSaved
             ? $"{AppVersion}"
             : $"{(DocManager.Inst.ChangesSaved ? "" : "*")}{AppVersion} [{DocManager.Inst.Project.FilePath}]";
-        
+        public double Width => Preferences.Default.MainWindowSize.Width;
+        public double Height => Preferences.Default.MainWindowSize.Height;
+
         /// <summary>
         ///0: welcome page, 1: tracks page
         /// </summary>

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -48,6 +48,9 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public NotesViewModel NotesViewModel { get; set; }
         [Reactive] public PlaybackViewModel? PlaybackViewModel { get; set; }
 
+        public double Width => Preferences.Default.PianorollWindowSize.Width;
+        public double Height => Preferences.Default.PianorollWindowSize.Height;
+
         public bool LockPitchPoints { get => Preferences.Default.LockUnselectedNotesPitch; }
         public bool LockVibrato { get => Preferences.Default.LockUnselectedNotesVibrato; }
         public bool LockExpressions { get => Preferences.Default.LockUnselectedNotesExpressions; }

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -4,10 +4,10 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:OpenUtau.App.ViewModels"
         xmlns:c="clr-namespace:OpenUtau.App.Controls"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="650"
         x:Class="OpenUtau.App.Views.MainWindow"
         Icon="/Assets/open-utau.ico"
-        Title="{Binding Title}" MinWidth="300" MinHeight="200"
+        Title="{Binding Title}" MinWidth="300" MinHeight="200" Width="{Binding Width}" Height="{Binding Height}"
         KeyDown="OnKeyDown" PointerPressed="OnPointerPressed" Closing="WindowClosing"
         Focusable="True" DragDrop.AllowDrop="True"
         TransparencyLevelHint="None">
@@ -69,6 +69,7 @@
               <MenuItem Header="{DynamicResource menu.tools.layout.hsplit13}" Click="OnMenuLayoutHSplit13"/>
             </MenuItem>
             <MenuItem Header="{DynamicResource menu.tools.fullscreen}" InputGesture="F11" Click="OnMenuFullScreen"/>
+            <MenuItem Header="{DynamicResource menu.tools.resetscreen}" InputGesture="F10" Click="OnMenuResetScreen"/>
             <MenuItem Header="{Binding ClearCacheHeader}" Click="OnMenuClearCache"/>
             <MenuItem Header="{DynamicResource menu.tools.debugwindow}" Click="OnMenuDebugWindow"/>
             <MenuItem Header="{DynamicResource phoneticassistant.caption}" Click="OnMenuPhoneticAssistant"/>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -84,6 +84,11 @@ namespace OpenUtau.App.Views {
 
             AddHandler(DragDrop.DropEvent, OnDrop);
 
+            if (Preferences.Default.MainWindowSize.TryGetPosition(out int x, out int y)) {
+                Position = new PixelPoint(x, y);
+            }
+            WindowState = (WindowState)Preferences.Default.MainWindowSize.State;
+
             DocManager.Inst.AddSubscriber(this);
 
             Log.Information("Main window checking Update.");
@@ -662,6 +667,13 @@ namespace OpenUtau.App.Views {
                 : WindowState.FullScreen;
         }
 
+        void OnMenuResetScreen(object sender, RoutedEventArgs args) {
+            this.WindowState = WindowState.Normal;
+            Position = new PixelPoint(0, 0);
+            Width = 1000;
+            Height = 650;
+        }
+
         void OnMenuClearCache(object sender, RoutedEventArgs args) {
             Task.Run(() => {
                 DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ThemeManager.GetString("progress.clearingcache")));
@@ -767,6 +779,9 @@ namespace OpenUtau.App.Views {
                             int endTick = viewModel.TracksViewModel.Parts.Max(part => part.End);
                             viewModel.PlaybackViewModel.MovePlayPos(endTick);
                         }
+                        break;
+                    case Key.F10:
+                        OnMenuResetScreen(this, new RoutedEventArgs());
                         break;
                     case Key.F11:
                         OnMenuFullScreen(this, new RoutedEventArgs());
@@ -1411,6 +1426,7 @@ namespace OpenUtau.App.Views {
                     PathManager.Inst.ClearCache();
                     Log.Information("Cache cleared.");
                 }
+                Preferences.Default.MainWindowSize.Set(Width, Height, Position.X, Position.Y, (int)WindowState);
                 Preferences.Default.RecoveryPath = string.Empty;
                 Preferences.Save();
                 return;

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -5,13 +5,12 @@
         xmlns:vm="using:OpenUtau.App.ViewModels"
         xmlns:api="using:OpenUtau.Api"
         xmlns:c="clr-namespace:OpenUtau.App.Controls"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="650"
         x:Class="OpenUtau.App.Views.PianoRollWindow"
         Icon="/Assets/open-utau.ico"
-        Title="{Binding NotesViewModel.WindowTitle}" MinWidth="300" MinHeight="200" Closing="WindowClosing"
-        Focusable="True"
-        TransparencyLevelHint="None"
-        Deactivated="WindowDeactivated">
+        Title="{Binding NotesViewModel.WindowTitle}" MinWidth="300" MinHeight="200" Width="{Binding Width}" Height="{Binding Height}"
+        Focusable="True" TransparencyLevelHint="None"
+        Closing="WindowClosing" Deactivated="WindowDeactivated">
   <Window.Styles>
     <StyleInclude Source="/Styles/PianoRollStyles.axaml"/>
   </Window.Styles>
@@ -272,6 +271,7 @@
                 </MenuItem.Icon>
               </MenuItem>
               <MenuItem Header="{DynamicResource menu.tools.fullscreen}" InputGesture="F11" Click="OnMenuFullScreen"/>
+              <MenuItem Header="{DynamicResource menu.tools.resetscreen}" InputGesture="F10" Click="OnMenuResetScreen"/>
               <MenuItem Header="{DynamicResource prefs.appearance.degree}">
                 <MenuItem Header="{DynamicResource prefs.appearance.degree.off}" Click="OnMenuDegreeStyle" Tag="0">
                   <MenuItem.Icon>

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -45,6 +45,11 @@ namespace OpenUtau.App.Views {
             InitializeComponent();
             DataContext = ViewModel = model;
             ValueTip.IsVisible = false;
+
+            if (Preferences.Default.PianorollWindowSize.TryGetPosition(out int x, out int y)) {
+                Position = new PixelPoint(x, y);
+            }
+            WindowState = (WindowState)Preferences.Default.PianorollWindowSize.State;
         }
 
         public void InitializePianoRollWindowAsync() {
@@ -186,6 +191,7 @@ namespace OpenUtau.App.Views {
         }
 
         void WindowClosing(object? sender, WindowClosingEventArgs e) {
+            Preferences.Default.PianorollWindowSize.Set(Width, Height, Position.X, Position.Y, (int)WindowState);
             Hide();
             e.Cancel = true;
         }
@@ -245,6 +251,12 @@ namespace OpenUtau.App.Views {
             this.WindowState = this.WindowState == WindowState.FullScreen
                 ? WindowState.Normal
                 : WindowState.FullScreen;
+        }
+        void OnMenuResetScreen(object sender, RoutedEventArgs args) {
+            this.WindowState = WindowState.Normal;
+            Position = new PixelPoint(0, 0);
+            Width = 1000;
+            Height = 650;
         }
         void OnMenuDegreeStyle(object sender, RoutedEventArgs args) {
             if (sender is MenuItem menu && int.TryParse(menu.Tag?.ToString(), out int tag)) {
@@ -1272,6 +1284,9 @@ namespace OpenUtau.App.Views {
                         Hide();
                         return true;
                     }
+                    break;
+                case Key.F10:
+                    OnMenuResetScreen(this, new RoutedEventArgs());
                     break;
                 case Key.F11:
                     OnMenuFullScreen(this, new RoutedEventArgs());


### PR DESCRIPTION
- Store the sizes of MainWindow and PianorollWindow in preferences.
- Added a window size reset command (to prevent stacking when a window accidentally moves off the monitor)
- I'd be grateful if someone could test it on macOS.