### PR TITLE
Trim and fade for the wave part

### DIFF
--- a/OpenUtau.Core/Commands/PartCommands.cs
+++ b/OpenUtau.Core/Commands/PartCommands.cs
@@ -50,10 +50,12 @@ namespace OpenUtau.Core {
         }
     }
 
-    public class ResizePartCommand : PartCommand {
+    public class ResizeVoicePartCommand : PartCommand {
+        public readonly new UVoicePart part;
         readonly int deltaDur;
         readonly bool fromStart;
-        public ResizePartCommand(UProject project, UPart part, int deltaDur, bool fromStart) : base(project, part) {
+        public ResizeVoicePartCommand(UProject project, UVoicePart part, int deltaDur, bool fromStart) : base(project, part) {
+            this.part = part;
             this.deltaDur = deltaDur;
             this.fromStart = fromStart;
         }
@@ -62,12 +64,10 @@ namespace OpenUtau.Core {
             if (fromStart) {
                 part.position -= deltaDur;
                 part.Duration += deltaDur;
-                if (part is UVoicePart voicePart) {
-                    voicePart.notes.ForEach(note => note.position += deltaDur);
-                    foreach (var curve in voicePart.curves) {
-                        for (var i = 0; i < curve.xs.Count; i++) {
-                            curve.xs[i] += deltaDur;
-                        }
+                part.notes.ForEach(note => note.position += deltaDur);
+                foreach (var curve in part.curves) {
+                    for (var i = 0; i < curve.xs.Count; i++) {
+                        curve.xs[i] += deltaDur;
                     }
                 }
             } else {
@@ -78,17 +78,79 @@ namespace OpenUtau.Core {
             if (fromStart) {
                 part.position += deltaDur;
                 part.Duration -= deltaDur;
-                if (part is UVoicePart voicePart) {
-                    voicePart.notes.ForEach(note => note.position -= deltaDur);
-                    foreach (var curve in voicePart.curves) {
-                        for (var i = 0; i < curve.xs.Count; i++) {
-                            curve.xs[i] -= deltaDur;
-                        }
+                part.notes.ForEach(note => note.position -= deltaDur);
+                foreach (var curve in part.curves) {
+                    for (var i = 0; i < curve.xs.Count; i++) {
+                        curve.xs[i] -= deltaDur;
                     }
                 }
             } else {
                 part.Duration -= deltaDur;
             }
+        }
+    }
+
+    public class ResizeWavePartCommand : PartCommand {
+        public readonly new UWavePart part;
+        readonly int deltaDur;
+        readonly bool fromStart;
+        public ResizeWavePartCommand(UProject project, UWavePart part, int deltaDur, bool fromStart) : base(project, part) {
+            this.part = part;
+            this.deltaDur = deltaDur;
+            this.fromStart = fromStart;
+        }
+        public override string ToString() => "Change parts duration";
+        public override void Execute() {
+            if (fromStart) {
+                part.position -= deltaDur;
+                part.skip -= deltaDur;
+            } else {
+                part.trim -= deltaDur;
+            }
+        }
+        public override void Unexecute() {
+            if (fromStart) {
+                part.position += deltaDur;
+                part.skip += deltaDur;
+            } else {
+                part.trim += deltaDur;
+            }
+        }
+    }
+
+    public class PartFadeInCommand : PartCommand {
+        public readonly new UWavePart part;
+        readonly int fadeTick;
+        readonly int oldFade;
+        public PartFadeInCommand(UProject project, UWavePart part, int fadeTick) : base(project, part) {
+            this.part = part;
+            this.fadeTick = fadeTick;
+            this.oldFade = part.fadein;
+        }
+        public override string ToString() => "Fade in part";
+        public override void Execute() {
+            part.fadein = fadeTick;
+        }
+        public override void Unexecute() {
+            part.fadein = oldFade;
+        }
+    }
+
+    public class PartFadeOutCommand : PartCommand {
+        public readonly new UWavePart part;
+        readonly int fadeTick;
+        readonly int oldFade;
+        public PartFadeOutCommand(UProject project, UWavePart part, int fadeTick) : base(project, part) {
+            this.part = part;
+            this.fadeTick = fadeTick;
+            this.oldFade = part.fadeout;
+        }
+        public override string ToString() => "Fade out part";
+        public override void Execute() {
+            part.fadeout = fadeTick;
+        }
+        public override void Unexecute() {
+            part.fadeout = oldFade;
         }
     }
 

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -267,7 +267,7 @@ namespace OpenUtau.Core.Editing {
             DocManager.Inst.ExecuteCmd(new AddNoteCommand(part, notes));
             int minDurTick = part.GetMinDurTick(project);
             if (part.Duration < minDurTick) {
-                DocManager.Inst.ExecuteCmd(new ResizePartCommand(project, part, minDurTick - part.Duration, false));
+                DocManager.Inst.ExecuteCmd(new ResizeVoicePartCommand(project, part, minDurTick - part.Duration, false));
             }
             DocManager.Inst.EndUndoGroup();
         }

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -84,16 +84,7 @@ namespace OpenUtau.Core.Render {
                     .Where(part => part is UWavePart && part.trackNo == i)
                     .Select(part => part as UWavePart)
                     .Where(part => part.Samples != null)
-                    .Select(part => {
-                        double offsetMs = project.timeAxis.TickPosToMsPos(part.position);
-                        double estimatedLengthMs = project.timeAxis.TickPosToMsPos(part.End) - offsetMs;
-                        var waveSource = new WaveSource(
-                            offsetMs,
-                            estimatedLengthMs,
-                            part.skipMs, part.channels);
-                        waveSource.SetSamples(part.Samples);
-                        return (ISignalSource)waveSource;
-                    }));
+                    .Select(part => part.TrimSamples(project)));
                 var trackMix = new WaveMix(trackSources);
                 var fader = new Fader(trackMix);
                 fader.Scale = PlaybackManager.DecibelToVolume(track.Muted ? -24 : track.Volume);

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -13,6 +13,8 @@
   <system:String x:Key="command.note.add">Add note</system:String>
   <system:String x:Key="command.note.delete">Delete note(s)</system:String>
   <system:String x:Key="command.note.edit">Edit note(s)</system:String>
+  <system:String x:Key="command.part.fadein">Edit part fade in</system:String>
+  <system:String x:Key="command.part.fadeout">Edit part fade out</system:String>
   <system:String x:Key="command.note.lyric">Edit lyric(s)</system:String>
   <system:String x:Key="command.note.move">Move note(s)</system:String>
   <system:String x:Key="command.note.paste">Paste note(s)</system:String>

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -420,7 +420,7 @@ namespace OpenUtau.App.ViewModels {
                     var partOldDuration = voicePart.Duration;
                     var partNewDuration = RemapTickPos(partOldStartTick + voicePart.duration, oldTimeAxis, newTimeAxis) - partNewStartTick;
                     if(partNewDuration != partOldDuration) {
-                        DocManager.Inst.ExecuteCmd(new ResizePartCommand(
+                        DocManager.Inst.ExecuteCmd(new ResizeVoicePartCommand(
                             project, voicePart, partNewDuration - partOldDuration, false));
                     }
                     var noteCommands = new List<UCommand>();

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -860,7 +860,7 @@ namespace OpenUtau.App.ViewModels {
                 DocManager.Inst.ExecuteCmd(new AddNoteCommand(Part, notes));
                 int minDurTick = Part.GetMinDurTick(Project);
                 if (Part.Duration < minDurTick) {
-                    DocManager.Inst.ExecuteCmd(new ResizePartCommand(Project, Part, minDurTick - Part.Duration, false));
+                    DocManager.Inst.ExecuteCmd(new ResizeVoicePartCommand(Project, Part, minDurTick - Part.Duration, false));
                 }
                 DocManager.Inst.EndUndoGroup();
                 Selection.Select(notes);
@@ -901,7 +901,7 @@ namespace OpenUtau.App.ViewModels {
                 DocManager.Inst.ExecuteCmd(new AddNoteCommand(Part, notes));
                 int minDurTick = Part.GetMinDurTick(Project);
                 if (Part.Duration < minDurTick) {
-                    DocManager.Inst.ExecuteCmd(new ResizePartCommand(Project, Part, minDurTick - Part.Duration, false));
+                    DocManager.Inst.ExecuteCmd(new ResizeVoicePartCommand(Project, Part, minDurTick - Part.Duration, false));
                 }
                 DocManager.Inst.EndUndoGroup();
                 Selection.Select(notes);
@@ -1109,7 +1109,7 @@ namespace OpenUtau.App.ViewModels {
                     if (isUndo && addPart.part == Part) {
                         UnloadPart();
                     }
-                } else if (cmd is ResizePartCommand) {
+                } else if (cmd is ResizeVoicePartCommand) {
                     OnPartModified();
                 } else if (cmd is MovePartCommand) {
                     OnPartModified();

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -1051,20 +1051,28 @@ namespace OpenUtau.App.Views {
                         Cursor = ViewConstants.cursorSizeAll;
                     }
                 } else if (hitControl is PartControl partControl) {
-                    bool isVoice = partControl.part is UVoicePart;
-                    bool isWave = partControl.part is UWavePart;
-                    bool trim = point.Position.X > partControl.Bounds.Right - ViewConstants.ResizeMargin;
+                    bool fadein = false;
+                    bool fadeout = false;
+                    if (partControl.part is UWavePart wavePart && point.Position.Y < partControl.Bounds.Top + 6) {
+                        var fadePos = partControl.Bounds.Left + partControl.FadeIn;
+                        fadein = fadePos < point.Position.X && point.Position.X < fadePos + 6;
+                        fadePos = partControl.Bounds.Left + partControl.FadeOut;
+                        fadeout = fadePos - 6 < point.Position.X && point.Position.X < fadePos;
+                    }
                     bool skip = point.Position.X < partControl.Bounds.Left + ViewConstants.ResizeMargin;
-                    if (isVoice && trim) {
-                        partEditState = new PartResizeEditState(control, viewModel, partControl.part);
+                    bool trim = point.Position.X > partControl.Bounds.Right - ViewConstants.ResizeMargin;
+                    if (fadein) {
+                        partEditState = new PartFadeInState(control, viewModel, (UWavePart)partControl.part);
                         Cursor = ViewConstants.cursorSizeWE;
-                    } else if (isVoice && skip) {
+                    } else if (fadeout) {
+                        partEditState = new PartFadeOutState(control, viewModel, (UWavePart)partControl.part);
+                        Cursor = ViewConstants.cursorSizeWE;
+                    } else if (skip) {
                         partEditState = new PartResizeEditState(control, viewModel, partControl.part, true);
                         Cursor = ViewConstants.cursorSizeWE;
-                    } else if (isWave && skip) {
-                        // TODO
-                    } else if (isWave && trim) {
-                        // TODO
+                    } else if (trim) {
+                        partEditState = new PartResizeEditState(control, viewModel, partControl.part);
+                        Cursor = ViewConstants.cursorSizeWE;
                     } else {
                         partEditState = new PartMoveEditState(control, viewModel, partControl.part);
                         Cursor = ViewConstants.cursorSizeAll;
@@ -1110,14 +1118,20 @@ namespace OpenUtau.App.Views {
             }
             var hitControl = control.InputHitTest(point.Position);
             if (hitControl is PartControl partControl) {
-                bool isVoice = partControl.part is UVoicePart;
-                bool isWave = partControl.part is UWavePart;
-                bool trim = point.Position.X > partControl.Bounds.Right - ViewConstants.ResizeMargin;
+                bool fadein = false;
+                bool fadeout = false;
+                if (partControl.part is UWavePart wavePart && point.Position.Y < partControl.Bounds.Top + 6) {
+                    var fadePos = partControl.Bounds.Left + partControl.FadeIn;
+                    fadein = fadePos < point.Position.X && point.Position.X < fadePos + 6;
+                    fadePos = partControl.Bounds.Left + partControl.FadeOut;
+                    fadeout = fadePos - 6 < point.Position.X && point.Position.X < fadePos;
+                }
                 bool skip = point.Position.X < partControl.Bounds.Left + ViewConstants.ResizeMargin;
-                if (isVoice && (skip || trim)) {
+                bool trim = point.Position.X > partControl.Bounds.Right - ViewConstants.ResizeMargin;
+                if (fadein || fadeout) {
+                    Cursor = ViewConstants.cursorHand;
+                } else if (skip || trim) {
                     Cursor = ViewConstants.cursorSizeWE;
-                } else if (isWave && (skip || trim)) {
-                    Cursor = null; // TODO
                 } else {
                     Cursor = null;
                 }


### PR DESCRIPTION
## New Features:
- Trim Wave Part: Not only UVoicePart but also UWavePart can now be trimmed.
- Fade: Grab the control at the edge of the Wave Part to set the fade.
<img width="854" height="314" alt="image" src="https://github.com/user-attachments/assets/b7de0a26-36bb-4d3a-94c8-91541a7b2519" />

## Tested items:
- Limits on part trimming
- Limits on part fading
- Display in light mode and dark mode
- Voice part trimming isn't broken
- File saving and restoration
- Undo and Redo (There is a minor bug where the view occasionally fails to update during redo operations)