### PR TITLE
Fix Voice Color Remapping Bug

### DIFF
--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -185,6 +185,11 @@ namespace OpenUtau.Core {
     public class VoiceColorRemappingNotification : UNotification {
         public int TrackNo;
         public bool Validate;
+        /// <summary>
+        /// Remap when the singer's voice color changes. Or use when the user intentionally wants to remap.
+        /// </summary>
+        /// <param name="trackNo">Track number for remapping the singer. When -1, checks whether remapping is required for all tracks.</param>
+        /// <param name="validate">When verifying if the color lineup has changed, set to true; when forcing remapping even if no changes occur, set to false.</param>
         public VoiceColorRemappingNotification(int trackNo, bool validate) {
             TrackNo = trackNo;
             Validate = validate;


### PR DESCRIPTION
Fixed an issue where Voice Color Remapping could not be manually invoked.

The following patterns were tested:
- When calling remapping from the track header,
  - If the singer has no color, display a warning.
  - If there are no notes, display a warning.
  - If neither applies, display the remapping dialog.
- When changing the track's singer,
  - If the singer has no color, do nothing.
  - If there are no notes, do nothing.
  - If neither applies, display the remapping dialog.