### PR TITLE
Improve MusicXML lyrics handling

### DIFF
--- a/OpenUtau.Core/Format/MusicXML.cs
+++ b/OpenUtau.Core/Format/MusicXML.cs
@@ -154,9 +154,10 @@ namespace OpenUtau.Core.Format
                                                 if(syllabicStatus == Syllabic.Single || syllabicStatus == Syllabic.End) {
                                                     incompletedLyricNote = null;
                                                 }
-                                            } else if (slurStatus == StartStopContinue.Continue || slurStatus == StartStopContinue.Stop) {
+                                            } else if (slurStatus == StartStopContinue.Continue || slurStatus == StartStopContinue.Stop
+                                            || incompletedLyricNote != null) {
                                                 // OpenUtau uses +~ for extending the current syllable,
-                                                // which is represented in sheet music as slur.
+                                                // which is represented in sheet music as slur or syllable span.
                                                 unote.lyric = "+~";
                                             }
                                             return unote;

--- a/OpenUtau.Test/Core/Format/MusicXMLTest.cs
+++ b/OpenUtau.Test/Core/Format/MusicXMLTest.cs
@@ -192,9 +192,13 @@ namespace OpenUtau.Core.Format {
             Assert.Equal("+", notesList[1].lyric);
             Assert.Equal("+", notesList[2].lyric);
             Assert.Equal("Ja!", notesList[3].lyric);
+            Assert.Equal("a", notesList[4].lyric);
             Assert.Equal("Trara!", notesList[5].lyric);
+            Assert.Equal("+~", notesList[6].lyric);
             Assert.Equal("+", notesList[7].lyric);
+            Assert.Equal("a", notesList[8].lyric);
             Assert.Equal("Bah!", notesList[9].lyric);
+            Assert.Equal("a", notesList[10].lyric);
         }
     }
 }


### PR DESCRIPTION
This PR improves MusicXML handling by using "+" instead of "a" as default lyrics, and handle multi-syllabic spans in MusicXML.