### PR TITLE
macOS audio device changed fix

### DIFF
--- a/OpenUtau.Core/Audio/DummyAudioOutput.cs
+++ b/OpenUtau.Core/Audio/DummyAudioOutput.cs
@@ -6,6 +6,7 @@ namespace OpenUtau.Audio {
     public class DummyAudioOutput : IAudioOutput {
         public PlaybackState PlaybackState => PlaybackState.Stopped;
         public int DeviceNumber => 0;
+        public event EventHandler DevicesChanged;
         public List<AudioOutputDevice> GetOutputDevices() => new List<AudioOutputDevice>();
         public long GetPosition() => 0;
         public void Init(ISampleProvider sampleProvider) { }

--- a/OpenUtau.Core/Audio/IAudioOutput.cs
+++ b/OpenUtau.Core/Audio/IAudioOutput.cs
@@ -16,6 +16,9 @@ namespace OpenUtau.Audio {
         PlaybackState PlaybackState { get; }
         int DeviceNumber { get; }
 
+        // Raised when available output devices list changes (plug/unplug).
+        event EventHandler DevicesChanged;
+
         void SelectDevice(Guid guid, int deviceNumber);
         void Init(ISampleProvider sampleProvider);
         void Pause();

--- a/OpenUtau/NAudioOutput.cs
+++ b/OpenUtau/NAudioOutput.cs
@@ -9,6 +9,7 @@ namespace OpenUtau.App {
     public class NAudioOutput : DummyAudioOutput { }
 #else
     public class NAudioOutput : IAudioOutput {
+        public event EventHandler DevicesChanged;
         const int Channels = 2;
 
         private readonly object lockObj = new object();

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -133,6 +133,23 @@ namespace OpenUtau.App.ViewModels {
                 if (device != null) {
                     AudioOutputDevice = device;
                 }
+                // Subscribe to device list changes to refresh UI when devices are plugged/unplugged.
+                try {
+                    audioOutput.DevicesChanged += (s, e) => {
+                        Avalonia.Threading.Dispatcher.UIThread.Post(() => {
+                            try {
+                                AudioOutputDevices = PlaybackManager.Inst.AudioOutput.GetOutputDevices();
+                                int curDeviceNumber = PlaybackManager.Inst.AudioOutput.DeviceNumber;
+                                var cur = AudioOutputDevices.FirstOrDefault(d => d.deviceNumber == curDeviceNumber);
+                                if (cur != null) {
+                                    AudioOutputDevice = cur;
+                                }
+                            } catch (Exception ex) {
+                                Log.Warning(ex, "Failed to update audio device list on DevicesChanged");
+                            }
+                        });
+                    };
+                } catch { }
             }
             PreferPortAudio = Preferences.Default.PreferPortAudio ? 1 : 0;
             PlaybackAutoScroll = Preferences.Default.PlaybackAutoScroll;


### PR DESCRIPTION
**Audio device change detection and notification:**

* Added a `DevicesChanged` event to the `IAudioOutput` interface, and implemented this event in `DummyAudioOutput`, `MiniAudioOutput`, and `NAudioOutput` to notify listeners when the available audio output devices change. 
* In `MiniAudioOutput`, introduced a polling mechanism using a `Timer` to periodically check for device changes, compare the current device list with the previous one, and raise the `DevicesChanged` event when a change is detected. Also ensured thread safety with a lock and cleaned up the timer during disposal. 

**UI updates for device changes:**

* In `PreferencesViewModel`, subscribed to the `DevicesChanged` event to update the list of audio output devices and the current selection in the UI when a device is plugged in or unplugged.