### PR TITLE
Fix import 24bit wav

### DIFF
--- a/OpenUtau.Core/Format/Wave.cs
+++ b/OpenUtau.Core/Format/Wave.cs
@@ -24,9 +24,11 @@ namespace OpenUtau.Core.Format {
                 }
             }
             if (tag == "RIFF") {
+#if WINDOWS
                 if (OS.IsWindows()) {
                     return new MediaFoundationReader(filepath);
                 }
+#endif
                 return new WaveFileReader(filepath);
             }
             if (ext == ".mp3") {

--- a/OpenUtau.Core/Format/Wave.cs
+++ b/OpenUtau.Core/Format/Wave.cs
@@ -24,7 +24,10 @@ namespace OpenUtau.Core.Format {
                 }
             }
             if (tag == "RIFF") {
-                return new MediaFoundationReader(filepath);
+                if (OS.IsWindows()) {
+                    return new MediaFoundationReader(filepath);
+                }
+                return new WaveFileReader(filepath);
             }
             if (ext == ".mp3") {
                 if (OverrideMp3Reader != null) {

--- a/OpenUtau.Core/Format/Wave.cs
+++ b/OpenUtau.Core/Format/Wave.cs
@@ -24,7 +24,7 @@ namespace OpenUtau.Core.Format {
                 }
             }
             if (tag == "RIFF") {
-                return new WaveFileReader(filepath);
+                return new MediaFoundationReader(filepath);
             }
             if (ext == ".mp3") {
                 if (OverrideMp3Reader != null) {


### PR DESCRIPTION
Fixed an issue where 24-bit WAV instruments could not be imported.
~~(It would be better if we could verify the behavior on macOS before merging)~~
For now, I've only fixed the Windows behavior. A better fix is expected.