### PR TITLE
Add ENG flag switching to Voice Color remapping

### DIFF
--- a/OpenUtau/ViewModels/VoiceColorMappingViewModel.cs
+++ b/OpenUtau/ViewModels/VoiceColorMappingViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using DynamicData;
@@ -8,24 +9,67 @@ namespace OpenUtau.App.ViewModels {
 
         public string TrackName { get; set; }
         public ObservableCollection<ColorMapping> ColorMappings { get; set; } = new ObservableCollection<ColorMapping>();
+        public ObservableCollection<EngineMapping> EngineMappings { get; set; } = new ObservableCollection<EngineMapping>();
+        public ObservableCollection<VoiceColorMappingRow> MappingRows { get; set; } = new ObservableCollection<VoiceColorMappingRow>();
 
-        public VoiceColorMappingViewModel(string[] oldColors, string[] newColors, string trackName) {
+        public VoiceColorMappingRow? DefaultMappingRow => MappingRows.FirstOrDefault();
+        public IEnumerable<VoiceColorMappingRow> NonDefaultMappingRows => MappingRows.Skip(1);
+
+        public VoiceColorMappingViewModel(string[] oldColors, string[] newColors, string trackName, string[] resamplers) {
             var NewColors = new ObservableCollection<string>(newColors);
             NewColors[0] = "(Default)";
             TrackName = trackName;
 
+            var engines = new ObservableCollection<string> { "(Default)" };
+            foreach (var r in resamplers) {
+                engines.Add(r);
+            }
+
             for (int i = 0; i < oldColors.Length; i++) {
+                int clrSelectedIndex;
                 if (i == 0) {
-                    ColorMappings.Add(new ColorMapping("(Default)", 0, 0, NewColors));
+                    clrSelectedIndex = 0;
                 } else if (newColors.Contains(oldColors[i])) {
-                    ColorMappings.Add(new ColorMapping(oldColors[i], i, newColors.IndexOf(oldColors[i]), NewColors));
+                    clrSelectedIndex = newColors.IndexOf(oldColors[i]);
                 } else if (i < newColors.Length) {
-                    ColorMappings.Add(new ColorMapping(oldColors[i], i, i, NewColors));
+                    clrSelectedIndex = i;
                 } else {
-                    ColorMappings.Add(new ColorMapping(oldColors[i], i, 0, NewColors));
+                    clrSelectedIndex = 0;
                 }
+
+                var colorMapping = new ColorMapping(
+                    i == 0 ? "(Default)" : oldColors[i],
+                    i,
+                    clrSelectedIndex,
+                    NewColors);
+                ColorMappings.Add(colorMapping);
+
+                var engineMapping = new EngineMapping(
+                    i == 0 ? "(Default)" : oldColors[i],
+                    i,
+                    0,
+                    engines);
+                EngineMappings.Add(engineMapping);
+
+                MappingRows.Add(new VoiceColorMappingRow {
+                    Name = i == 0 ? "(Default)" : oldColors[i],
+                    OldIndex = i,
+                    ColorSelectedIndex = clrSelectedIndex,
+                    NewColors = NewColors,
+                    EngineSelectedIndex = 0,
+                    Engines = engines,
+                });
             }
         }
+    }
+
+    public class VoiceColorMappingRow {
+        public string Name { get; set; } = string.Empty;
+        public int OldIndex { get; set; }
+        public int ColorSelectedIndex { get; set; }
+        public ObservableCollection<string> NewColors { get; set; } = new ObservableCollection<string>();
+        public int EngineSelectedIndex { get; set; }
+        public ObservableCollection<string> Engines { get; set; } = new ObservableCollection<string>();
     }
 
     public class ColorMapping {
@@ -39,6 +83,20 @@ namespace OpenUtau.App.ViewModels {
             OldIndex = oldIndex;
             SelectedIndex = selectedIndex;
             NewColors = newColors;
+        }
+    }
+
+    public class EngineMapping {
+        public string Name { get; set; }
+        public int OldColorIndex { get; set; }
+        public int SelectedIndex { get; set; }
+        public ObservableCollection<string> Engines { get; set; }
+
+        public EngineMapping(string name, int oldColorIndex, int selectedIndex, ObservableCollection<string> engines) {
+            Name = name;
+            OldColorIndex = oldColorIndex;
+            SelectedIndex = selectedIndex;
+            Engines = engines;
         }
     }
 }

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -35,6 +35,7 @@ namespace OpenUtau.App.Views {
 
         private PianoRollDetachedWindow? pianoRollWindow;
         private PianoRoll? pianoRoll;
+        private bool openPianoRollWindow;
 
         private PartEditState? partEditState;
         private readonly DispatcherTimer timer;
@@ -1173,19 +1174,26 @@ namespace OpenUtau.App.Views {
         }
 
         public void PartsCanvasPointerReleased(object sender, PointerReleasedEventArgs args) {
-            if (partEditState?.MouseButton != args.InitialPressMouseButton) {
-                return;
+            if (partEditState != null) {
+                if (partEditState.MouseButton != args.InitialPressMouseButton) {
+                    return;
+                }
+                var control = (Control)sender;
+                var point = args.GetCurrentPoint(control);
+                partEditState.Update(point.Pointer, point.Position);
+                partEditState.End(point.Pointer, point.Position);
+                partEditState = null;
+                Cursor = null;
             }
-            var control = (Control)sender;
-            var point = args.GetCurrentPoint(control);
-            partEditState.Update(point.Pointer, point.Position);
-            partEditState.End(point.Pointer, point.Position);
-            partEditState = null;
-            Cursor = null;
+            if (openPianoRollWindow) {
+                pianoRollWindow?.Show();
+                pianoRollWindow?.Activate();
+                openPianoRollWindow = false;
+            }
         }
 
         public async void PartsCanvasDoubleTapped(object sender, TappedEventArgs args) {
-            if (sender is not Canvas canvas) {
+            if (!(sender is Canvas canvas)) {
                 return;
             }
             var control = canvas.InputHitTest(args.GetPosition(canvas));
@@ -1201,9 +1209,11 @@ namespace OpenUtau.App.Views {
                     };
 
                     if (Preferences.Default.DetachPianoRoll) {
-                        viewModel.ShowPianoRoll = false;
+                        viewModel!.ShowPianoRoll = false;
                         pianoRollWindow = new(pianoRoll);
+                        pianoRollWindow.Show();
                     } else {
+                        viewModel!.ShowPianoRoll = true;
                         PianoRollContainer.Content = pianoRoll;
                     }
 
@@ -1214,12 +1224,11 @@ namespace OpenUtau.App.Views {
 
                     pianoRoll.ViewModel.PlaybackViewModel = viewModel.PlaybackViewModel;
                 }
+                // Workaround for new window losing focus.
                 if (pianoRollWindow != null) {
-                    pianoRollWindow.Show();
-                    pianoRollWindow.Activate();
+                    openPianoRollWindow = true;
                 } else {
                     viewModel.ShowPianoRoll = true;
-                    pianoRoll.Focus();
                 }
                 int tick = viewModel.TracksViewModel.PointToTick(args.GetPosition(canvas));
                 DocManager.Inst.ExecuteCmd(new LoadPartNotification(partControl.part, DocManager.Inst.Project, tick));
@@ -1235,11 +1244,11 @@ namespace OpenUtau.App.Views {
                 pianoRollWindow?.ForceClose();
                 pianoRollWindow = null;
                 PianoRollContainer.Content = pianoRoll;
-                viewModel.ShowPianoRoll = true;
+                viewModel!.ShowPianoRoll = true;
                 Preferences.Default.DetachPianoRoll = false;
             } else {
                 PianoRollContainer.Content = null;
-                viewModel.ShowPianoRoll = false;
+                viewModel!.ShowPianoRoll = false;
                 if (pianoRollWindow == null) {
                     pianoRollWindow = new(pianoRoll);
                     pianoRollWindow.Show();
@@ -1742,7 +1751,8 @@ namespace OpenUtau.App.Views {
                 .Where(vpart => vpart.notes.Count > 0);
             if (parts.Any()) {
                 var dialog = new VoiceColorMappingDialog();
-                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName);
+                var resamplers = ToolsManager.Inst.Resamplers.Select(r => r.ToString()!).ToArray();
+                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName, resamplers);
                 dialog.DataContext = vm;
                 await dialog.ShowDialog(this);
 
@@ -1758,7 +1768,8 @@ namespace OpenUtau.App.Views {
                 .Where(vpart => vpart.notes.Count > 0);
             if (parts.Any()) {
                 var dialog = new VoiceColorMappingDialog();
-                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName);
+                var resamplers = ToolsManager.Inst.Resamplers.Select(r => r.ToString()!).ToArray();
+                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName, resamplers);
                 dialog.DataContext = vm;
                 dialog.onFinish = () => {
                     DocManager.Inst.StartUndoGroup("command.track.remapvc");
@@ -1771,22 +1782,61 @@ namespace OpenUtau.App.Views {
             }
         }
         void SetVoiceColorRemapping(UTrack track, IEnumerable<UVoicePart> parts, VoiceColorMappingViewModel vm) {
+            var project = DocManager.Inst.Project;
+            SyncEngDescriptorOptions(project, track);
+            track.TryGetExpDescriptor(project, Ustx.ENG, out var engDescriptor);
             foreach (var part in parts) {
                 foreach (var phoneme in part.phonemes) {
-                    var tuple = phoneme.GetExpression(DocManager.Inst.Project, track, Ustx.CLR);
-                    if (vm.ColorMappings.Any(m => m.OldIndex == tuple.Item1)) {
-                        var mapping = vm.ColorMappings.First(m => m.OldIndex == tuple.Item1);
-                        if (mapping.OldIndex != mapping.SelectedIndex) {
-                            if (mapping.SelectedIndex == 0) {
-                                DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, part, phoneme, Ustx.CLR, null));
+                    var tuple = phoneme.GetExpression(project, track, Ustx.CLR);
+                    int oldClr = (int)tuple.Item1;
+                    var row = vm.MappingRows.FirstOrDefault(r => r.OldIndex == oldClr);
+                    if (row != null) {
+                        if (row.OldIndex != row.ColorSelectedIndex) {
+                            if (row.ColorSelectedIndex == 0) {
+                                DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(project, track, part, phoneme, Ustx.CLR, null));
                             } else {
-                                DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, part, phoneme, Ustx.CLR, mapping.SelectedIndex));
+                                DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(project, track, part, phoneme, Ustx.CLR, row.ColorSelectedIndex));
+                            }
+                        }
+                        if (row.EngineSelectedIndex == 0) {
+                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(project, track, part, phoneme, Ustx.ENG, null));
+                        } else {
+                            string engineName = row.Engines[row.EngineSelectedIndex];
+                            int engIndex = (engDescriptor?.options != null)
+                                ? Array.IndexOf(engDescriptor.options, engineName)
+                                : -1;
+                            if (engIndex >= 0) {
+                                DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(project, track, part, phoneme, Ustx.ENG, engIndex));
                             }
                         }
                     } else {
-                        DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, part, phoneme, Ustx.CLR, null));
+                        DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(project, track, part, phoneme, Ustx.CLR, null));
                     }
                 }
