### PR TITLE
Fix error phoneme pitch

### DIFF
--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -211,6 +211,12 @@ namespace OpenUtau.Core.Render {
                 uNotes.Add(next);
                 next = next.Next;
             }
+            if (uNotes.First().Prev != null && uNotes.First().Prev.End == uNotes.First().position) {
+                uNotes.Insert(0, uNotes.First().Prev);
+            }
+            if (uNotes.Last().Next != null && uNotes.Last().End == uNotes.Last().Next.position) {
+                uNotes.Add(uNotes.Last().Next);
+            }
 
             singer = track.Singer;
             renderer = track.RendererSettings.Renderer;


### PR DESCRIPTION
Fixed an issue where pitch curves exhibited steps around notes that failed phonemization. This occurred regardless of the renderer.
(tested with the Classic and DiffSinger voicebanks)

<img width="595" height="350" alt="image" src="https://github.com/user-attachments/assets/12c74a65-0275-43f7-b184-d3c0f7a6b97c" />

<img width="502" height="376" alt="image" src="https://github.com/user-attachments/assets/c88d8292-9a2b-47f1-b850-3b4f9d1d4f65" />
