### PR TITLE
Changes and improvements on rule-based Filipino phonemizer

### DIFF
--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using OpenUtau.Api;
+using OpenUtau.Core.G2p;
+
+namespace OpenUtau.Core.G2p {
+    public class RuleBasedFilipinoG2p : IG2p {
+        readonly static Regex kAllPunct = new Regex(@"^[\p{P}]$");
+
+        private string[] validPhonemes =
+            { "m", "n", "ng", "p", "t", "ty", "k", "q", "b", "d", "dy", "g", "s", "sy", "h", "l", "y", "w", "r", "vf", "a", "e", "i", "o", "u" };
+
+        private readonly string[] glides = { "w", "y" };
+
+        private string[] vowels = { "a", "e", "i", "o", "u" };
+
+        public bool IsGlide(string symbol) => glides.Contains(symbol);
+
+        public bool IsValidSymbol(string symbol) => validPhonemes.Contains(symbol);
+
+        public bool IsVowel(string symbol) => vowels.Contains(symbol);
+
+        public string[] UnpackHint(string hint, char separator = ' ') {
+            return hint.Split(separator)
+                .Where(x => validPhonemes.Contains(x))
+                .ToArray();
+        }
+
+        public string[] Query(string grapheme) {
+            if (string.IsNullOrEmpty(grapheme) || kAllPunct.IsMatch(grapheme)) {
+                return null;
+            }
+            return Predict(grapheme);
+        }
+
+        string[]? Predict(string grapheme) {
+            grapheme = grapheme.ToLower(new CultureInfo("fil-PH"));
+            if (grapheme.Equals("mga")) grapheme = "manga";
+            if (grapheme.Equals("ng")) grapheme = "nang";
+            List<string> phonemes = new List<string>();
+            foreach (var c in grapheme) {
+                var prev = phonemes.LastOrDefault("");
+                switch (c) {
+                    case 'a':
+                    case 'o':
+                    case 'u':
+                        if (prev.Equals("c")) phonemes[^1] = "k";
+                        phonemes.Add(c.ToString());
+                        break;
+                    case 'e':
+                        if (prev.Equals("c")) phonemes[^1] = "s";
+                        phonemes.Add("e");
+                        break;
+                    case 'i':
+                        if (prev.Equals("c")) phonemes[^1] = "sy";
+                        else phonemes.Add("i");
+                        break;
+                    case 'f':
+                        phonemes.Add("p");
+                        break;
+                    case 'g':
+                        if (prev.Equals("n")) phonemes[^1] = "ng";
+                        else phonemes.Add("g");
+                        break;
+                    case 'j':
+                        phonemes.Add("dy");
+                        break;
+                    case 'ñ':
+                        phonemes.Add("n");
+                        phonemes.Add("y");
+                        break;
+                    case 'y':
+                        if (prev.Equals("t") || prev.Equals("d") || prev.Equals("s"))
+                            phonemes[^1] = prev + "y";
+                        else phonemes.Add("y");
+                        break;
+                    case 'z':
+                        phonemes.Add("s");
+                        break;
+                    case '-':
+                        phonemes.Add("q");
+                        break;
+                    case '\'':
+                        phonemes.Add("vf");
+                        break;
+                    default:
+                        phonemes.Add(c.ToString());
+                        break;
+                }
+            }
+
+            string[] filteredPhonemes = phonemes.Where(x => validPhonemes.Contains(x)).ToArray();
+
+            return (filteredPhonemes.Length == 0) ? null : filteredPhonemes;
+        }
+    }
+}
+
+namespace OpenUtau.Core.DiffSinger {
+    [Phonemizer("DiffSinger Rule-based Filipino Phonemizer", "DIFFS FIL", "UtaUtaUtau", "FIL")]
+    public class DiffSingerRuleBasedFilipinoPhonemizer : DiffSingerG2pPhonemizer {
+        protected override string GetDictionaryName() => "dsdict-fil.yaml";
+
+        public override string GetLangCode() => "fil";
+
+        protected override IG2p LoadBaseG2p() => new RuleBasedFilipinoG2p();
+
+        protected override string[] GetBaseG2pVowels() => new string[] {
+            "a", "e", "i", "o", "u"
+        };
+
+        protected override string[] GetBaseG2pConsonants() => new string[] {
+            "m", "n", "ng", "p", "t", "ty", "k", "q", "b", "d", "dy", "g", "s", "sy", "h", "l", "y", "w", "r", "vf"
+        };
+    }
+}

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
@@ -22,6 +22,8 @@ namespace OpenUtau.Core.G2p {
 
         public bool IsVowel(string symbol) => vowels.Contains(symbol);
 
+        bool IsConsonant(string symbol) => !symbol.Equals("|") && !IsVowel(symbol);
+
         public string[] UnpackHint(string hint, char separator = ' ') {
             return hint.Split(separator)
                 .Where(x => validPhonemes.Contains(x))
@@ -64,12 +66,20 @@ namespace OpenUtau.Core.G2p {
                         if (prev.Equals("n")) phonemes[^1] = "ng";
                         else phonemes.Add("g");
                         break;
+                    case 'h':
+                        if (prev.Equals("c")) phonemes[^1] = "ty";
+                        else phonemes.Add("h");
+                        break;
                     case 'j':
                         phonemes.Add("dy");
                         break;
                     case 'ñ':
                         phonemes.Add("n");
                         phonemes.Add("y");
+                        break;
+                    case 's':
+                        if (prev.Equals("t")) phonemes[^1] = "ty";
+                        else phonemes.Add("s");
                         break;
                     case 'y':
                         if (prev.Equals("t") || prev.Equals("d") || prev.Equals("s"))
@@ -90,6 +100,21 @@ namespace OpenUtau.Core.G2p {
                         break;
                 }
             }
+            
+            // glide pass
+            for (int i = 1; i < phonemes.Count - 1; i++) {
+                string prev = phonemes[i - 1];
+                string curr = phonemes[i];
+                string next = phonemes[i + 1];
+                phonemes[i] = curr switch {
+                    "u" when IsConsonant(prev) && IsVowel(next) => "w",
+                    "i" when IsConsonant(prev) && IsVowel(next) => "y",
+                    _ => phonemes[i]
+                };
+            }
+            
+            // extra palatalization pass
+            
 
             string[] filteredPhonemes = phonemes.Where(x => validPhonemes.Contains(x)).ToArray();
 

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
@@ -7,14 +7,15 @@ using OpenUtau.Core.G2p;
 
 namespace OpenUtau.Core.G2p {
     public class RuleBasedFilipinoG2p : IG2p {
-        readonly static Regex kAllPunct = new Regex(@"^[\p{P}]$");
+        static readonly Regex kAllPunct = new Regex(@"^[\p{P}]$");
 
-        private string[] validPhonemes =
-            { "m", "n", "ng", "p", "t", "ty", "k", "q", "b", "d", "dy", "g", "s", "sy", "h", "l", "y", "w", "r", "vf", "a", "e", "i", "o", "u" };
+        private readonly string[] validPhonemes =
+            ["m", "n", "ng", "p", "t", "ty", "k", "q", "b", "d", "dy", "g", "s", "sy", "h", "l", "y", "Y", "w", "W", "r", "vf", "a", "e", "i", "o", "u"
+            ];
 
-        private readonly string[] glides = { "w", "y" };
+        private readonly string[] glides = ["w", "y"];
 
-        private string[] vowels = { "a", "e", "i", "o", "u" };
+        private readonly string[] vowels = ["a", "e", "i", "o", "u"];
 
         public bool IsGlide(string symbol) => glides.Contains(symbol);
 
@@ -49,15 +50,20 @@ namespace OpenUtau.Core.G2p {
                     case 'o':
                     case 'u':
                         if (prev.Equals("c")) phonemes[^1] = "k";
+                        else if (IsVowel(prev)) phonemes.Add("q");
                         phonemes.Add(c.ToString());
                         break;
                     case 'e':
                         if (prev.Equals("c")) phonemes[^1] = "s";
+                        else if (IsVowel(prev)) phonemes.Add("q");
                         phonemes.Add("e");
                         break;
                     case 'i':
                         if (prev.Equals("c")) phonemes[^1] = "sy";
-                        else phonemes.Add("i");
+                        else if (IsVowel(prev)) {
+                            phonemes.Add("q");
+                            phonemes.Add("i");
+                        } else phonemes.Add("i");
                         break;
                     case 'f':
                         phonemes.Add("p");
@@ -67,8 +73,18 @@ namespace OpenUtau.Core.G2p {
                         else phonemes.Add("g");
                         break;
                     case 'h':
-                        if (prev.Equals("c")) phonemes[^1] = "ty";
-                        else phonemes.Add("h");
+                        switch (prev)
+                        {
+                            case "c":
+                                phonemes[^1] = "ty";
+                                break;
+                            case "s":
+                                phonemes[^1] = "sh";
+                                break;
+                            default:
+                                phonemes.Add("h");
+                                break;
+                        }
                         break;
                     case 'j':
                         phonemes.Add("dy");
@@ -101,7 +117,7 @@ namespace OpenUtau.Core.G2p {
                 }
             }
             
-            // glide pass
+            // glide+coda pass
             for (int i = 1; i < phonemes.Count - 1; i++) {
                 string prev = phonemes[i - 1];
                 string curr = phonemes[i];
@@ -109,13 +125,15 @@ namespace OpenUtau.Core.G2p {
                 phonemes[i] = curr switch {
                     "u" when IsConsonant(prev) && IsVowel(next) => "w",
                     "i" when IsConsonant(prev) && IsVowel(next) => "y",
+                    "w" when IsVowel(prev) && IsConsonant(next) => "W",
+                    "y" when IsVowel(prev) && IsConsonant(next) => "Y",
                     _ => phonemes[i]
                 };
             }
             
-            // extra palatalization pass
+            // end coda
+            if (IsVowel(phonemes[^2]) && IsGlide(phonemes[^1])) phonemes[^1] = phonemes[^1].ToUpperInvariant();
             
-
             string[] filteredPhonemes = phonemes.Where(x => validPhonemes.Contains(x)).ToArray();
 
             return (filteredPhonemes.Length == 0) ? null : filteredPhonemes;
@@ -137,7 +155,7 @@ namespace OpenUtau.Core.DiffSinger {
         };
 
         protected override string[] GetBaseG2pConsonants() => new string[] {
-            "m", "n", "ng", "p", "t", "ty", "k", "q", "b", "d", "dy", "g", "s", "sy", "h", "l", "y", "w", "r", "vf"
+            "m", "n", "ng", "p", "t", "ty", "k", "q", "b", "d", "dy", "g", "s", "sy", "h", "l", "y", "Y", "w", "W", "r", "vf"
         };
     }
 }

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
@@ -132,7 +132,8 @@ namespace OpenUtau.Core.G2p {
             }
             
             // end coda
-            if (IsVowel(phonemes[^2]) && IsGlide(phonemes[^1])) phonemes[^1] = phonemes[^1].ToUpperInvariant();
+            
+            if ((phonemes.Count >= 2) && IsVowel(phonemes[^2]) && IsGlide(phonemes[^1])) phonemes[^1] = phonemes[^1].ToUpperInvariant();
             
             string[] filteredPhonemes = phonemes.Where(x => validPhonemes.Contains(x)).ToArray();
 

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
@@ -118,19 +118,17 @@ namespace OpenUtau.Core.G2p {
             }
             
             // glide+coda pass
-            if (phonemes.Count >= 3) {
-                for (int i = 1; i < phonemes.Count - 1; i++) {
-                    string prev = phonemes[i - 1];
-                    string curr = phonemes[i];
-                    string next = phonemes[i + 1];
-                    phonemes[i] = curr switch {
-                        "u" when IsConsonant(prev) && IsVowel(next) => "w",
-                        "i" when IsConsonant(prev) && IsVowel(next) => "y",
-                        "w" when IsVowel(prev) && IsConsonant(next) => "W",
-                        "y" when IsVowel(prev) && IsConsonant(next) => "Y",
-                        _ => phonemes[i]
-                    };
-                }
+            for (int i = 1; i < phonemes.Count - 1; i++) {
+                string prev = phonemes[i - 1];
+                string curr = phonemes[i];
+                string next = phonemes[i + 1];
+                phonemes[i] = curr switch {
+                    "u" when IsConsonant(prev) && IsVowel(next) => "w",
+                    "i" when IsConsonant(prev) && IsVowel(next) => "y",
+                    "w" when IsVowel(prev) && IsConsonant(next) => "W",
+                    "y" when IsVowel(prev) && IsConsonant(next) => "Y",
+                    _ => phonemes[i]
+                };
             }
             
             // end coda

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
@@ -118,17 +118,19 @@ namespace OpenUtau.Core.G2p {
             }
             
             // glide+coda pass
-            for (int i = 1; i < phonemes.Count - 1; i++) {
-                string prev = phonemes[i - 1];
-                string curr = phonemes[i];
-                string next = phonemes[i + 1];
-                phonemes[i] = curr switch {
-                    "u" when IsConsonant(prev) && IsVowel(next) => "w",
-                    "i" when IsConsonant(prev) && IsVowel(next) => "y",
-                    "w" when IsVowel(prev) && IsConsonant(next) => "W",
-                    "y" when IsVowel(prev) && IsConsonant(next) => "Y",
-                    _ => phonemes[i]
-                };
+            if (phonemes.Count >= 3) {
+                for (int i = 1; i < phonemes.Count - 1; i++) {
+                    string prev = phonemes[i - 1];
+                    string curr = phonemes[i];
+                    string next = phonemes[i + 1];
+                    phonemes[i] = curr switch {
+                        "u" when IsConsonant(prev) && IsVowel(next) => "w",
+                        "i" when IsConsonant(prev) && IsVowel(next) => "y",
+                        "w" when IsVowel(prev) && IsConsonant(next) => "W",
+                        "y" when IsVowel(prev) && IsConsonant(next) => "Y",
+                        _ => phonemes[i]
+                    };
+                }
             }
             
             // end coda


### PR DESCRIPTION
This PR includes a few improvements on the G2P to follow the behavior of the language more closely.

Main changes:
 - Added glottal stop insertion rule between vowels
 - Added vowel to glide conversion for certain vowel combinations (u + vowel, i + vowel)
 - Added sh digraph
 - Added coda-exclusive phonemes for diphthongs (Y, W)
Extra:
 - `|` is now considered a bypass character for these extra rules. For example, tatsulok is phonemized as [t a ty u l o k] which is wrong, but can be corrected by bypassing the digraph check on the ts, which is done like so: tat|sulok.