+            }
+        }
+
+        static void SyncEngDescriptorOptions(UProject project, UTrack track) {
+            if (!track.TryGetExpDescriptor(project, Ustx.ENG, out var descriptor)) {
+                return;
+            }
+            var resamplers = ToolsManager.Inst.Resamplers.Select(r => r.ToString()!);
+            var completeOptions = new List<string> { "" };
+            completeOptions.AddRange(resamplers!);
+            bool needsUpdate = false;
+            if (descriptor.options == null || descriptor.options.Length != completeOptions.Count) {
+                needsUpdate = true;
+            } else {
+                for (int i = 0; i < completeOptions.Count; i++) {
+                    if (descriptor.options[i] != completeOptions[i]) {
+                        needsUpdate = true;
+                        break;
+                    }
+                }
+            }
+            if (needsUpdate) {
+                descriptor.options = completeOptions.ToArray();
+                descriptor.max = completeOptions.Count - 1;
             }
         }
 

--- a/OpenUtau/Views/VoiceColorMappingDialog.axaml
+++ b/OpenUtau/Views/VoiceColorMappingDialog.axaml
@@ -2,30 +2,100 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" MinWidth="200" MinHeight="200" Width="350" Height="350"
+        mc:Ignorable="d" MinWidth="200" MinHeight="200" Width="480" Height="350"
         x:Class="OpenUtau.App.Views.VoiceColorMappingDialog"
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource dialogs.voicecolorremapping}"
         WindowStartupLocation="CenterOwner">
