### PR TITLE
Detached Pianoroll Window Position Fix

### DIFF
--- a/OpenUtau/Views/PianoRollDetachedWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollDetachedWindow.axaml.cs
@@ -23,7 +23,21 @@ namespace OpenUtau.App.Views {
         }
 
         public void WindowClosing(object? sender, WindowClosingEventArgs e) {
-            Preferences.Default.PianorollWindowSize.Set(Width, Height, Position.X, Position.Y, (int)WindowState);
+            // Check window state first cuz it flops sometimes
+            if (WindowState != WindowState.Minimized) {
+                Preferences.Default.PianorollWindowSize.Set(Width, Height, Position.X, Position.Y, (int)WindowState);
+            } else {
+                // when the window flops like maximized -> minimized, the size and position are lost
+                // so we need to restore them to the default values
+                var prevSize = Preferences.Default.PianorollWindowSize;
+                Preferences.Default.PianorollWindowSize.Set(
+                    prevSize.Width, 
+                    prevSize.Height, 
+                    prevSize.PositionX ?? 0, 
+                    prevSize.PositionY ?? 0, 
+                    (int)WindowState.Normal 
+                );
+            }
             Preferences.Save();
             Hide();
             e.Cancel = !forceClose;


### PR DESCRIPTION
- Updated the `WindowClosing` logic in `PianoRollDetachedWindow` to handle the minimized state safely cuz If the user closes the main app while the piano roll is minimized, the original code would save (int)WindowState as Minimized. The next time they launched the app, the piano roll would open, but it would launch completely minimized and out of sight, confusing the user. (the bug is randomly occurs but I caught it this time)