### PR TITLE
Support for ignoring auto-VCV during ust import

### DIFF
--- a/OpenUtau.Core/Classic/Ust.cs
+++ b/OpenUtau.Core/Classic/Ust.cs
@@ -184,7 +184,11 @@ namespace OpenUtau.Classic {
                 pitch = note.pitch
             };
             ustNote.Parse(lastNotePos, lastNoteEnd, iniLines, out noteTempo);
-            note.lyric = ustNote.lyric;
+            if (ustNote.lyric.StartsWith("!")) {
+                note.lyric = $"[{ustNote.lyric.Substring(1)}]";
+            } else {
+                note.lyric = ustNote.lyric;
+            }
             note.position = ustNote.position;
             note.duration = ustNote.duration;
             note.tone = ustNote.noteNum;


### PR DESCRIPTION
In original UTAU (paid version) or UTAlet, adding "!" at the beginning of lyrics ignores automatic VCV conversion.
During UST import, this will be optimized for OU format.
<img width="1044" height="616" alt="image" src="https://github.com/user-attachments/assets/5b6c19c1-9c05-49f3-9fb5-448189295d6d" />