-  <Grid RowDefinitions="40,1*,30" Margin="10">
+  <Grid RowDefinitions="38,1*,30" Margin="10">
     <StackPanel Grid.Row="0" >
       <TextBlock Text="{DynamicResource dialogs.voicecolorremapping.caption}" />
       <TextBlock Text="{Binding TrackName}" />
     </StackPanel>
 
-    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" >
-      <ItemsControl ItemsSource="{Binding ColorMappings}" VerticalAlignment="Stretch" >
-        <ItemsControl.ItemTemplate>
-          <DataTemplate>
-            <Grid ColumnDefinitions="1*,1*">
-              <TextBlock Text="{Binding Name}"
-                         Grid.Column="0" HorizontalAlignment="Right" Margin="0,5,10,5"/>
-              <ComboBox ItemsSource="{Binding NewColors}" SelectedIndex="{Binding SelectedIndex}"
-                        Grid.Column="1" HorizontalAlignment="Left" Margin="10,5,0,5" MinWidth="100" />
-            </Grid>
-          </DataTemplate>
-        </ItemsControl.ItemTemplate>
-      </ItemsControl>
+    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+      <Grid HorizontalAlignment="Center" ColumnDefinitions="Auto,Auto,Auto">
+        <!-- Name column -->
+        <StackPanel Grid.Column="0" Margin="0,0,10,0">
+          <TextBlock FontWeight="Bold" Margin="0,0,0,2" />
+          <Grid Height="28">
+            <TextBlock Text="{Binding DefaultMappingRow.Name}"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Center" />
+          </Grid>
+          <ItemsControl ItemsSource="{Binding NonDefaultMappingRows}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Grid Height="28">
+                  <TextBlock Text="{Binding Name}"
+                             HorizontalAlignment="Right"
+                             VerticalAlignment="Center" />
+                </Grid>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+
+        <!-- Voice color column -->
+        <StackPanel Grid.Column="1" Margin="0,0,14,0" HorizontalAlignment="Left">
+          <Grid HorizontalAlignment="Left"
+                Width="{Binding Bounds.Width, ElementName=DefaultColorCombo}"
+                Margin="0,0,0,2">
+            <TextBlock Text="{DynamicResource dialogs.voicecolorremapping}"
+                       FontWeight="Bold"
+                       HorizontalAlignment="Center" />
+          </Grid>
+          <Grid Height="28">
+            <ComboBox x:Name="DefaultColorCombo"
+                      ItemsSource="{Binding DefaultMappingRow.NewColors}"
+                      SelectedIndex="{Binding DefaultMappingRow.ColorSelectedIndex}"
+                      HorizontalAlignment="Left"
+                      VerticalAlignment="Center" />
+          </Grid>
+          <ItemsControl ItemsSource="{Binding NonDefaultMappingRows}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Grid Height="28">
+                  <ComboBox ItemsSource="{Binding NewColors}"
+                            SelectedIndex="{Binding ColorSelectedIndex}"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center" />
+                </Grid>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+
+        <!-- Resampler column -->
+        <StackPanel Grid.Column="2" HorizontalAlignment="Left">
+          <Grid HorizontalAlignment="Left"
+                Width="{Binding Bounds.Width, ElementName=DefaultEngineCombo}"
+                Margin="0,0,0,2">
+            <TextBlock Text="{DynamicResource prefs.rendering.resampler}"
+                       FontWeight="Bold"
+                       HorizontalAlignment="Center" />
+          </Grid>
+          <Grid Height="28">
+            <ComboBox x:Name="DefaultEngineCombo"
+                      ItemsSource="{Binding DefaultMappingRow.Engines}"
+                      SelectedIndex="{Binding DefaultMappingRow.EngineSelectedIndex}"
+                      HorizontalAlignment="Left"
+                      VerticalAlignment="Center" />
+          </Grid>
+          <ItemsControl ItemsSource="{Binding NonDefaultMappingRows}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <Grid Height="28">
+                  <ComboBox ItemsSource="{Binding Engines}"
+                            SelectedIndex="{Binding EngineSelectedIndex}"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center" />
+                </Grid>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+      </Grid>
     </ScrollViewer>
 
     <StackPanel Orientation="Horizontal" Grid.Row="2" HorizontalAlignment="Center" Spacing="10">


### PR DESCRIPTION
This change adds support for changing the ENG flag from the Voice Color remapping dialog.

It allows users to switch to a more suitable resampler for each voice color while remapping voice colors at the same time. This makes resampler selection and testing much faster and more convenient.

Because the list is automatically populated from the resamplers in the Resamplers folder, users no longer need to type resampler names into the ENG flag repeatedly.

I believe this change will make UTAU singer tuning more convenient and efficient.