### PR TITLE
Ust Import Enhancement

### DIFF
--- a/OpenUtau.Core/Classic/Ust.cs
+++ b/OpenUtau.Core/Classic/Ust.cs
@@ -254,7 +254,9 @@ namespace OpenUtau.Classic {
                     return;
                 }
                 var abbr = FindAbbrFromFlagKey(project.expressions, flag);
-                if (abbr != String.Empty) {
+                if (string.IsNullOrEmpty(abbr)) {
+                    undefinedFlags.Add(flag.Key);
+                } else {
                     SetExpression(project, note, abbr, flag.Value);
                 }
             });

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -86,6 +86,8 @@ OpenUtau aims to be an open source editing environment for UTAU community, with 
   <system:String x:Key="errors.failed.importaudio">Failed to import audio</system:String>
   <system:String x:Key="errors.failed.importfiles">Failed to import files</system:String>
   <system:String x:Key="errors.failed.importmidi">Failed to import midi</system:String>
+  <system:String x:Key="errors.failed.importustandothers">Failed to open the projects. It contains a mix of ust and other file formats.</system:String>
+  <system:String x:Key="errors.failed.importustflags">The following undefined flags within the project were not imported:</system:String>
   <system:String x:Key="errors.failed.installsinger">Failed to install singer</system:String>
   <system:String x:Key="errors.failed.load">Failed to load</system:String>
   <system:String x:Key="errors.failed.loadprefs">Failed to load prefs. Initialize it.</system:String>


### PR DESCRIPTION
## Feature Enhancement
- If the t flag is set in the note, import it as tuning. (#1860 )

## Fixes
- Fixed an issue where imports failed when expressions not defined in the project were included in the UST. (#1863 )
  - When these flags are included in generation options or notes, a dialog will be displayed.  <img width="440" height="214" alt="image" src="https://github.com/user-attachments/assets/3bb4009e-98fa-4017-8bb4-c2c16ce69e87" />
  - This may appear simultaneously with the tempo import dialog. i hope this will be fixed in the future.
- The error has been translated.