### PR TITLE
Add Linux metadata files

### DIFF
--- a/Misc/Linux/com.openutau.OpenUtau.desktop
+++ b/Misc/Linux/com.openutau.OpenUtau.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=OpenUtau
+Comment=Open singing synthesis platform
+Icon=openutau
+Exec=OpenUtau
+Categories=AudioVideo;Audio;Midi;

--- a/Misc/Linux/com.openutau.OpenUtau.metainfo.xml
+++ b/Misc/Linux/com.openutau.OpenUtau.metainfo.xml
@@ -26,7 +26,7 @@
 
   <screenshots>
     <screenshot type="default">
-      <image>https://github.com/user-attachments/assets/bbb5bcba-ce56-4312-b122-1f49351cd8dc</image>
+      <image>https://static.wikia.nocookie.net/vocalsynth/images/2/20/OpenUtau_v0.0.364.0_screenshot.png</image>
     </screenshot>
   </screenshots>
 

--- a/Misc/Linux/com.openutau.OpenUtau.metainfo.xml
+++ b/Misc/Linux/com.openutau.OpenUtau.metainfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.openutau.OpenUtau</id>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <name>OpenUtau</name>
+  <summary>Open singing synthesis platform</summary>
+
+  <developer id="io.github.stakira">
+    <name>StAkira</name>
+  </developer>
+
+  <description>
+    <p>OpenUtau is a free, open-source editor made for the UTAU community, featuring a modern user experience and support for multiple vocal tracks.</p>
+  </description>
+
+  <launchable type="desktop-id">com.openutau.OpenUtau.desktop</launchable>
+
+  <content_rating type="oars-1.1" />
+
+  <url type="bugtracker">https://github.com/stakira/OpenUtau/issues</url>
+  <url type="homepage">https://www.openutau.com/</url>
+  <url type="vcs-browser">https://github.com/stakira/OpenUtau</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/user-attachments/assets/bbb5bcba-ce56-4312-b122-1f49351cd8dc</image>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="0.1.565" date="2025-09-14">
+      <url type="details">https://github.com/stakira/OpenUtau/wiki/Release-Notes#01565-09-14-2025</url>
+    </release>
+  </releases>
+</component>


### PR DESCRIPTION
This PR introduces standard Linux metadata files, including [XDG desktop entry](https://specifications.freedesktop.org/desktop-entry/latest/) and [AppStream MetaInfo file](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

These files are essential for Linux packaging, particularly for Flatpak. This PR follows the [Flathub quality guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines), such as keeping the summary under 35 characters. ~Since I didn't find an official screenshot, I've used one from the release notes. If an official screenshot is available, feel free to replace it.~

Related to #1511. Supersedes #549.