### PR TITLE
Refresh real curves after phrase rendering

### DIFF
--- a/OpenUtau.Core/Classic/ClassicRenderer.cs
+++ b/OpenUtau.Core/Classic/ClassicRenderer.cs
@@ -48,7 +48,7 @@ namespace OpenUtau.Classic {
             };
         }
 
-        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender) {
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender, RenderPhraseEvents? renderEvents = null) {
             if (phrase.wavtool == SharpWavtool.nameConvergence || phrase.wavtool == SharpWavtool.nameSimple) {
                 return RenderInternal(phrase, progress, trackNo, cancellation, isPreRender);
             } else {

--- a/OpenUtau.Core/Classic/ClassicRenderer.cs
+++ b/OpenUtau.Core/Classic/ClassicRenderer.cs
@@ -47,7 +47,7 @@ namespace OpenUtau.Classic {
             };
         }
 
-        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender) {
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender, RenderPhraseEvents? renderEvents = null) {
             if (phrase.wavtool == SharpWavtool.nameConvergence || phrase.wavtool == SharpWavtool.nameSimple) {
                 return RenderInternal(phrase, progress, trackNo, cancellation, isPreRender);
             } else {

--- a/OpenUtau.Core/Classic/WorldlineRenderer.cs
+++ b/OpenUtau.Core/Classic/WorldlineRenderer.cs
@@ -63,7 +63,7 @@ namespace OpenUtau.Classic {
             };
         }
 
-        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender) {
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender, RenderPhraseEvents? renderEvents = null) {
             var resamplerItems = new List<ResamplerItem>();
             foreach (var phone in phrase.phones) {
                 resamplerItems.Add(new ResamplerItem(phrase, phone));

--- a/OpenUtau.Core/Commands/ExpCommands.cs
+++ b/OpenUtau.Core/Commands/ExpCommands.cs
@@ -327,6 +327,7 @@ namespace OpenUtau.Core {
         public SetCurveCommand(UProject project, UVoicePart part, string abbr, int x, int y, int lastX, int lastY) : base(part) {
             this.project = project;
             this.abbr = abbr;
+            Key = abbr;
             this.x = x;
             this.y = y;
             this.lastX = lastX;
@@ -388,6 +389,7 @@ namespace OpenUtau.Core {
             string abbr, int[] oldXs, int[] oldYs, int[] newXs, int[] newYs, bool setReal = false) : base(part) {
             this.project = project;
             this.abbr = abbr;
+            Key = setReal ? string.Empty : abbr;
             this.oldXs = oldXs;
             this.oldYs = oldYs;
             this.newXs = newXs;
@@ -439,6 +441,7 @@ namespace OpenUtau.Core {
         public PasteCurveCommand(UProject project, UVoicePart part, string abbr, IEnumerable<int> xs, IEnumerable<int> ys) : base(part) {
             this.project = project;
             this.abbr = abbr;
+            Key = abbr;
             this.xs = xs.ToArray();
             this.ys = ys.ToArray();
             var curve = part.curves.FirstOrDefault(c => c.abbr == abbr);
@@ -448,6 +451,7 @@ namespace OpenUtau.Core {
         public PasteCurveCommand(UProject project, UVoicePart part, string abbr, int startX, int startY, int endX, int endY) : base(part) {
             this.project = project;
             this.abbr = abbr;
+            Key = abbr;
             this.xs = new int[] { startX, endX };
             this.ys = new int[] { startY, endY };
             var curve = part.curves.FirstOrDefault(c => c.abbr == abbr);
@@ -499,6 +503,7 @@ namespace OpenUtau.Core {
         readonly int[] oldYs;
         public ClearCurveCommand(UVoicePart part, string abbr) : base(part) {
             this.abbr = abbr;
+            Key = abbr;
             var curve = Part.curves.FirstOrDefault(curve => curve.abbr == abbr);
             if (curve != null) {
                 oldXs = curve.xs.ToArray();

--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -249,20 +249,6 @@ namespace OpenUtau.Core {
         public override string ToString() => "Part rendered.";
     }
 
-    public class PhraseRenderedNotification : UNotification {
-        public readonly RenderPhrase phrase;
-        public readonly RenderResult result;
-        public readonly int trackNo;
-        public override bool Silent => true;
-        public PhraseRenderedNotification(UVoicePart part, RenderPhrase phrase, RenderResult result, int trackNo) {
-            this.part = part;
-            this.phrase = phrase;
-            this.result = result;
-            this.trackNo = trackNo;
-        }
-        public override string ToString() => "Phrase rendered.";
-    }
-
     public class RealCurvesUpdatedNotification : UNotification {
         public readonly IReadOnlyList<RealCurveUpdate> updates;
         public override bool Silent => true;
@@ -271,6 +257,16 @@ namespace OpenUtau.Core {
             this.updates = updates;
         }
         public override string ToString() => "Real curves updated.";
+    }
+
+    public class RealCurveCoverageNotification : UNotification {
+        public readonly IReadOnlyList<(int start, int end)> ranges;
+        public override bool Silent => true;
+        public RealCurveCoverageNotification(UVoicePart part, IReadOnlyList<(int start, int end)> ranges) {
+            this.part = part;
+            this.ranges = ranges;
+        }
+        public override string ToString() => "Real curve coverage.";
     }
 
     public class GotoOtoNotification : UNotification {

--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -265,10 +265,12 @@ namespace OpenUtau.Core {
 
     public class RealCurvesUpdatedNotification : UNotification {
         public readonly IReadOnlyList<RealCurveUpdate> updates;
+        public readonly bool isFullRefresh;
         public override bool Silent => true;
-        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
+        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates, bool isFullRefresh = false) {
             this.part = part;
             this.updates = updates;
+            this.isFullRefresh = isFullRefresh;
         }
         public override string ToString() => "Real curves updated.";
     }

--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -265,26 +265,14 @@ namespace OpenUtau.Core {
 
     public class RealCurvesUpdatedNotification : UNotification {
         public readonly IReadOnlyList<RealCurveUpdate> updates;
+        public readonly bool isFullRefresh;
         public override bool Silent => true;
-        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
+        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates, bool isFullRefresh = false) {
             this.part = part;
             this.updates = updates;
+            this.isFullRefresh = isFullRefresh;
         }
         public override string ToString() => "Real curves updated.";
-    }
-
-    // Posted once per part when every phrase in a render pass has reported real-curve data.
-    // The accumulated updates define which tick ranges the renderer actually covered this pass,
-    // so DocManager can trim stale realXs/realYs entries that fell outside the new coverage
-    // (e.g., a phrase shrank at its tail after undo).
-    public class RealCurveCoverageNotification : UNotification {
-        public readonly IReadOnlyList<RealCurveUpdate> updates;
-        public override bool Silent => true;
-        public RealCurveCoverageNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
-            this.part = part;
-            this.updates = updates;
-        }
-        public override string ToString() => "Real curve coverage.";
     }
 
     public class GotoOtoNotification : UNotification {

--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -265,12 +265,10 @@ namespace OpenUtau.Core {
 
     public class RealCurvesUpdatedNotification : UNotification {
         public readonly IReadOnlyList<RealCurveUpdate> updates;
-        public readonly bool isFullRefresh;
         public override bool Silent => true;
-        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates, bool isFullRefresh = false) {
+        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
             this.part = part;
             this.updates = updates;
-            this.isFullRefresh = isFullRefresh;
         }
         public override string ToString() => "Real curves updated.";
     }

--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using OpenUtau.Core.Render;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core {
@@ -245,6 +247,30 @@ namespace OpenUtau.Core {
             this.part = part;
         }
         public override string ToString() => "Part rendered.";
+    }
+
+    public class PhraseRenderedNotification : UNotification {
+        public readonly RenderPhrase phrase;
+        public readonly RenderResult result;
+        public readonly int trackNo;
+        public override bool Silent => true;
+        public PhraseRenderedNotification(UVoicePart part, RenderPhrase phrase, RenderResult result, int trackNo) {
+            this.part = part;
+            this.phrase = phrase;
+            this.result = result;
+            this.trackNo = trackNo;
+        }
+        public override string ToString() => "Phrase rendered.";
+    }
+
+    public class RealCurvesUpdatedNotification : UNotification {
+        public readonly IReadOnlyList<RealCurveUpdate> updates;
+        public override bool Silent => true;
+        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
+            this.part = part;
+            this.updates = updates;
+        }
+        public override string ToString() => "Real curves updated.";
     }
 
     public class GotoOtoNotification : UNotification {

--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -265,14 +265,26 @@ namespace OpenUtau.Core {
 
     public class RealCurvesUpdatedNotification : UNotification {
         public readonly IReadOnlyList<RealCurveUpdate> updates;
-        public readonly bool isFullRefresh;
         public override bool Silent => true;
-        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates, bool isFullRefresh = false) {
+        public RealCurvesUpdatedNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
             this.part = part;
             this.updates = updates;
-            this.isFullRefresh = isFullRefresh;
         }
         public override string ToString() => "Real curves updated.";
+    }
+
+    // Posted once per part when every phrase in a render pass has reported real-curve data.
+    // The accumulated updates define which tick ranges the renderer actually covered this pass,
+    // so DocManager can trim stale realXs/realYs entries that fell outside the new coverage
+    // (e.g., a phrase shrank at its tail after undo).
+    public class RealCurveCoverageNotification : UNotification {
+        public readonly IReadOnlyList<RealCurveUpdate> updates;
+        public override bool Silent => true;
+        public RealCurveCoverageNotification(UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
+            this.part = part;
+            this.updates = updates;
+        }
+        public override string ToString() => "Real curve coverage.";
     }
 
     public class GotoOtoNotification : UNotification {

--- a/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
@@ -22,21 +22,7 @@ namespace OpenUtau.Core.DiffSinger {
                 !CanRefresh(project, part, expCommand.Key)) {
                 return;
             }
-            Schedule(project, part, isFullRefresh: false);
-        }
-
-        // Triggered by undo/redo: bypass command-type / abbr filter so any project mutation
-        // forces a full reload of variance-curve baselines, including the cache-hit path
-        // where Render() short-circuits and renderEvents.ReportRealCurves never fires.
-        public static void ScheduleForUndo(UProject project, UVoicePart part) {
-            if (part == null ||
-                !project.parts.Contains(part) ||
-                part.trackNo < 0 ||
-                part.trackNo >= project.tracks.Count ||
-                project.tracks[part.trackNo].RendererSettings.Renderer is not DiffSingerRenderer) {
-                return;
-            }
-            Schedule(project, part, isFullRefresh: true);
+            Schedule(project, part);
         }
 
         static bool IsCurveEditCommand(UCommand command) {
@@ -56,7 +42,7 @@ namespace OpenUtau.Core.DiffSinger {
             return project.tracks[part.trackNo].RendererSettings.Renderer is DiffSingerRenderer;
         }
 
-        static void Schedule(UProject project, UVoicePart part, bool isFullRefresh) {
+        static void Schedule(UProject project, UVoicePart part) {
             var cancellation = new CancellationTokenSource();
             lock (lockObj) {
                 if (pending.TryGetValue(part, out var previous)) {
@@ -64,21 +50,17 @@ namespace OpenUtau.Core.DiffSinger {
                 }
                 pending[part] = cancellation;
             }
-            _ = Task.Run(() => RefreshAsync(project, part, cancellation, isFullRefresh));
+            _ = Task.Run(() => RefreshAsync(project, part, cancellation));
         }
 
-        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation, bool isFullRefresh) {
+        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation) {
             try {
                 await Task.Delay(DebounceMs, cancellation.Token);
                 var updates = LoadPartUpdates(project, part, cancellation.Token);
-                if (cancellation.IsCancellationRequested) {
+                if (cancellation.IsCancellationRequested || updates.Count == 0) {
                     return;
                 }
-                // For undo/redo always publish so stale real curves get cleared even when
-                // LoadPartUpdates returns nothing (e.g. all phrases removed by the undo).
-                if (isFullRefresh || updates.Count > 0) {
-                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates, isFullRefresh));
-                }
+                DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
             } catch (OperationCanceledException) {
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh DiffSinger real curves after curve edit.");

--- a/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
@@ -22,7 +22,21 @@ namespace OpenUtau.Core.DiffSinger {
                 !CanRefresh(project, part, expCommand.Key)) {
                 return;
             }
-            Schedule(project, part);
+            Schedule(project, part, isFullRefresh: false);
+        }
+
+        // Triggered by undo/redo: bypass command-type / abbr filter so any project mutation
+        // forces a full reload of variance-curve baselines, including the cache-hit path
+        // where Render() short-circuits and renderEvents.ReportRealCurves never fires.
+        public static void ScheduleForUndo(UProject project, UVoicePart part) {
+            if (part == null ||
+                !project.parts.Contains(part) ||
+                part.trackNo < 0 ||
+                part.trackNo >= project.tracks.Count ||
+                project.tracks[part.trackNo].RendererSettings.Renderer is not DiffSingerRenderer) {
+                return;
+            }
+            Schedule(project, part, isFullRefresh: true);
         }
 
         static bool IsCurveEditCommand(UCommand command) {
@@ -42,7 +56,7 @@ namespace OpenUtau.Core.DiffSinger {
             return project.tracks[part.trackNo].RendererSettings.Renderer is DiffSingerRenderer;
         }
 
-        static void Schedule(UProject project, UVoicePart part) {
+        static void Schedule(UProject project, UVoicePart part, bool isFullRefresh) {
             var cancellation = new CancellationTokenSource();
             lock (lockObj) {
                 if (pending.TryGetValue(part, out var previous)) {
@@ -50,17 +64,21 @@ namespace OpenUtau.Core.DiffSinger {
                 }
                 pending[part] = cancellation;
             }
-            _ = Task.Run(() => RefreshAsync(project, part, cancellation));
+            _ = Task.Run(() => RefreshAsync(project, part, cancellation, isFullRefresh));
         }
 
-        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation) {
+        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation, bool isFullRefresh) {
             try {
                 await Task.Delay(DebounceMs, cancellation.Token);
                 var updates = LoadPartUpdates(project, part, cancellation.Token);
-                if (cancellation.IsCancellationRequested || updates.Count == 0) {
+                if (cancellation.IsCancellationRequested) {
                     return;
                 }
-                DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                // For undo/redo always publish so stale real curves get cleared even when
+                // LoadPartUpdates returns nothing (e.g. all phrases removed by the undo).
+                if (isFullRefresh || updates.Count > 0) {
+                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates, isFullRefresh));
+                }
             } catch (OperationCanceledException) {
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh DiffSinger real curves after curve edit.");

--- a/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
@@ -22,7 +22,21 @@ namespace OpenUtau.Core.DiffSinger {
                 !CanRefresh(project, part, expCommand.Key)) {
                 return;
             }
-            Schedule(project, part);
+            Schedule(project, part, isFullRefresh: false);
+        }
+
+        // Triggered by undo/redo: bypass command-type / abbr filter so any project mutation
+        // forces a full reload of variance-curve baselines, including the cache-hit path
+        // where Render() short-circuits and renderEvents.ReportRealCurves never fires.
+        public static void ScheduleForUndo(UProject project, UVoicePart part) {
+            if (part == null ||
+                !project.parts.Contains(part) ||
+                part.trackNo < 0 ||
+                part.trackNo >= project.tracks.Count ||
+                project.tracks[part.trackNo].RendererSettings.Renderer is not DiffSingerRenderer) {
+                return;
+            }
+            Schedule(project, part, isFullRefresh: true);
         }
 
         static bool IsCurveEditCommand(UCommand command) {
@@ -42,7 +56,7 @@ namespace OpenUtau.Core.DiffSinger {
             return project.tracks[part.trackNo].RendererSettings.Renderer is DiffSingerRenderer;
         }
 
-        static void Schedule(UProject project, UVoicePart part) {
+        static void Schedule(UProject project, UVoicePart part, bool isFullRefresh) {
             var cancellation = new CancellationTokenSource();
             lock (lockObj) {
                 if (pending.TryGetValue(part, out var previous)) {
@@ -50,15 +64,20 @@ namespace OpenUtau.Core.DiffSinger {
                 }
                 pending[part] = cancellation;
             }
-            _ = Task.Run(() => RefreshAsync(project, part, cancellation));
+            _ = Task.Run(() => RefreshAsync(project, part, cancellation, isFullRefresh));
         }
 
-        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation) {
+        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation, bool isFullRefresh) {
             try {
                 await Task.Delay(DebounceMs, cancellation.Token);
                 var updates = LoadPartUpdates(project, part, cancellation.Token);
-                if (updates.Count > 0 && !cancellation.IsCancellationRequested) {
-                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                if (cancellation.IsCancellationRequested) {
+                    return;
+                }
+                // For undo/redo always publish so stale real curves get cleared even when
+                // LoadPartUpdates returns nothing (e.g. all phrases removed by the undo).
+                if (isFullRefresh || updates.Count > 0) {
+                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates, isFullRefresh));
                 }
             } catch (OperationCanceledException) {
             } catch (Exception e) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
@@ -22,21 +22,7 @@ namespace OpenUtau.Core.DiffSinger {
                 !CanRefresh(project, part, expCommand.Key)) {
                 return;
             }
-            Schedule(project, part, isFullRefresh: false);
-        }
-
-        // Triggered by undo/redo: bypass command-type / abbr filter so any project mutation
-        // forces a full reload of variance-curve baselines, including the cache-hit path
-        // where Render() short-circuits and renderEvents.ReportRealCurves never fires.
-        public static void ScheduleForUndo(UProject project, UVoicePart part) {
-            if (part == null ||
-                !project.parts.Contains(part) ||
-                part.trackNo < 0 ||
-                part.trackNo >= project.tracks.Count ||
-                project.tracks[part.trackNo].RendererSettings.Renderer is not DiffSingerRenderer) {
-                return;
-            }
-            Schedule(project, part, isFullRefresh: true);
+            Schedule(project, part);
         }
 
         static bool IsCurveEditCommand(UCommand command) {
@@ -56,7 +42,7 @@ namespace OpenUtau.Core.DiffSinger {
             return project.tracks[part.trackNo].RendererSettings.Renderer is DiffSingerRenderer;
         }
 
-        static void Schedule(UProject project, UVoicePart part, bool isFullRefresh) {
+        static void Schedule(UProject project, UVoicePart part) {
             var cancellation = new CancellationTokenSource();
             lock (lockObj) {
                 if (pending.TryGetValue(part, out var previous)) {
@@ -64,20 +50,15 @@ namespace OpenUtau.Core.DiffSinger {
                 }
                 pending[part] = cancellation;
             }
-            _ = Task.Run(() => RefreshAsync(project, part, cancellation, isFullRefresh));
+            _ = Task.Run(() => RefreshAsync(project, part, cancellation));
         }
 
-        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation, bool isFullRefresh) {
+        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation) {
             try {
                 await Task.Delay(DebounceMs, cancellation.Token);
                 var updates = LoadPartUpdates(project, part, cancellation.Token);
-                if (cancellation.IsCancellationRequested) {
-                    return;
-                }
-                // For undo/redo always publish so stale real curves get cleared even when
-                // LoadPartUpdates returns nothing (e.g. all phrases removed by the undo).
-                if (isFullRefresh || updates.Count > 0) {
-                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates, isFullRefresh));
+                if (updates.Count > 0 && !cancellation.IsCancellationRequested) {
+                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
                 }
             } catch (OperationCanceledException) {
             } catch (Exception e) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRealCurveScheduler.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using Serilog;
+
+namespace OpenUtau.Core.DiffSinger {
+    internal static class DiffSingerRealCurveScheduler {
+        // Coalesce drag-generated curve commands without adding pointer-level preview logic.
+        const int DebounceMs = 200;
+        static readonly object lockObj = new object();
+        static readonly Dictionary<UVoicePart, CancellationTokenSource> pending = new Dictionary<UVoicePart, CancellationTokenSource>();
+
+        public static void TrySchedule(UProject project, UVoicePart part, UCommand command) {
+            if (command is not ExpCommand expCommand ||
+                !IsCurveEditCommand(command) ||
+                string.IsNullOrEmpty(expCommand.Key) ||
+                expCommand.Part != part ||
+                !CanRefresh(project, part, expCommand.Key)) {
+                return;
+            }
+            Schedule(project, part);
+        }
+
+        static bool IsCurveEditCommand(UCommand command) {
+            return command is SetCurveCommand ||
+                command is MergedSetCurveCommand ||
+                command is PasteCurveCommand ||
+                command is ClearCurveCommand;
+        }
+
+        static bool CanRefresh(UProject project, UVoicePart part, string abbr) {
+            if (!DiffSingerRenderer.ShouldRefreshRealCurvesOnCurveEdit(abbr) ||
+                !project.parts.Contains(part) ||
+                part.trackNo < 0 ||
+                part.trackNo >= project.tracks.Count) {
+                return false;
+            }
+            return project.tracks[part.trackNo].RendererSettings.Renderer is DiffSingerRenderer;
+        }
+
+        static void Schedule(UProject project, UVoicePart part) {
+            var cancellation = new CancellationTokenSource();
+            lock (lockObj) {
+                if (pending.TryGetValue(part, out var previous)) {
+                    previous.Cancel();
+                }
+                pending[part] = cancellation;
+            }
+            _ = Task.Run(() => RefreshAsync(project, part, cancellation));
+        }
+
+        static async Task RefreshAsync(UProject project, UVoicePart part, CancellationTokenSource cancellation) {
+            try {
+                await Task.Delay(DebounceMs, cancellation.Token);
+                var updates = LoadPartUpdates(project, part, cancellation.Token);
+                if (updates.Count > 0 && !cancellation.IsCancellationRequested) {
+                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                }
+            } catch (OperationCanceledException) {
+            } catch (Exception e) {
+                Log.Debug(e, "Failed to refresh DiffSinger real curves after curve edit.");
+            } finally {
+                lock (lockObj) {
+                    if (pending.TryGetValue(part, out var current) && current == cancellation) {
+                        pending.Remove(part);
+                    }
+                }
+                cancellation.Dispose();
+            }
+        }
+
+        static IReadOnlyList<RealCurveUpdate> LoadPartUpdates(
+            UProject project,
+            UVoicePart part,
+            CancellationToken cancellationToken) {
+            RenderPhrase[] phrases;
+            lock (project) {
+                if (!project.parts.Contains(part) ||
+                    part.trackNo < 0 ||
+                    part.trackNo >= project.tracks.Count ||
+                    project.tracks[part.trackNo].RendererSettings.Renderer is not DiffSingerRenderer) {
+                    return Array.Empty<RealCurveUpdate>();
+                }
+                phrases = part.renderPhrases.ToArray();
+            }
+            if (phrases.Length == 0) {
+                return Array.Empty<RealCurveUpdate>();
+            }
+            var updates = new List<RealCurveUpdate>();
+            foreach (var phrase in phrases) {
+                if (cancellationToken.IsCancellationRequested) {
+                    return Array.Empty<RealCurveUpdate>();
+                }
+                updates.AddRange(RealCurveUpdater.LoadPhraseUpdates(part, phrase));
+            }
+            return updates;
+        }
+    }
+}

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -79,7 +79,7 @@ namespace OpenUtau.Core.DiffSinger {
             };
         }
 
-        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender) {
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender, RenderPhraseEvents? renderEvents = null) {
             var task = Task.Run(() => {
                 lock (lockObj) {
                     if (cancellation.IsCancellationRequested) {
@@ -114,7 +114,7 @@ namespace OpenUtau.Core.DiffSinger {
                         }
                     }
                     if (result.samples == null) {
-                        result.samples = InvokeDiffsinger(phrase, depth, steps, cancellation);
+                        result.samples = InvokeDiffsinger(phrase, depth, steps, cancellation, renderEvents);
                         if (result.samples != null) {
                             var source = new WaveSource(0, 0, 0, 1);
                             source.SetSamples(result.samples);
@@ -135,7 +135,7 @@ namespace OpenUtau.Core.DiffSinger {
         leadingMs、positionMs、estimatedLengthMs: timeaxis layout in Ms, double
          */
 
-        float[] InvokeDiffsinger(RenderPhrase phrase, double depth, int steps, CancellationTokenSource cancellation) {
+        float[] InvokeDiffsinger(RenderPhrase phrase, double depth, int steps, CancellationTokenSource cancellation, RenderPhraseEvents? renderEvents) {
             var singer = phrase.singer as DiffSingerSinger;
             //Check if dsconfig.yaml is correct
             if(String.IsNullOrEmpty(singer.dsConfig.vocoder) ||
@@ -361,6 +361,7 @@ namespace OpenUtau.Core.DiffSinger {
                     }
                     varianceResult = singer.getVariancePredictor().Process(phrase);
                 }
+                renderEvents?.ReportRealCurves(BuildRenderedRealCurves(phrase, varianceResult));
                 //TODO: let user edit variance curves
                 if(singer.dsConfig.useEnergyEmbed){
                     var energyCurve = phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE);
@@ -521,6 +522,10 @@ namespace OpenUtau.Core.DiffSinger {
             }
         }
 
+        public void ScheduleRealCurveRefresh(UProject project, UVoicePart part, UCommand command) {
+            DiffSingerRealCurveScheduler.TrySchedule(project, part, command);
+        }
+
         public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
             if (!Preferences.Default.DiffSingerTensorCache) {
                 throw new Exception("Please enable DiffSinger tensor cache and re-render the phrase to display correct base curves.");
@@ -532,57 +537,68 @@ namespace OpenUtau.Core.DiffSinger {
             var variancePredictor = singer.getVariancePredictor()!;
             lock (variancePredictor) {
                 var result = variancePredictor.Process(phrase);
-                var frameMs = result.frameMs;
-                var headFrames = result.headFrames;
-                var tailFrames = result.tailFrames;
-                var startMs = phrase.positionMs - headFrames * frameMs;
-                var realCurves = new (string, float[], float[], Func<float, float>)[] {
-                    (
-                        ENE, result.energy ?? Array.Empty<float>(),
-                        phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE)?.Item2
-                        ?? Array.Empty<float>(),
-                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
-                    ),
-                    (
-                        Format.Ustx.BREC, result.breathiness ?? Array.Empty<float>(), phrase.breathiness,
-                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
-                    ),
-                    (
-                        Format.Ustx.VOIC, result.voicing ?? Array.Empty<float>(), phrase.voicing,
-                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
-                    ),
-                    (
-                        Format.Ustx.TENC, result.tension ?? Array.Empty<float>(), phrase.tension,
-                        x => Math.Clamp(x, -10f, 10f) / 20f + 0.5f
-                    ),
-                }.Select(t => {
-                    var abbr = t.Item1;
-                    var realCurve = t.Item2;
-                    if (realCurve.Length == 0) {
-                        return new RenderRealCurveResult {
-                            abbr = abbr,
-                            ticks = Array.Empty<float>(),
-                            values = Array.Empty<float>(),
-                        };
-                    }
-                    var deltaCurve = DiffSingerUtils.SampleCurve(
-                        phrase, t.Item3, 0, frameMs, realCurve.Length,
-                        headFrames, tailFrames, x => x)
-                        .Select(x => (float)x)
-                        .ToArray();
-                    var normFunc = t.Item4;
+                return BuildRenderedRealCurves(phrase, result);
+            }
+        }
+
+        internal static bool ShouldRefreshRealCurvesOnCurveEdit(string abbr) {
+            return abbr == ENE ||
+                abbr == Format.Ustx.BREC ||
+                abbr == Format.Ustx.VOIC ||
+                abbr == Format.Ustx.TENC;
+        }
+
+        private List<RenderRealCurveResult> BuildRenderedRealCurves(RenderPhrase phrase, VarianceResult result) {
+            var frameMs = result.frameMs;
+            var headFrames = result.headFrames;
+            var tailFrames = result.tailFrames;
+            var startMs = phrase.positionMs - headFrames * frameMs;
+            var realCurves = new (string, float[], float[], Func<float, float>)[] {
+                (
+                    ENE, result.energy ?? Array.Empty<float>(),
+                    phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE)?.Item2
+                    ?? Array.Empty<float>(),
+                    x => Math.Clamp(x, -96f, 0f) / 96f + 1f
+                ),
+                (
+                    Format.Ustx.BREC, result.breathiness ?? Array.Empty<float>(), phrase.breathiness,
+                    x => Math.Clamp(x, -96f, 0f) / 96f + 1f
+                ),
+                (
+                    Format.Ustx.VOIC, result.voicing ?? Array.Empty<float>(), phrase.voicing,
+                    x => Math.Clamp(x, -96f, 0f) / 96f + 1f
+                ),
+                (
+                    Format.Ustx.TENC, result.tension ?? Array.Empty<float>(), phrase.tension,
+                    x => Math.Clamp(x, -10f, 10f) / 20f + 0.5f
+                ),
+            }.Select(t => {
+                var abbr = t.Item1;
+                var realCurve = t.Item2;
+                if (realCurve.Length == 0) {
                     return new RenderRealCurveResult {
                         abbr = abbr,
-                        ticks = Enumerable.Range(0, realCurve.Length)
-                            .Select(i => (float)phrase.timeAxis.MsPosToTickPos(startMs + i * frameMs) - phrase.position)
-                            .ToArray(),
-                        values = realCurve.Zip(deltaCurve, varianceDeltaFunctions[abbr])
-                            .Select(normFunc)
-                            .ToArray()
+                        ticks = Array.Empty<float>(),
+                        values = Array.Empty<float>(),
                     };
-                }).ToList();
-                return realCurves;
-            }
+                }
+                var deltaCurve = DiffSingerUtils.SampleCurve(
+                    phrase, t.Item3, 0, frameMs, realCurve.Length,
+                    headFrames, tailFrames, x => x)
+                    .Select(x => (float)x)
+                    .ToArray();
+                var normFunc = t.Item4;
+                return new RenderRealCurveResult {
+                    abbr = abbr,
+                    ticks = Enumerable.Range(0, realCurve.Length)
+                        .Select(i => (float)phrase.timeAxis.MsPosToTickPos(startMs + i * frameMs) - phrase.position)
+                        .ToArray(),
+                    values = realCurve.Zip(deltaCurve, varianceDeltaFunctions[abbr])
+                        .Select(normFunc)
+                        .ToArray()
+                };
+            }).ToList();
+            return realCurves;
         }
 
         public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -526,10 +526,6 @@ namespace OpenUtau.Core.DiffSinger {
             DiffSingerRealCurveScheduler.TrySchedule(project, part, command);
         }
 
-        public void ScheduleFullRealCurveRefresh(UProject project, UVoicePart part) {
-            DiffSingerRealCurveScheduler.ScheduleForUndo(project, part);
-        }
-
         public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
             if (!Preferences.Default.DiffSingerTensorCache) {
                 throw new Exception("Please enable DiffSinger tensor cache and re-render the phrase to display correct base curves.");

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -526,6 +526,10 @@ namespace OpenUtau.Core.DiffSinger {
             DiffSingerRealCurveScheduler.TrySchedule(project, part, command);
         }
 
+        public void ScheduleFullRealCurveRefresh(UProject project, UVoicePart part) {
+            DiffSingerRealCurveScheduler.ScheduleForUndo(project, part);
+        }
+
         public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
             if (!Preferences.Default.DiffSingerTensorCache) {
                 throw new Exception("Please enable DiffSinger tensor cache and re-render the phrase to display correct base curves.");

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -565,6 +565,10 @@ namespace OpenUtau.Core.DiffSinger {
             DiffSingerRealCurveScheduler.TrySchedule(project, part, command);
         }
 
+        public void ScheduleFullRealCurveRefresh(UProject project, UVoicePart part) {
+            DiffSingerRealCurveScheduler.ScheduleForUndo(project, part);
+        }
+
         public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
             if (!Preferences.Default.DiffSingerTensorCache) {
                 throw new Exception("Please enable DiffSinger tensor cache and re-render the phrase to display correct base curves.");

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -565,10 +565,6 @@ namespace OpenUtau.Core.DiffSinger {
             DiffSingerRealCurveScheduler.TrySchedule(project, part, command);
         }
 
-        public void ScheduleFullRealCurveRefresh(UProject project, UVoicePart part) {
-            DiffSingerRealCurveScheduler.ScheduleForUndo(project, part);
-        }
-
         public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
             if (!Preferences.Default.DiffSingerTensorCache) {
                 throw new Exception("Please enable DiffSinger tensor cache and re-render the phrase to display correct base curves.");

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -79,7 +79,7 @@ namespace OpenUtau.Core.DiffSinger {
             };
         }
 
-        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender) {
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender, RenderPhraseEvents? renderEvents = null) {
             var task = Task.Run(() => {
                 lock (lockObj) {
                     if (cancellation.IsCancellationRequested) {
@@ -114,7 +114,7 @@ namespace OpenUtau.Core.DiffSinger {
                         }
                     }
                     if (result.samples == null) {
-                        result.samples = InvokeDiffsinger(phrase, depth, steps, cancellation);
+                        result.samples = InvokeDiffsinger(phrase, depth, steps, cancellation, renderEvents);
                         if (result.samples != null) {
                             var source = new WaveSource(0, 0, 0, 1);
                             source.SetSamples(result.samples);
@@ -137,7 +137,7 @@ namespace OpenUtau.Core.DiffSinger {
         leadingMs、positionMs、estimatedLengthMs: timeaxis layout in Ms, double
          */
 
-        float[] InvokeDiffsinger(RenderPhrase phrase, double depth, int steps, CancellationTokenSource cancellation) {
+        float[] InvokeDiffsinger(RenderPhrase phrase, double depth, int steps, CancellationTokenSource cancellation, RenderPhraseEvents? renderEvents) {
             var singer = phrase.singer as DiffSingerSinger;
             //Check if dsconfig.yaml is correct
             if(String.IsNullOrEmpty(singer.dsConfig.vocoder) ||
@@ -363,6 +363,7 @@ namespace OpenUtau.Core.DiffSinger {
                     }
                     varianceResult = singer.getVariancePredictor().Process(phrase);
                 }
+                renderEvents?.ReportRealCurves(BuildRenderedRealCurves(phrase, varianceResult));
                 //TODO: let user edit variance curves
                 if(singer.dsConfig.useEnergyEmbed){
                     var energyCurve = phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE);
@@ -560,6 +561,10 @@ namespace OpenUtau.Core.DiffSinger {
             }
         }
 
+        public void ScheduleRealCurveRefresh(UProject project, UVoicePart part, UCommand command) {
+            DiffSingerRealCurveScheduler.TrySchedule(project, part, command);
+        }
+
         public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
             if (!Preferences.Default.DiffSingerTensorCache) {
                 throw new Exception("Please enable DiffSinger tensor cache and re-render the phrase to display correct base curves.");
@@ -571,57 +576,68 @@ namespace OpenUtau.Core.DiffSinger {
             var variancePredictor = singer.getVariancePredictor()!;
             lock (variancePredictor) {
                 var result = variancePredictor.Process(phrase);
-                var frameMs = result.frameMs;
-                var headFrames = result.headFrames;
-                var tailFrames = result.tailFrames;
-                var startMs = phrase.positionMs - headFrames * frameMs;
-                var realCurves = new (string, float[], float[], Func<float, float>)[] {
-                    (
-                        ENE, result.energy ?? Array.Empty<float>(),
-                        phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE)?.Item2
-                        ?? Array.Empty<float>(),
-                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
-                    ),
-                    (
-                        Format.Ustx.BREC, result.breathiness ?? Array.Empty<float>(), phrase.breathiness,
-                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
-                    ),
-                    (
-                        Format.Ustx.VOIC, result.voicing ?? Array.Empty<float>(), phrase.voicing,
-                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
-                    ),
-                    (
-                        Format.Ustx.TENC, result.tension ?? Array.Empty<float>(), phrase.tension,
-                        x => Math.Clamp(x, -10f, 10f) / 20f + 0.5f
-                    ),
-                }.Select(t => {
-                    var abbr = t.Item1;
-                    var realCurve = t.Item2;
-                    if (realCurve.Length == 0) {
-                        return new RenderRealCurveResult {
-                            abbr = abbr,
-                            ticks = Array.Empty<float>(),
-                            values = Array.Empty<float>(),
-                        };
-                    }
-                    var deltaCurve = DiffSingerUtils.SampleCurve(
-                        phrase, t.Item3, 0, frameMs, realCurve.Length,
-                        headFrames, tailFrames, x => x)
-                        .Select(x => (float)x)
-                        .ToArray();
-                    var normFunc = t.Item4;
+                return BuildRenderedRealCurves(phrase, result);
+            }
+        }
+
+        internal static bool ShouldRefreshRealCurvesOnCurveEdit(string abbr) {
+            return abbr == ENE ||
+                abbr == Format.Ustx.BREC ||
+                abbr == Format.Ustx.VOIC ||
+                abbr == Format.Ustx.TENC;
+        }
+
+        private List<RenderRealCurveResult> BuildRenderedRealCurves(RenderPhrase phrase, VarianceResult result) {
+            var frameMs = result.frameMs;
+            var headFrames = result.headFrames;
+            var tailFrames = result.tailFrames;
+            var startMs = phrase.positionMs - headFrames * frameMs;
+            var realCurves = new (string, float[], float[], Func<float, float>)[] {
+                (
+                    ENE, result.energy ?? Array.Empty<float>(),
+                    phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE)?.Item2
+                    ?? Array.Empty<float>(),
+                    x => Math.Clamp(x, -96f, 0f) / 96f + 1f
+                ),
+                (
+                    Format.Ustx.BREC, result.breathiness ?? Array.Empty<float>(), phrase.breathiness,
+                    x => Math.Clamp(x, -96f, 0f) / 96f + 1f
+                ),
+                (
+                    Format.Ustx.VOIC, result.voicing ?? Array.Empty<float>(), phrase.voicing,
+                    x => Math.Clamp(x, -96f, 0f) / 96f + 1f
+                ),
+                (
+                    Format.Ustx.TENC, result.tension ?? Array.Empty<float>(), phrase.tension,
+                    x => Math.Clamp(x, -10f, 10f) / 20f + 0.5f
+                ),
+            }.Select(t => {
+                var abbr = t.Item1;
+                var realCurve = t.Item2;
+                if (realCurve.Length == 0) {
                     return new RenderRealCurveResult {
                         abbr = abbr,
-                        ticks = Enumerable.Range(0, realCurve.Length)
-                            .Select(i => (float)phrase.timeAxis.MsPosToTickPos(startMs + i * frameMs) - phrase.position)
-                            .ToArray(),
-                        values = realCurve.Zip(deltaCurve, varianceDeltaFunctions[abbr])
-                            .Select(normFunc)
-                            .ToArray()
+                        ticks = Array.Empty<float>(),
+                        values = Array.Empty<float>(),
                     };
-                }).ToList();
-                return realCurves;
-            }
+                }
+                var deltaCurve = DiffSingerUtils.SampleCurve(
+                    phrase, t.Item3, 0, frameMs, realCurve.Length,
+                    headFrames, tailFrames, x => x)
+                    .Select(x => (float)x)
+                    .ToArray();
+                var normFunc = t.Item4;
+                return new RenderRealCurveResult {
+                    abbr = abbr,
+                    ticks = Enumerable.Range(0, realCurve.Length)
+                        .Select(i => (float)phrase.timeAxis.MsPosToTickPos(startMs + i * frameMs) - phrase.position)
+                        .ToArray(),
+                    values = realCurve.Zip(deltaCurve, varianceDeltaFunctions[abbr])
+                        .Select(normFunc)
+                        .ToArray()
+                };
+            }).ToList();
+            return realCurves;
         }
 
         public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -228,11 +228,11 @@ namespace OpenUtau.Core {
                     rangeEndTick = setRange.endTick;
                 } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
-                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
-                    }
-                } else if (cmd is RealCurveCoverageNotification coverageNotif) {
-                    if (coverageNotif.part is UVoicePart coveragePart) {
-                        RealCurveUpdater.TrimToCoverage(Project, coveragePart, coverageNotif.updates);
+                        if (realCurvesNotif.isFullRefresh) {
+                            RealCurveUpdater.ApplyFullRefresh(Project, voicePart, realCurvesNotif.updates);
+                        } else {
+                            RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                        }
                     }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
@@ -288,6 +288,36 @@ namespace OpenUtau.Core {
         void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
             foreach (var cmd in commands) {
                 ScheduleRealCurveRefresh(cmd);
+            }
+        }
+
+        // After undo/redo we cannot rely on per-command ExpCommand routing: note moves,
+        // phoneme edits and part-level mutations all change the rendered baseline, and a
+        // cache-hit re-render skips renderEvents.ReportRealCurves entirely. Schedule a full
+        // refresh for every voice part the undone group touched so the variance baseline is
+        // reloaded (and stale ranges cleared) by the same debounced path the curve-edit hook
+        // uses.
+        void ScheduleFullRealCurveRefresh(IEnumerable<UCommand> commands) {
+            var parts = new HashSet<UVoicePart>();
+            foreach (var cmd in commands) {
+                UVoicePart? part = cmd switch {
+                    ExpCommand ec => ec.Part,
+                    NoteCommand nc => nc.Part,
+                    PartCommand pc => pc.part as UVoicePart,
+                    _ => null
+                };
+                if (part != null) {
+                    parts.Add(part);
+                }
+            }
+            foreach (var part in parts) {
+                if (!Project.parts.Contains(part) ||
+                    part.trackNo < 0 ||
+                    part.trackNo >= Project.tracks.Count) {
+                    continue;
+                }
+                Project.tracks[part.trackNo].RendererSettings.Renderer
+                    ?.ScheduleFullRealCurveRefresh(Project, part);
             }
         }
 
@@ -353,6 +383,7 @@ namespace OpenUtau.Core {
             }
             redoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
+            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -371,6 +402,7 @@ namespace OpenUtau.Core {
             }
             undoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
+            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -228,11 +228,11 @@ namespace OpenUtau.Core {
                     rangeEndTick = setRange.endTick;
                 } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
-                        if (realCurvesNotif.isFullRefresh) {
-                            RealCurveUpdater.ApplyFullRefresh(Project, voicePart, realCurvesNotif.updates);
-                        } else {
-                            RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
-                        }
+                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                    }
+                } else if (cmd is RealCurveCoverageNotification coverageNotif) {
+                    if (coverageNotif.part is UVoicePart coveragePart) {
+                        RealCurveUpdater.TrimToCoverage(Project, coveragePart, coverageNotif.updates);
                     }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
@@ -288,36 +288,6 @@ namespace OpenUtau.Core {
         void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
             foreach (var cmd in commands) {
                 ScheduleRealCurveRefresh(cmd);
-            }
-        }
-
-        // After undo/redo we cannot rely on per-command ExpCommand routing: note moves,
-        // phoneme edits and part-level mutations all change the rendered baseline, and a
-        // cache-hit re-render skips renderEvents.ReportRealCurves entirely. Schedule a full
-        // refresh for every voice part the undone group touched so the variance baseline is
-        // reloaded (and stale ranges cleared) by the same debounced path the curve-edit hook
-        // uses.
-        void ScheduleFullRealCurveRefresh(IEnumerable<UCommand> commands) {
-            var parts = new HashSet<UVoicePart>();
-            foreach (var cmd in commands) {
-                UVoicePart? part = cmd switch {
-                    ExpCommand ec => ec.Part,
-                    NoteCommand nc => nc.Part,
-                    PartCommand pc => pc.part as UVoicePart,
-                    _ => null
-                };
-                if (part != null) {
-                    parts.Add(part);
-                }
-            }
-            foreach (var part in parts) {
-                if (!Project.parts.Contains(part) ||
-                    part.trackNo < 0 ||
-                    part.trackNo >= Project.tracks.Count) {
-                    continue;
-                }
-                Project.tracks[part.trackNo].RendererSettings.Renderer
-                    ?.ScheduleFullRealCurveRefresh(Project, part);
             }
         }
 
@@ -383,7 +353,6 @@ namespace OpenUtau.Core {
             }
             redoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
-            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -402,7 +371,6 @@ namespace OpenUtau.Core {
             }
             undoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
-            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -230,6 +230,10 @@ namespace OpenUtau.Core {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
                         RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
                     }
+                } else if (cmd is RealCurveCoverageNotification coverageNotif) {
+                    if (coverageNotif.part is UVoicePart coveragePart) {
+                        RealCurveUpdater.TrimToCoverage(Project, coveragePart, coverageNotif.ranges);
+                    }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
                 } else if (cmd is ValidateProjectNotification) {
@@ -331,7 +335,9 @@ namespace OpenUtau.Core {
                 }
                 Publish(cmd, true);
             }
+            ScheduleRealCurveRefresh(undoGroup.Commands);
             undoGroup.Commands.Clear();
+            ExecuteCmd(new PreRenderNotification());
         }
 
         public void Undo() {

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -263,6 +263,27 @@ namespace OpenUtau.Core {
             Publish(cmd);
             if (!undoGroup.DeferValidate) {
                 Project.Validate(cmd.ValidateOptions);
+                ScheduleRealCurveRefresh(cmd);
+            }
+        }
+
+        void ScheduleRealCurveRefresh(UCommand cmd) {
+            if (cmd is not ExpCommand expCommand) {
+                return;
+            }
+            var part = expCommand.Part;
+            if (!Project.parts.Contains(part) ||
+                part.trackNo < 0 ||
+                part.trackNo >= Project.tracks.Count) {
+                return;
+            }
+            Project.tracks[part.trackNo].RendererSettings.Renderer
+                ?.ScheduleRealCurveRefresh(Project, part, cmd);
+        }
+
+        void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
+            foreach (var cmd in commands) {
+                ScheduleRealCurveRefresh(cmd);
             }
         }
 
@@ -291,6 +312,7 @@ namespace OpenUtau.Core {
                 Project.ValidateFull();
             }
             undoGroup.Merge();
+            ScheduleRealCurveRefresh(undoGroup.Commands);
             undoGroup = null;
             Log.Information("undoGroup ended");
             ExecuteCmd(new PreRenderNotification());
@@ -326,6 +348,7 @@ namespace OpenUtau.Core {
                 Publish(cmd, true);
             }
             redoQueue.AddToBack(group);
+            ScheduleRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -343,6 +366,7 @@ namespace OpenUtau.Core {
                 Publish(cmd);
             }
             undoQueue.AddToBack(group);
+            ScheduleRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -10,6 +10,7 @@ using OpenUtau.Api;
 using OpenUtau.Classic;
 using OpenUtau.Core.Editing;
 using OpenUtau.Core.Lib;
+using OpenUtau.Core.Render;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
 using Serilog;
@@ -222,9 +223,13 @@ namespace OpenUtau.Core {
                     rangeEndTick = 0;
                 } else if (cmd is SetPlayPosTickNotification setPlayPosTickNotif) {
                     playPosTick = setPlayPosTickNotif.playPosTick;
-                } else if (cmd is SetRangeSelectionNotification setRange) {
+} else if (cmd is SetRangeSelectionNotification setRange) {
                     rangeStartTick = setRange.startTick;
                     rangeEndTick = setRange.endTick;
+                } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
+                    if (realCurvesNotif.part is UVoicePart voicePart) {
+                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                    }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
                 } else if (cmd is ValidateProjectNotification) {

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -228,7 +228,11 @@ namespace OpenUtau.Core {
                     rangeEndTick = setRange.endTick;
                 } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
-                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                        if (realCurvesNotif.isFullRefresh) {
+                            RealCurveUpdater.ApplyFullRefresh(Project, voicePart, realCurvesNotif.updates);
+                        } else {
+                            RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                        }
                     }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
@@ -284,6 +288,36 @@ namespace OpenUtau.Core {
         void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
             foreach (var cmd in commands) {
                 ScheduleRealCurveRefresh(cmd);
+            }
+        }
+
+        // After undo/redo we cannot rely on per-command ExpCommand routing: note moves,
+        // phoneme edits and part-level mutations all change the rendered baseline, and a
+        // cache-hit re-render skips renderEvents.ReportRealCurves entirely. Schedule a full
+        // refresh for every voice part the undone group touched so the variance baseline is
+        // reloaded (and stale ranges cleared) by the same debounced path the curve-edit hook
+        // uses.
+        void ScheduleFullRealCurveRefresh(IEnumerable<UCommand> commands) {
+            var parts = new HashSet<UVoicePart>();
+            foreach (var cmd in commands) {
+                UVoicePart? part = cmd switch {
+                    ExpCommand ec => ec.Part,
+                    NoteCommand nc => nc.Part,
+                    PartCommand pc => pc.part as UVoicePart,
+                    _ => null
+                };
+                if (part != null) {
+                    parts.Add(part);
+                }
+            }
+            foreach (var part in parts) {
+                if (!Project.parts.Contains(part) ||
+                    part.trackNo < 0 ||
+                    part.trackNo >= Project.tracks.Count) {
+                    continue;
+                }
+                Project.tracks[part.trackNo].RendererSettings.Renderer
+                    ?.ScheduleFullRealCurveRefresh(Project, part);
             }
         }
 
@@ -349,6 +383,7 @@ namespace OpenUtau.Core {
             }
             redoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
+            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -367,6 +402,7 @@ namespace OpenUtau.Core {
             }
             undoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
+            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -228,11 +228,7 @@ namespace OpenUtau.Core {
                     rangeEndTick = setRange.endTick;
                 } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
-                        if (realCurvesNotif.isFullRefresh) {
-                            RealCurveUpdater.ApplyFullRefresh(Project, voicePart, realCurvesNotif.updates);
-                        } else {
-                            RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
-                        }
+                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
                     }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
@@ -288,36 +284,6 @@ namespace OpenUtau.Core {
         void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
             foreach (var cmd in commands) {
                 ScheduleRealCurveRefresh(cmd);
-            }
-        }
-
-        // After undo/redo we cannot rely on per-command ExpCommand routing: note moves,
-        // phoneme edits and part-level mutations all change the rendered baseline, and a
-        // cache-hit re-render skips renderEvents.ReportRealCurves entirely. Schedule a full
-        // refresh for every voice part the undone group touched so the variance baseline is
-        // reloaded (and stale ranges cleared) by the same debounced path the curve-edit hook
-        // uses.
-        void ScheduleFullRealCurveRefresh(IEnumerable<UCommand> commands) {
-            var parts = new HashSet<UVoicePart>();
-            foreach (var cmd in commands) {
-                UVoicePart? part = cmd switch {
-                    ExpCommand ec => ec.Part,
-                    NoteCommand nc => nc.Part,
-                    PartCommand pc => pc.part as UVoicePart,
-                    _ => null
-                };
-                if (part != null) {
-                    parts.Add(part);
-                }
-            }
-            foreach (var part in parts) {
-                if (!Project.parts.Contains(part) ||
-                    part.trackNo < 0 ||
-                    part.trackNo >= Project.tracks.Count) {
-                    continue;
-                }
-                Project.tracks[part.trackNo].RendererSettings.Renderer
-                    ?.ScheduleFullRealCurveRefresh(Project, part);
             }
         }
 
@@ -383,7 +349,6 @@ namespace OpenUtau.Core {
             }
             redoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
-            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -402,7 +367,6 @@ namespace OpenUtau.Core {
             }
             undoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
-            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -238,11 +238,11 @@ namespace OpenUtau.Core {
                     rangeEndTick = setRange.endTick;
                 } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
-                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
-                    }
-                } else if (cmd is RealCurveCoverageNotification coverageNotif) {
-                    if (coverageNotif.part is UVoicePart coveragePart) {
-                        RealCurveUpdater.TrimToCoverage(Project, coveragePart, coverageNotif.updates);
+                        if (realCurvesNotif.isFullRefresh) {
+                            RealCurveUpdater.ApplyFullRefresh(Project, voicePart, realCurvesNotif.updates);
+                        } else {
+                            RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                        }
                     }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
@@ -298,6 +298,36 @@ namespace OpenUtau.Core {
         void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
             foreach (var cmd in commands) {
                 ScheduleRealCurveRefresh(cmd);
+            }
+        }
+
+        // After undo/redo we cannot rely on per-command ExpCommand routing: note moves,
+        // phoneme edits and part-level mutations all change the rendered baseline, and a
+        // cache-hit re-render skips renderEvents.ReportRealCurves entirely. Schedule a full
+        // refresh for every voice part the undone group touched so the variance baseline is
+        // reloaded (and stale ranges cleared) by the same debounced path the curve-edit hook
+        // uses.
+        void ScheduleFullRealCurveRefresh(IEnumerable<UCommand> commands) {
+            var parts = new HashSet<UVoicePart>();
+            foreach (var cmd in commands) {
+                UVoicePart? part = cmd switch {
+                    ExpCommand ec => ec.Part,
+                    NoteCommand nc => nc.Part,
+                    PartCommand pc => pc.part as UVoicePart,
+                    _ => null
+                };
+                if (part != null) {
+                    parts.Add(part);
+                }
+            }
+            foreach (var part in parts) {
+                if (!Project.parts.Contains(part) ||
+                    part.trackNo < 0 ||
+                    part.trackNo >= Project.tracks.Count) {
+                    continue;
+                }
+                Project.tracks[part.trackNo].RendererSettings.Renderer
+                    ?.ScheduleFullRealCurveRefresh(Project, part);
             }
         }
 
@@ -363,6 +393,7 @@ namespace OpenUtau.Core {
             }
             redoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
+            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -381,6 +412,7 @@ namespace OpenUtau.Core {
             }
             undoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
+            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -238,11 +238,11 @@ namespace OpenUtau.Core {
                     rangeEndTick = setRange.endTick;
                 } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
-                        if (realCurvesNotif.isFullRefresh) {
-                            RealCurveUpdater.ApplyFullRefresh(Project, voicePart, realCurvesNotif.updates);
-                        } else {
-                            RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
-                        }
+                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                    }
+                } else if (cmd is RealCurveCoverageNotification coverageNotif) {
+                    if (coverageNotif.part is UVoicePart coveragePart) {
+                        RealCurveUpdater.TrimToCoverage(Project, coveragePart, coverageNotif.updates);
                     }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
@@ -298,36 +298,6 @@ namespace OpenUtau.Core {
         void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
             foreach (var cmd in commands) {
                 ScheduleRealCurveRefresh(cmd);
-            }
-        }
-
-        // After undo/redo we cannot rely on per-command ExpCommand routing: note moves,
-        // phoneme edits and part-level mutations all change the rendered baseline, and a
-        // cache-hit re-render skips renderEvents.ReportRealCurves entirely. Schedule a full
-        // refresh for every voice part the undone group touched so the variance baseline is
-        // reloaded (and stale ranges cleared) by the same debounced path the curve-edit hook
-        // uses.
-        void ScheduleFullRealCurveRefresh(IEnumerable<UCommand> commands) {
-            var parts = new HashSet<UVoicePart>();
-            foreach (var cmd in commands) {
-                UVoicePart? part = cmd switch {
-                    ExpCommand ec => ec.Part,
-                    NoteCommand nc => nc.Part,
-                    PartCommand pc => pc.part as UVoicePart,
-                    _ => null
-                };
-                if (part != null) {
-                    parts.Add(part);
-                }
-            }
-            foreach (var part in parts) {
-                if (!Project.parts.Contains(part) ||
-                    part.trackNo < 0 ||
-                    part.trackNo >= Project.tracks.Count) {
-                    continue;
-                }
-                Project.tracks[part.trackNo].RendererSettings.Renderer
-                    ?.ScheduleFullRealCurveRefresh(Project, part);
             }
         }
 
@@ -393,7 +363,6 @@ namespace OpenUtau.Core {
             }
             redoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
-            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -412,7 +381,6 @@ namespace OpenUtau.Core {
             }
             undoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
-            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -238,11 +238,7 @@ namespace OpenUtau.Core {
                     rangeEndTick = setRange.endTick;
                 } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
-                        if (realCurvesNotif.isFullRefresh) {
-                            RealCurveUpdater.ApplyFullRefresh(Project, voicePart, realCurvesNotif.updates);
-                        } else {
-                            RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
-                        }
+                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
                     }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
@@ -298,36 +294,6 @@ namespace OpenUtau.Core {
         void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
             foreach (var cmd in commands) {
                 ScheduleRealCurveRefresh(cmd);
-            }
-        }
-
-        // After undo/redo we cannot rely on per-command ExpCommand routing: note moves,
-        // phoneme edits and part-level mutations all change the rendered baseline, and a
-        // cache-hit re-render skips renderEvents.ReportRealCurves entirely. Schedule a full
-        // refresh for every voice part the undone group touched so the variance baseline is
-        // reloaded (and stale ranges cleared) by the same debounced path the curve-edit hook
-        // uses.
-        void ScheduleFullRealCurveRefresh(IEnumerable<UCommand> commands) {
-            var parts = new HashSet<UVoicePart>();
-            foreach (var cmd in commands) {
-                UVoicePart? part = cmd switch {
-                    ExpCommand ec => ec.Part,
-                    NoteCommand nc => nc.Part,
-                    PartCommand pc => pc.part as UVoicePart,
-                    _ => null
-                };
-                if (part != null) {
-                    parts.Add(part);
-                }
-            }
-            foreach (var part in parts) {
-                if (!Project.parts.Contains(part) ||
-                    part.trackNo < 0 ||
-                    part.trackNo >= Project.tracks.Count) {
-                    continue;
-                }
-                Project.tracks[part.trackNo].RendererSettings.Renderer
-                    ?.ScheduleFullRealCurveRefresh(Project, part);
             }
         }
 
@@ -393,7 +359,6 @@ namespace OpenUtau.Core {
             }
             redoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
-            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -412,7 +377,6 @@ namespace OpenUtau.Core {
             }
             undoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
-            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -240,6 +240,10 @@ namespace OpenUtau.Core {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
                         RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
                     }
+                } else if (cmd is RealCurveCoverageNotification coverageNotif) {
+                    if (coverageNotif.part is UVoicePart coveragePart) {
+                        RealCurveUpdater.TrimToCoverage(Project, coveragePart, coverageNotif.ranges);
+                    }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
                 } else if (cmd is ValidateProjectNotification) {
@@ -341,7 +345,9 @@ namespace OpenUtau.Core {
                 }
                 Publish(cmd, true);
             }
+            ScheduleRealCurveRefresh(undoGroup.Commands);
             undoGroup.Commands.Clear();
+            ExecuteCmd(new PreRenderNotification());
         }
 
         public void Undo() {

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -10,6 +10,7 @@ using OpenUtau.Api;
 using OpenUtau.Classic;
 using OpenUtau.Core.Editing;
 using OpenUtau.Core.Lib;
+using OpenUtau.Core.Render;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
 using Serilog;
@@ -232,9 +233,13 @@ namespace OpenUtau.Core {
                     rangeEndTick = 0;
                 } else if (cmd is SetPlayPosTickNotification setPlayPosTickNotif) {
                     playPosTick = setPlayPosTickNotif.playPosTick;
-                } else if (cmd is SetRangeSelectionNotification setRange) {
+} else if (cmd is SetRangeSelectionNotification setRange) {
                     rangeStartTick = setRange.startTick;
                     rangeEndTick = setRange.endTick;
+                } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
+                    if (realCurvesNotif.part is UVoicePart voicePart) {
+                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                    }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
                 } else if (cmd is ValidateProjectNotification) {

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -238,7 +238,11 @@ namespace OpenUtau.Core {
                     rangeEndTick = setRange.endTick;
                 } else if (cmd is RealCurvesUpdatedNotification realCurvesNotif) {
                     if (realCurvesNotif.part is UVoicePart voicePart) {
-                        RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                        if (realCurvesNotif.isFullRefresh) {
+                            RealCurveUpdater.ApplyFullRefresh(Project, voicePart, realCurvesNotif.updates);
+                        } else {
+                            RealCurveUpdater.Apply(Project, voicePart, realCurvesNotif.updates);
+                        }
                     }
                 } else if (cmd is SingersChangedNotification) {
                     SingerManager.Inst.SearchAllSingers();
@@ -294,6 +298,36 @@ namespace OpenUtau.Core {
         void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
             foreach (var cmd in commands) {
                 ScheduleRealCurveRefresh(cmd);
+            }
+        }
+
+        // After undo/redo we cannot rely on per-command ExpCommand routing: note moves,
+        // phoneme edits and part-level mutations all change the rendered baseline, and a
+        // cache-hit re-render skips renderEvents.ReportRealCurves entirely. Schedule a full
+        // refresh for every voice part the undone group touched so the variance baseline is
+        // reloaded (and stale ranges cleared) by the same debounced path the curve-edit hook
+        // uses.
+        void ScheduleFullRealCurveRefresh(IEnumerable<UCommand> commands) {
+            var parts = new HashSet<UVoicePart>();
+            foreach (var cmd in commands) {
+                UVoicePart? part = cmd switch {
+                    ExpCommand ec => ec.Part,
+                    NoteCommand nc => nc.Part,
+                    PartCommand pc => pc.part as UVoicePart,
+                    _ => null
+                };
+                if (part != null) {
+                    parts.Add(part);
+                }
+            }
+            foreach (var part in parts) {
+                if (!Project.parts.Contains(part) ||
+                    part.trackNo < 0 ||
+                    part.trackNo >= Project.tracks.Count) {
+                    continue;
+                }
+                Project.tracks[part.trackNo].RendererSettings.Renderer
+                    ?.ScheduleFullRealCurveRefresh(Project, part);
             }
         }
 
@@ -359,6 +393,7 @@ namespace OpenUtau.Core {
             }
             redoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
+            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -377,6 +412,7 @@ namespace OpenUtau.Core {
             }
             undoQueue.AddToBack(group);
             ScheduleRealCurveRefresh(group.Commands);
+            ScheduleFullRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -273,6 +273,27 @@ namespace OpenUtau.Core {
             Publish(cmd);
             if (!undoGroup.DeferValidate) {
                 Project.Validate(cmd.ValidateOptions);
+                ScheduleRealCurveRefresh(cmd);
+            }
+        }
+
+        void ScheduleRealCurveRefresh(UCommand cmd) {
+            if (cmd is not ExpCommand expCommand) {
+                return;
+            }
+            var part = expCommand.Part;
+            if (!Project.parts.Contains(part) ||
+                part.trackNo < 0 ||
+                part.trackNo >= Project.tracks.Count) {
+                return;
+            }
+            Project.tracks[part.trackNo].RendererSettings.Renderer
+                ?.ScheduleRealCurveRefresh(Project, part, cmd);
+        }
+
+        void ScheduleRealCurveRefresh(IEnumerable<UCommand> commands) {
+            foreach (var cmd in commands) {
+                ScheduleRealCurveRefresh(cmd);
             }
         }
 
@@ -301,6 +322,7 @@ namespace OpenUtau.Core {
                 Project.ValidateFull();
             }
             undoGroup.Merge();
+            ScheduleRealCurveRefresh(undoGroup.Commands);
             undoGroup = null;
             Log.Information("undoGroup ended");
             ExecuteCmd(new PreRenderNotification());
@@ -336,6 +358,7 @@ namespace OpenUtau.Core {
                 Publish(cmd, true);
             }
             redoQueue.AddToBack(group);
+            ScheduleRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 
@@ -353,6 +376,7 @@ namespace OpenUtau.Core {
                 Publish(cmd);
             }
             undoQueue.AddToBack(group);
+            ScheduleRealCurveRefresh(group.Commands);
             ExecuteCmd(new PreRenderNotification());
         }
 

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -826,17 +826,17 @@ namespace OpenUtau.Core.Editing {
                 finished += 1;
                 setProgressCallback(finished, part.renderPhrases.Count);
             }
-            var commands = curveDict
-                .Select(kv => new MergedSetCurveCommand(
-                    project, part, kv.Key,
-                    kv.Value?.realXs.ToArray() ?? Array.Empty<int>(),
-                    kv.Value?.realYs.ToArray() ?? Array.Empty<int>(),
-                    newXsDict[kv.Key].ToArray(),
-                    newYsDict[kv.Key].ToArray(),
-                    true))
-                .ToList();
 
             DocManager.Inst.PostOnUIThread(() => {
+                var commands = curveDict
+                    .Select(kv => new MergedSetCurveCommand(
+                        project, part, kv.Key,
+                        kv.Value?.realXs.ToArray() ?? Array.Empty<int>(),
+                        kv.Value?.realYs.ToArray() ?? Array.Empty<int>(),
+                        newXsDict[kv.Key].ToArray(),
+                        newYsDict[kv.Key].ToArray(),
+                        true))
+                    .ToList();
                 docManager.StartUndoGroup("command.batch.note", true);
                 commands.ForEach(docManager.ExecuteCmd);
                 docManager.EndUndoGroup();

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -833,17 +833,17 @@ namespace OpenUtau.Core.Editing {
                 finished += 1;
                 setProgressCallback(finished, part.renderPhrases.Count);
             }
-            var commands = curveDict
-                .Select(kv => new MergedSetCurveCommand(
-                    project, part, kv.Key,
-                    kv.Value?.realXs.ToArray() ?? Array.Empty<int>(),
-                    kv.Value?.realYs.ToArray() ?? Array.Empty<int>(),
-                    newXsDict[kv.Key].ToArray(),
-                    newYsDict[kv.Key].ToArray(),
-                    true))
-                .ToList();
 
             DocManager.Inst.PostOnUIThread(() => {
+                var commands = curveDict
+                    .Select(kv => new MergedSetCurveCommand(
+                        project, part, kv.Key,
+                        kv.Value?.realXs.ToArray() ?? Array.Empty<int>(),
+                        kv.Value?.realYs.ToArray() ?? Array.Empty<int>(),
+                        newXsDict[kv.Key].ToArray(),
+                        newYsDict[kv.Key].ToArray(),
+                        true))
+                    .ToList();
                 docManager.StartUndoGroup("command.batch.note", true);
                 commands.ForEach(docManager.ExecuteCmd);
                 docManager.EndUndoGroup();

--- a/OpenUtau.Core/Enunu/EnunuRenderer.cs
+++ b/OpenUtau.Core/Enunu/EnunuRenderer.cs
@@ -73,7 +73,7 @@ namespace OpenUtau.Core.Enunu {
             };
         }
 
-        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender) {
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender, RenderPhraseEvents? renderEvents = null) {
             var task = Task.Run(() => {
                 lock (lockObj) {
                     if (cancellation.IsCancellationRequested) {

--- a/OpenUtau.Core/Properties/AssemblyInfo.cs
+++ b/OpenUtau.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpenUtau.Test")]

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -87,6 +87,7 @@ namespace OpenUtau.Core.Render {
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase);
         List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) { return new List<RenderRealCurveResult>(0);}
         void ScheduleRealCurveRefresh(UProject project, UVoicePart part, UCommand command) { }
+        void ScheduleFullRealCurveRefresh(UProject project, UVoicePart part) { }
         UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings);
     }
 }

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -87,7 +87,6 @@ namespace OpenUtau.Core.Render {
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase);
         List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) { return new List<RenderRealCurveResult>(0);}
         void ScheduleRealCurveRefresh(UProject project, UVoicePart part, UCommand command) { }
-        void ScheduleFullRealCurveRefresh(UProject project, UVoicePart part) { }
         UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings);
     }
 }

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core.Render {
@@ -59,6 +60,20 @@ namespace OpenUtau.Core.Render {
         public float[] values;
     }
 
+    public class RenderPhraseEvents {
+        readonly Action<IReadOnlyList<RenderRealCurveResult>>? realCurvesCallback;
+
+        public RenderPhraseEvents(Action<IReadOnlyList<RenderRealCurveResult>>? realCurvesCallback = null) {
+            this.realCurvesCallback = realCurvesCallback;
+        }
+
+        public void ReportRealCurves(IReadOnlyList<RenderRealCurveResult> realCurves) {
+            if (realCurves.Count > 0) {
+                realCurvesCallback?.Invoke(realCurves);
+            }
+        }
+    }
+
     /// <summary>
     /// Interface of phrase-based renderer.
     /// </summary>
@@ -68,9 +83,10 @@ namespace OpenUtau.Core.Render {
         bool SupportsRealCurve { get { return false; } }
         bool SupportsExpression(UExpressionDescriptor descriptor);
         RenderResult Layout(RenderPhrase phrase);
-        Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender = false);
+        Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender = false, RenderPhraseEvents? renderEvents = null);
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase);
         List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) { return new List<RenderRealCurveResult>(0);}
+        void ScheduleRealCurveRefresh(UProject project, UVoicePart part, UCommand command) { }
         UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings);
     }
 }

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -96,6 +96,7 @@ namespace OpenUtau.Core.Render {
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase, HashSet<int> selectedNotePositions) { return LoadRenderedPitch(phrase); }
         List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) { return new List<RenderRealCurveResult>(0);}
         void ScheduleRealCurveRefresh(UProject project, UVoicePart part, UCommand command) { }
+        void ScheduleFullRealCurveRefresh(UProject project, UVoicePart part) { }
         UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings);
     }
 }

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core.Render {
@@ -67,6 +68,20 @@ namespace OpenUtau.Core.Render {
         public float[] values;
     }
 
+    public class RenderPhraseEvents {
+        readonly Action<IReadOnlyList<RenderRealCurveResult>>? realCurvesCallback;
+
+        public RenderPhraseEvents(Action<IReadOnlyList<RenderRealCurveResult>>? realCurvesCallback = null) {
+            this.realCurvesCallback = realCurvesCallback;
+        }
+
+        public void ReportRealCurves(IReadOnlyList<RenderRealCurveResult> realCurves) {
+            if (realCurves.Count > 0) {
+                realCurvesCallback?.Invoke(realCurves);
+            }
+        }
+    }
+
     /// <summary>
     /// Interface of phrase-based renderer.
     /// </summary>
@@ -76,10 +91,11 @@ namespace OpenUtau.Core.Render {
         bool SupportsRealCurve { get { return false; } }
         bool SupportsExpression(UExpressionDescriptor descriptor);
         RenderResult Layout(RenderPhrase phrase);
-        Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender = false);
+        Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender = false, RenderPhraseEvents? renderEvents = null);
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase);
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase, HashSet<int> selectedNotePositions) { return LoadRenderedPitch(phrase); }
         List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) { return new List<RenderRealCurveResult>(0);}
+        void ScheduleRealCurveRefresh(UProject project, UVoicePart part, UCommand command) { }
         UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings);
     }
 }

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -96,7 +96,6 @@ namespace OpenUtau.Core.Render {
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase, HashSet<int> selectedNotePositions) { return LoadRenderedPitch(phrase); }
         List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) { return new List<RenderRealCurveResult>(0);}
         void ScheduleRealCurveRefresh(UProject project, UVoicePart part, UCommand command) { }
-        void ScheduleFullRealCurveRefresh(UProject project, UVoicePart part) { }
         UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings);
     }
 }

--- a/OpenUtau.Core/Render/RealCurveUpdater.cs
+++ b/OpenUtau.Core/Render/RealCurveUpdater.cs
@@ -87,6 +87,75 @@ namespace OpenUtau.Core.Render {
             return Apply(project, part, updates, phraseHashes);
         }
 
+        // Removes realXs/realYs points outside the union of `ranges` (the tick spans the renderer
+        // actually produced this pass). Clears ghost real curves left behind when a phrase shrinks,
+        // moves, splits, or is deleted. realXs is kept sorted, so a single two-pointer walk decides
+        // each point; a new list is allocated only when a stale point is found (clean case is free).
+        public static bool TrimToCoverage(
+            UProject project, UVoicePart part, IReadOnlyList<(int start, int end)> ranges) {
+            if (!project.parts.Contains(part) || ranges.Count == 0) {
+                return false;
+            }
+            var merged = MergeRanges(ranges);
+            bool changed = false;
+            foreach (var curve in part.curves) {
+                if (TrimCurve(curve, merged)) {
+                    changed = true;
+                }
+            }
+            return changed;
+        }
+
+        static bool TrimCurve(UCurve curve, List<(int start, int end)> merged) {
+            var xs = curve.realXs;
+            var ys = curve.realYs;
+            if (xs.Count == 0) {
+                return false;
+            }
+            List<int>? newXs = null;
+            List<int>? newYs = null;
+            int ri = 0;
+            for (int i = 0; i < xs.Count; ++i) {
+                int x = xs[i];
+                while (ri < merged.Count && merged[ri].end < x) {
+                    ri++;
+                }
+                bool keep = ri < merged.Count && x >= merged[ri].start;
+                if (keep) {
+                    newXs?.Add(x);
+                    newYs?.Add(ys[i]);
+                } else if (newXs == null) {
+                    newXs = new List<int>(xs.Count);
+                    newYs = new List<int>(ys.Count);
+                    for (int j = 0; j < i; ++j) {
+                        newXs.Add(xs[j]);
+                        newYs.Add(ys[j]);
+                    }
+                }
+            }
+            if (newXs == null) {
+                return false;
+            }
+            curve.realXs = newXs;
+            curve.realYs = newYs;
+            return true;
+        }
+
+        internal static List<(int start, int end)> MergeRanges(IReadOnlyList<(int start, int end)> ranges) {
+            var sorted = ranges.ToList();
+            sorted.Sort((a, b) => a.start.CompareTo(b.start));
+            var merged = new List<(int start, int end)> { sorted[0] };
+            for (int i = 1; i < sorted.Count; ++i) {
+                var last = merged[merged.Count - 1];
+                if (sorted[i].start <= last.end) {
+                    merged[merged.Count - 1] = (last.start, Math.Max(last.end, sorted[i].end));
+                } else {
+                    merged.Add(sorted[i]);
+                }
+            }
+            return merged;
+        }
+
         internal static bool Apply(
             UProject project,
             UVoicePart part,

--- a/OpenUtau.Core/Render/RealCurveUpdater.cs
+++ b/OpenUtau.Core/Render/RealCurveUpdater.cs
@@ -87,25 +87,68 @@ namespace OpenUtau.Core.Render {
             return Apply(project, part, updates, phraseHashes);
         }
 
-        // Used by undo/redo: wipe every existing real curve in the part, then apply whatever
-        // baseline came back from the renderer. The wipe guarantees stale ranges (from a render
-        // whose phrase end was past the restored end) don't survive as ghost segments.
-        public static bool ApplyFullRefresh(UProject project, UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
-            if (!project.parts.Contains(part)) {
+        // Posted once per part after every phrase has reported its real-curve data. For each abbr
+        // that has at least one update, removes realXs entries that fall outside the union of the
+        // updates' [startTick, endTick] ranges. This clears stale tail data left over from an
+        // earlier render whose phrase ranges were wider than the current ones (e.g., after undo
+        // shrinks a phrase). Abbrs without updates are untouched.
+        public static bool TrimToCoverage(UProject project, UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
+            if (!project.parts.Contains(part) || updates.Count == 0) {
                 return false;
+            }
+            var ranges = new Dictionary<string, List<(int start, int end)>>();
+            foreach (var update in updates) {
+                if (!update.IsValid) {
+                    continue;
+                }
+                if (!ranges.TryGetValue(update.abbr, out var list)) {
+                    list = new List<(int, int)>();
+                    ranges[update.abbr] = list;
+                }
+                list.Add((update.startTick, update.endTick));
             }
             bool changed = false;
             foreach (var curve in part.curves) {
-                if (curve.realXs.Count > 0 || curve.realYs.Count > 0) {
-                    curve.realXs.Clear();
-                    curve.realYs.Clear();
-                    changed = true;
+                if (!ranges.TryGetValue(curve.abbr, out var list) || list.Count == 0) {
+                    continue;
+                }
+                var merged = MergeRanges(list);
+                for (int i = curve.realXs.Count - 1; i >= 0; --i) {
+                    if (!InAnyRange(merged, curve.realXs[i])) {
+                        curve.realXs.RemoveAt(i);
+                        curve.realYs.RemoveAt(i);
+                        changed = true;
+                    }
                 }
             }
-            if (updates.Count > 0) {
-                changed |= Apply(project, part, updates);
-            }
             return changed;
+        }
+
+        internal static List<(int start, int end)> MergeRanges(List<(int start, int end)> ranges) {
+            if (ranges.Count <= 1) {
+                return ranges;
+            }
+            ranges.Sort((a, b) => a.start.CompareTo(b.start));
+            var merged = new List<(int start, int end)> { ranges[0] };
+            for (int i = 1; i < ranges.Count; ++i) {
+                var (curStart, curEnd) = merged[merged.Count - 1];
+                var (nextStart, nextEnd) = ranges[i];
+                if (nextStart <= curEnd) {
+                    merged[merged.Count - 1] = (curStart, Math.Max(curEnd, nextEnd));
+                } else {
+                    merged.Add((nextStart, nextEnd));
+                }
+            }
+            return merged;
+        }
+
+        static bool InAnyRange(List<(int start, int end)> ranges, int x) {
+            foreach (var (start, end) in ranges) {
+                if (x >= start && x <= end) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         internal static bool Apply(

--- a/OpenUtau.Core/Render/RealCurveUpdater.cs
+++ b/OpenUtau.Core/Render/RealCurveUpdater.cs
@@ -87,6 +87,27 @@ namespace OpenUtau.Core.Render {
             return Apply(project, part, updates, phraseHashes);
         }
 
+        // Used by undo/redo: wipe every existing real curve in the part, then apply whatever
+        // baseline came back from the renderer. The wipe guarantees stale ranges (from a render
+        // whose phrase end was past the restored end) don't survive as ghost segments.
+        public static bool ApplyFullRefresh(UProject project, UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
+            if (!project.parts.Contains(part)) {
+                return false;
+            }
+            bool changed = false;
+            foreach (var curve in part.curves) {
+                if (curve.realXs.Count > 0 || curve.realYs.Count > 0) {
+                    curve.realXs.Clear();
+                    curve.realYs.Clear();
+                    changed = true;
+                }
+            }
+            if (updates.Count > 0) {
+                changed |= Apply(project, part, updates);
+            }
+            return changed;
+        }
+
         internal static bool Apply(
             UProject project,
             UVoicePart part,

--- a/OpenUtau.Core/Render/RealCurveUpdater.cs
+++ b/OpenUtau.Core/Render/RealCurveUpdater.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenUtau.Core.Ustx;
+
+namespace OpenUtau.Core.Render {
+    public readonly struct RealCurveUpdate {
+        public readonly string abbr;
+        public readonly ulong phraseHash;
+        public readonly int startTick;
+        public readonly int endTick;
+        public readonly int[] xs;
+        public readonly int[] ys;
+
+        public RealCurveUpdate(string abbr, ulong phraseHash, int startTick, int endTick, int[] xs, int[] ys) {
+            this.abbr = abbr;
+            this.phraseHash = phraseHash;
+            this.startTick = startTick;
+            this.endTick = endTick;
+            this.xs = xs;
+            this.ys = ys;
+        }
+
+        public bool IsValid => !string.IsNullOrEmpty(abbr) &&
+            endTick >= startTick && xs.Length == ys.Length && xs.Length > 0;
+    }
+
+    public static class RealCurveUpdater {
+        public static RealCurveUpdate[] LoadPhraseUpdates(UVoicePart part, RenderPhrase phrase) {
+            if (!phrase.renderer.SupportsRealCurve) {
+                return Array.Empty<RealCurveUpdate>();
+            }
+            return BuildUpdates(part, phrase, phrase.renderer.LoadRenderedRealCurves(phrase));
+        }
+
+        internal static RealCurveUpdate[] BuildUpdates(
+            UVoicePart part,
+            RenderPhrase phrase,
+            IEnumerable<RenderRealCurveResult> results) {
+            return BuildUpdates(part.position, phrase.position, phrase.hash, results);
+        }
+
+        internal static RealCurveUpdate[] BuildUpdates(
+            int partPosition,
+            int phrasePosition,
+            ulong phraseHash,
+            IEnumerable<RenderRealCurveResult> results) {
+            var updates = new List<RealCurveUpdate>();
+            foreach (var result in results) {
+                if (string.IsNullOrEmpty(result.abbr) || result.ticks == null || result.values == null) {
+                    continue;
+                }
+                int count = Math.Min(result.ticks.Length, result.values.Length);
+                if (count == 0) {
+                    continue;
+                }
+                var ticks = result.ticks
+                    .Take(count)
+                    .Select(tick => phrasePosition - partPosition + (int)tick)
+                    .ToArray();
+                var values = result.values
+                    .Take(count)
+                    .Select(value => (int)(value * 1000.0))
+                    .ToArray();
+                int startTick = ticks.Min();
+                int endTick = ticks.Max();
+                var xs = new List<int>(count + 1) { ticks[0] };
+                var ys = new List<int>(count + 1) { -1 };
+                xs.AddRange(ticks);
+                ys.AddRange(values);
+                updates.Add(new RealCurveUpdate(
+                    result.abbr,
+                    phraseHash,
+                    startTick,
+                    endTick,
+                    xs.ToArray(),
+                    ys.ToArray()));
+            }
+            return updates.ToArray();
+        }
+
+        public static bool Apply(UProject project, UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
+            if (updates.Count == 0 || !project.parts.Contains(part)) {
+                return false;
+            }
+            var phraseHashes = part.renderPhrases.Select(phrase => phrase.hash).ToHashSet();
+            return Apply(project, part, updates, phraseHashes);
+        }
+
+        internal static bool Apply(
+            UProject project,
+            UVoicePart part,
+            IReadOnlyList<RealCurveUpdate> updates,
+            IReadOnlySet<ulong> phraseHashes) {
+            bool changed = false;
+            foreach (var update in updates) {
+                if (!update.IsValid || !phraseHashes.Contains(update.phraseHash)) {
+                    continue;
+                }
+                changed |= ApplyUpdate(project, part, update);
+            }
+            return changed;
+        }
+
+        private static bool ApplyUpdate(UProject project, UVoicePart part, RealCurveUpdate update) {
+            var curve = part.curves.FirstOrDefault(curve => curve.abbr == update.abbr);
+            if (curve == null) {
+                var track = project.tracks[part.trackNo];
+                if (!track.TryGetExpDescriptor(project, update.abbr, out var descriptor)) {
+                    return false;
+                }
+                curve = new UCurve(descriptor);
+                part.curves.Add(curve);
+            }
+            RemoveRange(curve.realXs, curve.realYs, update.startTick, update.endTick);
+            InsertRange(curve.realXs, curve.realYs, update.xs, update.ys);
+            return true;
+        }
+
+        internal static void RemoveRange(List<int> xs, List<int> ys, int startTick, int endTick) {
+            for (int i = xs.Count - 1; i >= 0; --i) {
+                if (xs[i] >= startTick && xs[i] <= endTick) {
+                    xs.RemoveAt(i);
+                    ys.RemoveAt(i);
+                }
+            }
+        }
+
+        internal static void InsertRange(List<int> targetXs, List<int> targetYs, int[] xs, int[] ys) {
+            if (xs.Length == 0) {
+                return;
+            }
+            int insertIndex = targetXs.BinarySearch(xs[0]);
+            if (insertIndex < 0) {
+                insertIndex = ~insertIndex;
+            } else {
+                while (insertIndex < targetXs.Count && targetXs[insertIndex] <= xs[0]) {
+                    insertIndex++;
+                }
+            }
+            targetXs.InsertRange(insertIndex, xs);
+            targetYs.InsertRange(insertIndex, ys);
+        }
+    }
+}

--- a/OpenUtau.Core/Render/RealCurveUpdater.cs
+++ b/OpenUtau.Core/Render/RealCurveUpdater.cs
@@ -87,27 +87,6 @@ namespace OpenUtau.Core.Render {
             return Apply(project, part, updates, phraseHashes);
         }
 
-        // Used by undo/redo: wipe every existing real curve in the part, then apply whatever
-        // baseline came back from the renderer. The wipe guarantees stale ranges (from a render
-        // whose phrase end was past the restored end) don't survive as ghost segments.
-        public static bool ApplyFullRefresh(UProject project, UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
-            if (!project.parts.Contains(part)) {
-                return false;
-            }
-            bool changed = false;
-            foreach (var curve in part.curves) {
-                if (curve.realXs.Count > 0 || curve.realYs.Count > 0) {
-                    curve.realXs.Clear();
-                    curve.realYs.Clear();
-                    changed = true;
-                }
-            }
-            if (updates.Count > 0) {
-                changed |= Apply(project, part, updates);
-            }
-            return changed;
-        }
-
         internal static bool Apply(
             UProject project,
             UVoicePart part,

--- a/OpenUtau.Core/Render/RealCurveUpdater.cs
+++ b/OpenUtau.Core/Render/RealCurveUpdater.cs
@@ -87,68 +87,25 @@ namespace OpenUtau.Core.Render {
             return Apply(project, part, updates, phraseHashes);
         }
 
-        // Posted once per part after every phrase has reported its real-curve data. For each abbr
-        // that has at least one update, removes realXs entries that fall outside the union of the
-        // updates' [startTick, endTick] ranges. This clears stale tail data left over from an
-        // earlier render whose phrase ranges were wider than the current ones (e.g., after undo
-        // shrinks a phrase). Abbrs without updates are untouched.
-        public static bool TrimToCoverage(UProject project, UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
-            if (!project.parts.Contains(part) || updates.Count == 0) {
+        // Used by undo/redo: wipe every existing real curve in the part, then apply whatever
+        // baseline came back from the renderer. The wipe guarantees stale ranges (from a render
+        // whose phrase end was past the restored end) don't survive as ghost segments.
+        public static bool ApplyFullRefresh(UProject project, UVoicePart part, IReadOnlyList<RealCurveUpdate> updates) {
+            if (!project.parts.Contains(part)) {
                 return false;
-            }
-            var ranges = new Dictionary<string, List<(int start, int end)>>();
-            foreach (var update in updates) {
-                if (!update.IsValid) {
-                    continue;
-                }
-                if (!ranges.TryGetValue(update.abbr, out var list)) {
-                    list = new List<(int, int)>();
-                    ranges[update.abbr] = list;
-                }
-                list.Add((update.startTick, update.endTick));
             }
             bool changed = false;
             foreach (var curve in part.curves) {
-                if (!ranges.TryGetValue(curve.abbr, out var list) || list.Count == 0) {
-                    continue;
+                if (curve.realXs.Count > 0 || curve.realYs.Count > 0) {
+                    curve.realXs.Clear();
+                    curve.realYs.Clear();
+                    changed = true;
                 }
-                var merged = MergeRanges(list);
-                for (int i = curve.realXs.Count - 1; i >= 0; --i) {
-                    if (!InAnyRange(merged, curve.realXs[i])) {
-                        curve.realXs.RemoveAt(i);
-                        curve.realYs.RemoveAt(i);
-                        changed = true;
-                    }
-                }
+            }
+            if (updates.Count > 0) {
+                changed |= Apply(project, part, updates);
             }
             return changed;
-        }
-
-        internal static List<(int start, int end)> MergeRanges(List<(int start, int end)> ranges) {
-            if (ranges.Count <= 1) {
-                return ranges;
-            }
-            ranges.Sort((a, b) => a.start.CompareTo(b.start));
-            var merged = new List<(int start, int end)> { ranges[0] };
-            for (int i = 1; i < ranges.Count; ++i) {
-                var (curStart, curEnd) = merged[merged.Count - 1];
-                var (nextStart, nextEnd) = ranges[i];
-                if (nextStart <= curEnd) {
-                    merged[merged.Count - 1] = (curStart, Math.Max(curEnd, nextEnd));
-                } else {
-                    merged.Add((nextStart, nextEnd));
-                }
-            }
-            return merged;
-        }
-
-        static bool InAnyRange(List<(int start, int end)> ranges, int x) {
-            foreach (var (start, end) in ranges) {
-                if (x >= start && x <= end) {
-                    return true;
-                }
-            }
-            return false;
         }
 
         internal static bool Apply(

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -249,14 +249,20 @@ namespace OpenUtau.Core.Render {
                 tuples = orderedTuples;
             }
             var progress = new Progress(tuples.Sum(t => t.Item1.phones.Length));
+            // Only full-project passes (pre-render / export) maintain the real-curve coverage
+            // invariant. Partial playback passes must not trim curves outside their tick window.
+            bool maintainCoverage = startTick == 0 && endTick == -1;
+            var coverageRanges = maintainCoverage
+                ? new Dictionary<UVoicePart, List<(int start, int end)>>()
+                : null;
             foreach (var tuple in tuples) {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
-                bool realCurvesPublished = false;
+                RealCurveUpdate[]? publishedUpdates = null;
                 var renderEvents = phrase.renderer.SupportsRealCurve
                     ? new RenderPhraseEvents(realCurves => {
-                        realCurvesPublished = PublishRealCurveUpdates(request.part, phrase, realCurves);
+                        publishedUpdates = PublishRealCurveUpdates(request.part, phrase, realCurves);
                     })
                     : null;
                 var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true, renderEvents);
@@ -266,51 +272,74 @@ namespace OpenUtau.Core.Render {
                 }
                 var result = task.Result;
                 source.SetSamples(result.samples);
-                DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
-                if (!realCurvesPublished) {
-                    PublishRealCurveUpdates(request.part, phrase);
+                if (publishedUpdates == null) {
+                    publishedUpdates = PublishRealCurveUpdates(request.part, phrase);
+                }
+                if (coverageRanges != null && publishedUpdates != null) {
+                    AccumulateCoverage(coverageRanges, request.part, publishedUpdates);
                 }
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
+                    if (coverageRanges != null &&
+                        phrase.renderer.SupportsRealCurve &&
+                        coverageRanges.TryGetValue(request.part, out var ranges) &&
+                        ranges.Count > 0) {
+                        DocManager.Inst.ExecuteCmd(new RealCurveCoverageNotification(request.part, ranges));
+                    }
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
                 }
             }
             progress.Clear();
         }
 
-        private bool PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+        private RealCurveUpdate[]? PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
             if (!phrase.renderer.SupportsRealCurve) {
-                return false;
+                return null;
             }
             try {
                 var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return true;
+                    return updates;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh rendered real curves.");
             }
-            return false;
+            return null;
         }
 
-        private bool PublishRealCurveUpdates(
+        private RealCurveUpdate[]? PublishRealCurveUpdates(
             UVoicePart part,
             RenderPhrase phrase,
             IReadOnlyList<RenderRealCurveResult> realCurves) {
             if (realCurves.Count == 0) {
-                return false;
+                return null;
             }
             try {
                 var updates = RealCurveUpdater.BuildUpdates(part, phrase, realCurves);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return true;
+                    return updates;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to publish rendered real curves.");
             }
-            return false;
+            return null;
+        }
+
+        private static void AccumulateCoverage(
+            Dictionary<UVoicePart, List<(int start, int end)>> coverage,
+            UVoicePart part,
+            RealCurveUpdate[] updates) {
+            if (!coverage.TryGetValue(part, out var ranges)) {
+                ranges = new List<(int start, int end)>();
+                coverage[part] = ranges;
+            }
+            foreach (var update in updates) {
+                if (update.IsValid) {
+                    ranges.Add((update.startTick, update.endTick));
+                }
+            }
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -253,7 +253,13 @@ namespace OpenUtau.Core.Render {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
-                var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true);
+                bool realCurvesPublished = false;
+                var renderEvents = phrase.renderer.SupportsRealCurve
+                    ? new RenderPhraseEvents(realCurves => {
+                        realCurvesPublished = PublishRealCurveUpdates(request.part, phrase, realCurves);
+                    })
+                    : null;
+                var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true, renderEvents);
                 task.Wait();
                 if (cancellation.IsCancellationRequested) {
                     break;
@@ -261,7 +267,9 @@ namespace OpenUtau.Core.Render {
                 var result = task.Result;
                 source.SetSamples(result.samples);
                 DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
-                PublishRealCurveUpdates(request.part, phrase);
+                if (!realCurvesPublished) {
+                    PublishRealCurveUpdates(request.part, phrase);
+                }
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
@@ -270,18 +278,39 @@ namespace OpenUtau.Core.Render {
             progress.Clear();
         }
 
-        private void PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+        private bool PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
             if (!phrase.renderer.SupportsRealCurve) {
-                return;
+                return false;
             }
             try {
                 var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                    return true;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh rendered real curves.");
             }
+            return false;
+        }
+
+        private bool PublishRealCurveUpdates(
+            UVoicePart part,
+            RenderPhrase phrase,
+            IReadOnlyList<RenderRealCurveResult> realCurves) {
+            if (realCurves.Count == 0) {
+                return false;
+            }
+            try {
+                var updates = RealCurveUpdater.BuildUpdates(part, phrase, realCurves);
+                if (updates.Length > 0) {
+                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                    return true;
+                }
+            } catch (Exception e) {
+                Log.Debug(e, "Failed to publish rendered real curves.");
+            }
+            return false;
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -249,15 +249,14 @@ namespace OpenUtau.Core.Render {
                 tuples = orderedTuples;
             }
             var progress = new Progress(tuples.Sum(t => t.Item1.phones.Length));
-            var partUpdates = new Dictionary<UVoicePart, List<RealCurveUpdate>>();
             foreach (var tuple in tuples) {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
-                RealCurveUpdate[]? callbackUpdates = null;
+                bool realCurvesPublished = false;
                 var renderEvents = phrase.renderer.SupportsRealCurve
                     ? new RenderPhraseEvents(realCurves => {
-                        callbackUpdates = PublishRealCurveUpdates(request.part, phrase, realCurves);
+                        realCurvesPublished = PublishRealCurveUpdates(request.part, phrase, realCurves);
                     })
                     : null;
                 var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true, renderEvents);
@@ -268,58 +267,50 @@ namespace OpenUtau.Core.Render {
                 var result = task.Result;
                 source.SetSamples(result.samples);
                 DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
-                var phraseUpdates = callbackUpdates ?? PublishRealCurveUpdates(request.part, phrase);
-                if (phraseUpdates != null && phraseUpdates.Length > 0) {
-                    if (!partUpdates.TryGetValue(request.part, out var list)) {
-                        list = new List<RealCurveUpdate>();
-                        partUpdates[request.part] = list;
-                    }
-                    list.AddRange(phraseUpdates);
+                if (!realCurvesPublished) {
+                    PublishRealCurveUpdates(request.part, phrase);
                 }
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
-                    if (partUpdates.TryGetValue(request.part, out var accumulated) && accumulated.Count > 0) {
-                        DocManager.Inst.ExecuteCmd(new RealCurveCoverageNotification(request.part, accumulated));
-                    }
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
                 }
             }
             progress.Clear();
         }
 
-        private RealCurveUpdate[]? PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+        private bool PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
             if (!phrase.renderer.SupportsRealCurve) {
-                return null;
+                return false;
             }
             try {
                 var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return updates;
+                    return true;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh rendered real curves.");
             }
-            return null;
+            return false;
         }
 
-        private RealCurveUpdate[]? PublishRealCurveUpdates(
+        private bool PublishRealCurveUpdates(
             UVoicePart part,
             RenderPhrase phrase,
             IReadOnlyList<RenderRealCurveResult> realCurves) {
             if (realCurves.Count == 0) {
-                return null;
+                return false;
             }
             try {
                 var updates = RealCurveUpdater.BuildUpdates(part, phrase, realCurves);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return updates;
+                    return true;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to publish rendered real curves.");
             }
-            return null;
+            return false;
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -258,13 +258,30 @@ namespace OpenUtau.Core.Render {
                 if (cancellation.IsCancellationRequested) {
                     break;
                 }
-                source.SetSamples(task.Result.samples);
+                var result = task.Result;
+                source.SetSamples(result.samples);
+                DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
+                PublishRealCurveUpdates(request.part, phrase);
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
                 }
             }
             progress.Clear();
+        }
+
+        private void PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+            if (!phrase.renderer.SupportsRealCurve) {
+                return;
+            }
+            try {
+                var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
+                if (updates.Length > 0) {
+                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                }
+            } catch (Exception e) {
+                Log.Debug(e, "Failed to refresh rendered real curves.");
+            }
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -249,14 +249,15 @@ namespace OpenUtau.Core.Render {
                 tuples = orderedTuples;
             }
             var progress = new Progress(tuples.Sum(t => t.Item1.phones.Length));
+            var partUpdates = new Dictionary<UVoicePart, List<RealCurveUpdate>>();
             foreach (var tuple in tuples) {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
-                bool realCurvesPublished = false;
+                RealCurveUpdate[]? callbackUpdates = null;
                 var renderEvents = phrase.renderer.SupportsRealCurve
                     ? new RenderPhraseEvents(realCurves => {
-                        realCurvesPublished = PublishRealCurveUpdates(request.part, phrase, realCurves);
+                        callbackUpdates = PublishRealCurveUpdates(request.part, phrase, realCurves);
                     })
                     : null;
                 var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true, renderEvents);
@@ -267,50 +268,58 @@ namespace OpenUtau.Core.Render {
                 var result = task.Result;
                 source.SetSamples(result.samples);
                 DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
-                if (!realCurvesPublished) {
-                    PublishRealCurveUpdates(request.part, phrase);
+                var phraseUpdates = callbackUpdates ?? PublishRealCurveUpdates(request.part, phrase);
+                if (phraseUpdates != null && phraseUpdates.Length > 0) {
+                    if (!partUpdates.TryGetValue(request.part, out var list)) {
+                        list = new List<RealCurveUpdate>();
+                        partUpdates[request.part] = list;
+                    }
+                    list.AddRange(phraseUpdates);
                 }
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
+                    if (partUpdates.TryGetValue(request.part, out var accumulated) && accumulated.Count > 0) {
+                        DocManager.Inst.ExecuteCmd(new RealCurveCoverageNotification(request.part, accumulated));
+                    }
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
                 }
             }
             progress.Clear();
         }
 
-        private bool PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+        private RealCurveUpdate[]? PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
             if (!phrase.renderer.SupportsRealCurve) {
-                return false;
+                return null;
             }
             try {
                 var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return true;
+                    return updates;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh rendered real curves.");
             }
-            return false;
+            return null;
         }
 
-        private bool PublishRealCurveUpdates(
+        private RealCurveUpdate[]? PublishRealCurveUpdates(
             UVoicePart part,
             RenderPhrase phrase,
             IReadOnlyList<RenderRealCurveResult> realCurves) {
             if (realCurves.Count == 0) {
-                return false;
+                return null;
             }
             try {
                 var updates = RealCurveUpdater.BuildUpdates(part, phrase, realCurves);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return true;
+                    return updates;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to publish rendered real curves.");
             }
-            return false;
+            return null;
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -255,15 +255,14 @@ namespace OpenUtau.Core.Render {
                 tuples = orderedTuples;
             }
             var progress = new Progress(tuples.Sum(t => t.Item1.phones.Length));
-            var partUpdates = new Dictionary<UVoicePart, List<RealCurveUpdate>>();
             foreach (var tuple in tuples) {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
-                RealCurveUpdate[]? callbackUpdates = null;
+                bool realCurvesPublished = false;
                 var renderEvents = phrase.renderer.SupportsRealCurve
                     ? new RenderPhraseEvents(realCurves => {
-                        callbackUpdates = PublishRealCurveUpdates(request.part, phrase, realCurves);
+                        realCurvesPublished = PublishRealCurveUpdates(request.part, phrase, realCurves);
                     })
                     : null;
                 var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true, renderEvents);
@@ -274,58 +273,50 @@ namespace OpenUtau.Core.Render {
                 var result = task.Result;
                 source.SetSamples(result.samples);
                 DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
-                var phraseUpdates = callbackUpdates ?? PublishRealCurveUpdates(request.part, phrase);
-                if (phraseUpdates != null && phraseUpdates.Length > 0) {
-                    if (!partUpdates.TryGetValue(request.part, out var list)) {
-                        list = new List<RealCurveUpdate>();
-                        partUpdates[request.part] = list;
-                    }
-                    list.AddRange(phraseUpdates);
+                if (!realCurvesPublished) {
+                    PublishRealCurveUpdates(request.part, phrase);
                 }
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
-                    if (partUpdates.TryGetValue(request.part, out var accumulated) && accumulated.Count > 0) {
-                        DocManager.Inst.ExecuteCmd(new RealCurveCoverageNotification(request.part, accumulated));
-                    }
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
                 }
             }
             progress.Clear();
         }
 
-        private RealCurveUpdate[]? PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+        private bool PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
             if (!phrase.renderer.SupportsRealCurve) {
-                return null;
+                return false;
             }
             try {
                 var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return updates;
+                    return true;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh rendered real curves.");
             }
-            return null;
+            return false;
         }
 
-        private RealCurveUpdate[]? PublishRealCurveUpdates(
+        private bool PublishRealCurveUpdates(
             UVoicePart part,
             RenderPhrase phrase,
             IReadOnlyList<RenderRealCurveResult> realCurves) {
             if (realCurves.Count == 0) {
-                return null;
+                return false;
             }
             try {
                 var updates = RealCurveUpdater.BuildUpdates(part, phrase, realCurves);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return updates;
+                    return true;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to publish rendered real curves.");
             }
-            return null;
+            return false;
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -264,13 +264,30 @@ namespace OpenUtau.Core.Render {
                 if (cancellation.IsCancellationRequested) {
                     break;
                 }
-                source.SetSamples(task.Result.samples);
+                var result = task.Result;
+                source.SetSamples(result.samples);
+                DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
+                PublishRealCurveUpdates(request.part, phrase);
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
                 }
             }
             progress.Clear();
+        }
+
+        private void PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+            if (!phrase.renderer.SupportsRealCurve) {
+                return;
+            }
+            try {
+                var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
+                if (updates.Length > 0) {
+                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                }
+            } catch (Exception e) {
+                Log.Debug(e, "Failed to refresh rendered real curves.");
+            }
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -255,14 +255,20 @@ namespace OpenUtau.Core.Render {
                 tuples = orderedTuples;
             }
             var progress = new Progress(tuples.Sum(t => t.Item1.phones.Length));
+            // Only full-project passes (pre-render / export) maintain the real-curve coverage
+            // invariant. Partial playback passes must not trim curves outside their tick window.
+            bool maintainCoverage = startTick == 0 && endTick == -1;
+            var coverageRanges = maintainCoverage
+                ? new Dictionary<UVoicePart, List<(int start, int end)>>()
+                : null;
             foreach (var tuple in tuples) {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
-                bool realCurvesPublished = false;
+                RealCurveUpdate[]? publishedUpdates = null;
                 var renderEvents = phrase.renderer.SupportsRealCurve
                     ? new RenderPhraseEvents(realCurves => {
-                        realCurvesPublished = PublishRealCurveUpdates(request.part, phrase, realCurves);
+                        publishedUpdates = PublishRealCurveUpdates(request.part, phrase, realCurves);
                     })
                     : null;
                 var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true, renderEvents);
@@ -272,51 +278,74 @@ namespace OpenUtau.Core.Render {
                 }
                 var result = task.Result;
                 source.SetSamples(result.samples);
-                DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
-                if (!realCurvesPublished) {
-                    PublishRealCurveUpdates(request.part, phrase);
+                if (publishedUpdates == null) {
+                    publishedUpdates = PublishRealCurveUpdates(request.part, phrase);
+                }
+                if (coverageRanges != null && publishedUpdates != null) {
+                    AccumulateCoverage(coverageRanges, request.part, publishedUpdates);
                 }
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
+                    if (coverageRanges != null &&
+                        phrase.renderer.SupportsRealCurve &&
+                        coverageRanges.TryGetValue(request.part, out var ranges) &&
+                        ranges.Count > 0) {
+                        DocManager.Inst.ExecuteCmd(new RealCurveCoverageNotification(request.part, ranges));
+                    }
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
                 }
             }
             progress.Clear();
         }
 
-        private bool PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+        private RealCurveUpdate[]? PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
             if (!phrase.renderer.SupportsRealCurve) {
-                return false;
+                return null;
             }
             try {
                 var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return true;
+                    return updates;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh rendered real curves.");
             }
-            return false;
+            return null;
         }
 
-        private bool PublishRealCurveUpdates(
+        private RealCurveUpdate[]? PublishRealCurveUpdates(
             UVoicePart part,
             RenderPhrase phrase,
             IReadOnlyList<RenderRealCurveResult> realCurves) {
             if (realCurves.Count == 0) {
-                return false;
+                return null;
             }
             try {
                 var updates = RealCurveUpdater.BuildUpdates(part, phrase, realCurves);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return true;
+                    return updates;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to publish rendered real curves.");
             }
-            return false;
+            return null;
+        }
+
+        private static void AccumulateCoverage(
+            Dictionary<UVoicePart, List<(int start, int end)>> coverage,
+            UVoicePart part,
+            RealCurveUpdate[] updates) {
+            if (!coverage.TryGetValue(part, out var ranges)) {
+                ranges = new List<(int start, int end)>();
+                coverage[part] = ranges;
+            }
+            foreach (var update in updates) {
+                if (update.IsValid) {
+                    ranges.Add((update.startTick, update.endTick));
+                }
+            }
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -255,14 +255,15 @@ namespace OpenUtau.Core.Render {
                 tuples = orderedTuples;
             }
             var progress = new Progress(tuples.Sum(t => t.Item1.phones.Length));
+            var partUpdates = new Dictionary<UVoicePart, List<RealCurveUpdate>>();
             foreach (var tuple in tuples) {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
-                bool realCurvesPublished = false;
+                RealCurveUpdate[]? callbackUpdates = null;
                 var renderEvents = phrase.renderer.SupportsRealCurve
                     ? new RenderPhraseEvents(realCurves => {
-                        realCurvesPublished = PublishRealCurveUpdates(request.part, phrase, realCurves);
+                        callbackUpdates = PublishRealCurveUpdates(request.part, phrase, realCurves);
                     })
                     : null;
                 var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true, renderEvents);
@@ -273,50 +274,58 @@ namespace OpenUtau.Core.Render {
                 var result = task.Result;
                 source.SetSamples(result.samples);
                 DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
-                if (!realCurvesPublished) {
-                    PublishRealCurveUpdates(request.part, phrase);
+                var phraseUpdates = callbackUpdates ?? PublishRealCurveUpdates(request.part, phrase);
+                if (phraseUpdates != null && phraseUpdates.Length > 0) {
+                    if (!partUpdates.TryGetValue(request.part, out var list)) {
+                        list = new List<RealCurveUpdate>();
+                        partUpdates[request.part] = list;
+                    }
+                    list.AddRange(phraseUpdates);
                 }
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
+                    if (partUpdates.TryGetValue(request.part, out var accumulated) && accumulated.Count > 0) {
+                        DocManager.Inst.ExecuteCmd(new RealCurveCoverageNotification(request.part, accumulated));
+                    }
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
                 }
             }
             progress.Clear();
         }
 
-        private bool PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+        private RealCurveUpdate[]? PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
             if (!phrase.renderer.SupportsRealCurve) {
-                return false;
+                return null;
             }
             try {
                 var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return true;
+                    return updates;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh rendered real curves.");
             }
-            return false;
+            return null;
         }
 
-        private bool PublishRealCurveUpdates(
+        private RealCurveUpdate[]? PublishRealCurveUpdates(
             UVoicePart part,
             RenderPhrase phrase,
             IReadOnlyList<RenderRealCurveResult> realCurves) {
             if (realCurves.Count == 0) {
-                return false;
+                return null;
             }
             try {
                 var updates = RealCurveUpdater.BuildUpdates(part, phrase, realCurves);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
-                    return true;
+                    return updates;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to publish rendered real curves.");
             }
-            return false;
+            return null;
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -259,7 +259,13 @@ namespace OpenUtau.Core.Render {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
-                var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true);
+                bool realCurvesPublished = false;
+                var renderEvents = phrase.renderer.SupportsRealCurve
+                    ? new RenderPhraseEvents(realCurves => {
+                        realCurvesPublished = PublishRealCurveUpdates(request.part, phrase, realCurves);
+                    })
+                    : null;
+                var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true, renderEvents);
                 task.Wait();
                 if (cancellation.IsCancellationRequested) {
                     break;
@@ -267,7 +273,9 @@ namespace OpenUtau.Core.Render {
                 var result = task.Result;
                 source.SetSamples(result.samples);
                 DocManager.Inst.ExecuteCmd(new PhraseRenderedNotification(request.part, phrase, result, request.trackNo));
-                PublishRealCurveUpdates(request.part, phrase);
+                if (!realCurvesPublished) {
+                    PublishRealCurveUpdates(request.part, phrase);
+                }
                 if (request.sources.All(s => s.HasSamples)) {
                     request.part.SetMix(request.mix);
                     DocManager.Inst.ExecuteCmd(new PartRenderedNotification(request.part));
@@ -276,18 +284,39 @@ namespace OpenUtau.Core.Render {
             progress.Clear();
         }
 
-        private void PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
+        private bool PublishRealCurveUpdates(UVoicePart part, RenderPhrase phrase) {
             if (!phrase.renderer.SupportsRealCurve) {
-                return;
+                return false;
             }
             try {
                 var updates = RealCurveUpdater.LoadPhraseUpdates(part, phrase);
                 if (updates.Length > 0) {
                     DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                    return true;
                 }
             } catch (Exception e) {
                 Log.Debug(e, "Failed to refresh rendered real curves.");
             }
+            return false;
+        }
+
+        private bool PublishRealCurveUpdates(
+            UVoicePart part,
+            RenderPhrase phrase,
+            IReadOnlyList<RenderRealCurveResult> realCurves) {
+            if (realCurves.Count == 0) {
+                return false;
+            }
+            try {
+                var updates = RealCurveUpdater.BuildUpdates(part, phrase, realCurves);
+                if (updates.Length > 0) {
+                    DocManager.Inst.ExecuteCmd(new RealCurvesUpdatedNotification(part, updates));
+                    return true;
+                }
+            } catch (Exception e) {
+                Log.Debug(e, "Failed to publish rendered real curves.");
+            }
+            return false;
         }
 
         public static void ReleaseSourceTemp() {

--- a/OpenUtau.Core/Vogen/VogenRenderer.cs
+++ b/OpenUtau.Core/Vogen/VogenRenderer.cs
@@ -53,7 +53,7 @@ namespace OpenUtau.Core.Vogen {
             };
         }
 
-        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender = false) {
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender = false, RenderPhraseEvents? renderEvents = null) {
             var task = Task.Run(() => {
                 lock (lockObj) {
                     if (cancellation.IsCancellationRequested) {

--- a/OpenUtau.Core/Voicevox/VoicevoxRenderer.cs
+++ b/OpenUtau.Core/Voicevox/VoicevoxRenderer.cs
@@ -57,7 +57,7 @@ namespace OpenUtau.Core.Voicevox {
             };
         }
 
-        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender) {
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender, RenderPhraseEvents? renderEvents = null) {
             var task = Task.Run(() => {
                 lock (lockObj) {
                     if (cancellation.IsCancellationRequested) {

--- a/OpenUtau.Test/Core/DiffSinger/DiffSingerRealCurveSchedulerTest.cs
+++ b/OpenUtau.Test/Core/DiffSinger/DiffSingerRealCurveSchedulerTest.cs
@@ -1,0 +1,18 @@
+using OpenUtau.Core.DiffSinger;
+using UstxFormat = OpenUtau.Core.Format.Ustx;
+using Xunit;
+
+namespace OpenUtau.Core {
+    public class DiffSingerRealCurveSchedulerTest {
+        [Fact]
+        public void RealCurveRefreshIsLimitedToVarianceOffsetCurves() {
+            Assert.True(DiffSingerRenderer.ShouldRefreshRealCurvesOnCurveEdit(DiffSingerUtils.ENE));
+            Assert.True(DiffSingerRenderer.ShouldRefreshRealCurvesOnCurveEdit(UstxFormat.BREC));
+            Assert.True(DiffSingerRenderer.ShouldRefreshRealCurvesOnCurveEdit(UstxFormat.VOIC));
+            Assert.True(DiffSingerRenderer.ShouldRefreshRealCurvesOnCurveEdit(UstxFormat.TENC));
+
+            Assert.False(DiffSingerRenderer.ShouldRefreshRealCurvesOnCurveEdit(UstxFormat.PITD));
+            Assert.False(DiffSingerRenderer.ShouldRefreshRealCurvesOnCurveEdit(UstxFormat.DYN));
+        }
+    }
+}

--- a/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
+++ b/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Core.Render;
@@ -94,44 +93,6 @@ namespace OpenUtau.Core {
             Assert.False(changed);
             Assert.Equal(new[] { 0, 0, 10 }, curve.realXs);
             Assert.Equal(new[] { -1, 10, 20 }, curve.realYs);
-        }
-
-        [Fact]
-        public void ApplyFullRefreshClearsEveryRealCurveInPart() {
-            var project = CreateProjectWithCurve(out var part, out var curve);
-            // Stale data from a previous render that covered a wider tick range than the
-            // restored phrase will after undo.
-            curve.realXs.AddRange(new[] { 0, 0, 10, 50, 50, 80 });
-            curve.realYs.AddRange(new[] { -1, 10, 20, -1, 90, 95 });
-
-            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
-
-            Assert.True(changed);
-            Assert.Empty(curve.realXs);
-            Assert.Empty(curve.realYs);
-        }
-
-        [Fact]
-        public void ApplyFullRefreshNoOpWhenAlreadyEmpty() {
-            var project = CreateProjectWithCurve(out var part, out _);
-
-            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
-
-            Assert.False(changed);
-        }
-
-        [Fact]
-        public void ApplyFullRefreshNoOpWhenPartNotInProject() {
-            var project = CreateProjectWithCurve(out var part, out var curve);
-            curve.realXs.AddRange(new[] { 0 });
-            curve.realYs.AddRange(new[] { 1 });
-            project.parts.Remove(part);
-
-            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
-
-            Assert.False(changed);
-            Assert.Equal(new[] { 0 }, curve.realXs);
-            Assert.Equal(new[] { 1 }, curve.realYs);
         }
 
         static UProject CreateProjectWithCurve(out UVoicePart part, out UCurve curve) {

--- a/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
+++ b/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
@@ -9,6 +9,23 @@ namespace OpenUtau.Core {
         const string Ene = "ene";
 
         [Fact]
+        public void RenderPhraseEventsReportsNonEmptyRealCurvesOnly() {
+            int reports = 0;
+            var events = new RenderPhraseEvents(_ => reports++);
+
+            events.ReportRealCurves(new List<RenderRealCurveResult>());
+            events.ReportRealCurves(new[] {
+                new RenderRealCurveResult {
+                    abbr = Ene,
+                    ticks = new[] { 0f },
+                    values = new[] { 0.1f },
+                },
+            });
+
+            Assert.Equal(1, reports);
+        }
+
+        [Fact]
         public void BuildUpdatesConvertsTicksToPartLocalCoordinates() {
             var result = new RenderRealCurveResult {
                 abbr = Ene,

--- a/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
+++ b/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
@@ -97,41 +97,102 @@ namespace OpenUtau.Core {
         }
 
         [Fact]
-        public void ApplyFullRefreshClearsEveryRealCurveInPart() {
-            var project = CreateProjectWithCurve(out var part, out var curve);
-            // Stale data from a previous render that covered a wider tick range than the
-            // restored phrase will after undo.
-            curve.realXs.AddRange(new[] { 0, 0, 10, 50, 50, 80 });
-            curve.realYs.AddRange(new[] { -1, 10, 20, -1, 90, 95 });
-
-            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
-
-            Assert.True(changed);
-            Assert.Empty(curve.realXs);
-            Assert.Empty(curve.realYs);
-        }
-
-        [Fact]
-        public void ApplyFullRefreshNoOpWhenAlreadyEmpty() {
-            var project = CreateProjectWithCurve(out var part, out _);
-
-            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
-
-            Assert.False(changed);
-        }
-
-        [Fact]
-        public void ApplyFullRefreshNoOpWhenPartNotInProject() {
+        public void TrimToCoverageNoOpWhenPartNotInProject() {
             var project = CreateProjectWithCurve(out var part, out var curve);
             curve.realXs.AddRange(new[] { 0 });
             curve.realYs.AddRange(new[] { 1 });
             project.parts.Remove(part);
 
-            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
+            bool changed = RealCurveUpdater.TrimToCoverage(project, part, new[] {
+                new RealCurveUpdate(Ene, 1, 0, 10, new[] { 0 }, new[] { 1 }),
+            });
 
             Assert.False(changed);
             Assert.Equal(new[] { 0 }, curve.realXs);
             Assert.Equal(new[] { 1 }, curve.realYs);
+        }
+
+        [Fact]
+        public void TrimToCoverageRemovesEntriesOutsideUnionForAbbrsWithUpdates() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            // Stale tail data past 110 that an earlier render with a wider phrase left behind.
+            curve.realXs.AddRange(new[] { 0, 0, 10, 100, 100, 110, 150, 200 });
+            curve.realYs.AddRange(new[] { -1, 10, 20, -1, 30, 40, 50, 60 });
+
+            // Two updates whose union is [0,10] U [100,110]. Entries at 150 and 200 fall outside.
+            bool changed = RealCurveUpdater.TrimToCoverage(project, part, new[] {
+                new RealCurveUpdate(Ene, 1, 0, 10, new[] { 0, 0, 5, 10 }, new[] { -1, 11, 12, 13 }),
+                new RealCurveUpdate(Ene, 2, 100, 110, new[] { 100, 100, 105, 110 }, new[] { -1, 31, 32, 33 }),
+            });
+
+            Assert.True(changed);
+            Assert.Equal(new[] { 0, 0, 10, 100, 100, 110 }, curve.realXs);
+            Assert.Equal(new[] { -1, 10, 20, -1, 30, 40 }, curve.realYs);
+        }
+
+        [Fact]
+        public void TrimToCoverageMergesOverlappingRanges() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            curve.realXs.AddRange(new[] { 0, 50, 80, 150 });
+            curve.realYs.AddRange(new[] { 1, 2, 3, 4 });
+
+            // Two overlapping ranges [0,60] and [40,100] merge into [0,100]; 150 falls outside.
+            bool changed = RealCurveUpdater.TrimToCoverage(project, part, new[] {
+                new RealCurveUpdate(Ene, 1, 0, 60, new[] { 0, 60 }, new[] { 1, 2 }),
+                new RealCurveUpdate(Ene, 2, 40, 100, new[] { 40, 100 }, new[] { 3, 4 }),
+            });
+
+            Assert.True(changed);
+            Assert.Equal(new[] { 0, 50, 80 }, curve.realXs);
+            Assert.Equal(new[] { 1, 2, 3 }, curve.realYs);
+        }
+
+        [Fact]
+        public void TrimToCoverageLeavesAbbrsWithoutUpdatesUntouched() {
+            var project = new UProject();
+            var eneDescriptor = new UExpressionDescriptor("energy", Ene, 0, 100, 0) {
+                type = UExpressionType.Curve,
+            };
+            var breDescriptor = new UExpressionDescriptor("breath", "bre", 0, 100, 0) {
+                type = UExpressionType.Curve,
+            };
+            project.RegisterExpression(eneDescriptor);
+            project.RegisterExpression(breDescriptor);
+            var part = new UVoicePart { trackNo = 0, position = 0, Duration = 480 };
+            project.parts.Add(part);
+            var eneCurve = new UCurve(eneDescriptor);
+            var breCurve = new UCurve(breDescriptor);
+            part.curves.Add(eneCurve);
+            part.curves.Add(breCurve);
+            eneCurve.realXs.AddRange(new[] { 0, 200 });
+            eneCurve.realYs.AddRange(new[] { 1, 2 });
+            breCurve.realXs.AddRange(new[] { 0, 200 });
+            breCurve.realYs.AddRange(new[] { 3, 4 });
+
+            // Only ene has an update; bre should be untouched even though its data extends past
+            // ene's covered range.
+            bool changed = RealCurveUpdater.TrimToCoverage(project, part, new[] {
+                new RealCurveUpdate(Ene, 1, 0, 100, new[] { 0, 100 }, new[] { 1, 2 }),
+            });
+
+            Assert.True(changed);
+            Assert.Equal(new[] { 0 }, eneCurve.realXs);
+            Assert.Equal(new[] { 1 }, eneCurve.realYs);
+            Assert.Equal(new[] { 0, 200 }, breCurve.realXs);
+            Assert.Equal(new[] { 3, 4 }, breCurve.realYs);
+        }
+
+        [Fact]
+        public void TrimToCoverageNoOpWhenUpdatesEmpty() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            curve.realXs.AddRange(new[] { 0, 100 });
+            curve.realYs.AddRange(new[] { 1, 2 });
+
+            bool changed = RealCurveUpdater.TrimToCoverage(project, part, Array.Empty<RealCurveUpdate>());
+
+            Assert.False(changed);
+            Assert.Equal(new[] { 0, 100 }, curve.realXs);
+            Assert.Equal(new[] { 1, 2 }, curve.realYs);
         }
 
         static UProject CreateProjectWithCurve(out UVoicePart part, out UCurve curve) {

--- a/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
+++ b/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
@@ -97,102 +97,41 @@ namespace OpenUtau.Core {
         }
 
         [Fact]
-        public void TrimToCoverageNoOpWhenPartNotInProject() {
+        public void ApplyFullRefreshClearsEveryRealCurveInPart() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            // Stale data from a previous render that covered a wider tick range than the
+            // restored phrase will after undo.
+            curve.realXs.AddRange(new[] { 0, 0, 10, 50, 50, 80 });
+            curve.realYs.AddRange(new[] { -1, 10, 20, -1, 90, 95 });
+
+            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
+
+            Assert.True(changed);
+            Assert.Empty(curve.realXs);
+            Assert.Empty(curve.realYs);
+        }
+
+        [Fact]
+        public void ApplyFullRefreshNoOpWhenAlreadyEmpty() {
+            var project = CreateProjectWithCurve(out var part, out _);
+
+            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
+
+            Assert.False(changed);
+        }
+
+        [Fact]
+        public void ApplyFullRefreshNoOpWhenPartNotInProject() {
             var project = CreateProjectWithCurve(out var part, out var curve);
             curve.realXs.AddRange(new[] { 0 });
             curve.realYs.AddRange(new[] { 1 });
             project.parts.Remove(part);
 
-            bool changed = RealCurveUpdater.TrimToCoverage(project, part, new[] {
-                new RealCurveUpdate(Ene, 1, 0, 10, new[] { 0 }, new[] { 1 }),
-            });
+            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
 
             Assert.False(changed);
             Assert.Equal(new[] { 0 }, curve.realXs);
             Assert.Equal(new[] { 1 }, curve.realYs);
-        }
-
-        [Fact]
-        public void TrimToCoverageRemovesEntriesOutsideUnionForAbbrsWithUpdates() {
-            var project = CreateProjectWithCurve(out var part, out var curve);
-            // Stale tail data past 110 that an earlier render with a wider phrase left behind.
-            curve.realXs.AddRange(new[] { 0, 0, 10, 100, 100, 110, 150, 200 });
-            curve.realYs.AddRange(new[] { -1, 10, 20, -1, 30, 40, 50, 60 });
-
-            // Two updates whose union is [0,10] U [100,110]. Entries at 150 and 200 fall outside.
-            bool changed = RealCurveUpdater.TrimToCoverage(project, part, new[] {
-                new RealCurveUpdate(Ene, 1, 0, 10, new[] { 0, 0, 5, 10 }, new[] { -1, 11, 12, 13 }),
-                new RealCurveUpdate(Ene, 2, 100, 110, new[] { 100, 100, 105, 110 }, new[] { -1, 31, 32, 33 }),
-            });
-
-            Assert.True(changed);
-            Assert.Equal(new[] { 0, 0, 10, 100, 100, 110 }, curve.realXs);
-            Assert.Equal(new[] { -1, 10, 20, -1, 30, 40 }, curve.realYs);
-        }
-
-        [Fact]
-        public void TrimToCoverageMergesOverlappingRanges() {
-            var project = CreateProjectWithCurve(out var part, out var curve);
-            curve.realXs.AddRange(new[] { 0, 50, 80, 150 });
-            curve.realYs.AddRange(new[] { 1, 2, 3, 4 });
-
-            // Two overlapping ranges [0,60] and [40,100] merge into [0,100]; 150 falls outside.
-            bool changed = RealCurveUpdater.TrimToCoverage(project, part, new[] {
-                new RealCurveUpdate(Ene, 1, 0, 60, new[] { 0, 60 }, new[] { 1, 2 }),
-                new RealCurveUpdate(Ene, 2, 40, 100, new[] { 40, 100 }, new[] { 3, 4 }),
-            });
-
-            Assert.True(changed);
-            Assert.Equal(new[] { 0, 50, 80 }, curve.realXs);
-            Assert.Equal(new[] { 1, 2, 3 }, curve.realYs);
-        }
-
-        [Fact]
-        public void TrimToCoverageLeavesAbbrsWithoutUpdatesUntouched() {
-            var project = new UProject();
-            var eneDescriptor = new UExpressionDescriptor("energy", Ene, 0, 100, 0) {
-                type = UExpressionType.Curve,
-            };
-            var breDescriptor = new UExpressionDescriptor("breath", "bre", 0, 100, 0) {
-                type = UExpressionType.Curve,
-            };
-            project.RegisterExpression(eneDescriptor);
-            project.RegisterExpression(breDescriptor);
-            var part = new UVoicePart { trackNo = 0, position = 0, Duration = 480 };
-            project.parts.Add(part);
-            var eneCurve = new UCurve(eneDescriptor);
-            var breCurve = new UCurve(breDescriptor);
-            part.curves.Add(eneCurve);
-            part.curves.Add(breCurve);
-            eneCurve.realXs.AddRange(new[] { 0, 200 });
-            eneCurve.realYs.AddRange(new[] { 1, 2 });
-            breCurve.realXs.AddRange(new[] { 0, 200 });
-            breCurve.realYs.AddRange(new[] { 3, 4 });
-
-            // Only ene has an update; bre should be untouched even though its data extends past
-            // ene's covered range.
-            bool changed = RealCurveUpdater.TrimToCoverage(project, part, new[] {
-                new RealCurveUpdate(Ene, 1, 0, 100, new[] { 0, 100 }, new[] { 1, 2 }),
-            });
-
-            Assert.True(changed);
-            Assert.Equal(new[] { 0 }, eneCurve.realXs);
-            Assert.Equal(new[] { 1 }, eneCurve.realYs);
-            Assert.Equal(new[] { 0, 200 }, breCurve.realXs);
-            Assert.Equal(new[] { 3, 4 }, breCurve.realYs);
-        }
-
-        [Fact]
-        public void TrimToCoverageNoOpWhenUpdatesEmpty() {
-            var project = CreateProjectWithCurve(out var part, out var curve);
-            curve.realXs.AddRange(new[] { 0, 100 });
-            curve.realYs.AddRange(new[] { 1, 2 });
-
-            bool changed = RealCurveUpdater.TrimToCoverage(project, part, Array.Empty<RealCurveUpdate>());
-
-            Assert.False(changed);
-            Assert.Equal(new[] { 0, 100 }, curve.realXs);
-            Assert.Equal(new[] { 1, 2 }, curve.realYs);
         }
 
         static UProject CreateProjectWithCurve(out UVoicePart part, out UCurve curve) {

--- a/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
+++ b/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
@@ -95,6 +95,46 @@ namespace OpenUtau.Core {
             Assert.Equal(new[] { -1, 10, 20 }, curve.realYs);
         }
 
+        [Fact]
+        public void TrimToCoverageRemovesGhostPointsOutsideCoverage() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            curve.realXs.AddRange(new[] { 0, 0, 25, 50, 60, 80, 100 });
+            curve.realYs.AddRange(new[] { -1, 10, 20, 30, 40, 50, 60 });
+
+            bool changed = RealCurveUpdater.TrimToCoverage(
+                project, part, new List<(int start, int end)> { (0, 50) });
+
+            Assert.True(changed);
+            Assert.Equal(new[] { 0, 0, 25, 50 }, curve.realXs);
+            Assert.Equal(new[] { -1, 10, 20, 30 }, curve.realYs);
+        }
+
+        [Fact]
+        public void TrimToCoverageKeepsPointsWhenAllInsideCoverage() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            curve.realXs.AddRange(new[] { 0, 0, 25, 50 });
+            curve.realYs.AddRange(new[] { -1, 10, 20, 30 });
+
+            bool changed = RealCurveUpdater.TrimToCoverage(
+                project, part, new List<(int start, int end)> { (0, 50) });
+
+            Assert.False(changed);
+            Assert.Equal(new[] { 0, 0, 25, 50 }, curve.realXs);
+        }
+
+        [Fact]
+        public void TrimToCoverageSkipsWhenNoRanges() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            curve.realXs.AddRange(new[] { 0, 50, 100 });
+            curve.realYs.AddRange(new[] { -1, 30, 60 });
+
+            bool changed = RealCurveUpdater.TrimToCoverage(
+                project, part, new List<(int start, int end)>());
+
+            Assert.False(changed);
+            Assert.Equal(3, curve.realXs.Count);
+        }
+
         static UProject CreateProjectWithCurve(out UVoicePart part, out UCurve curve) {
             var project = new UProject();
             var descriptor = new UExpressionDescriptor("energy", Ene, 0, 100, 0) {

--- a/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
+++ b/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Linq;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using Xunit;
+
+namespace OpenUtau.Core {
+    public class RealCurveUpdaterTest {
+        const string Ene = "ene";
+
+        [Fact]
+        public void BuildUpdatesConvertsTicksToPartLocalCoordinates() {
+            var result = new RenderRealCurveResult {
+                abbr = Ene,
+                ticks = new[] { 0f, 5f, 10f },
+                values = new[] { 0.1f, 0.2f, 0.3f },
+            };
+
+            var update = Assert.Single(RealCurveUpdater.BuildUpdates(
+                partPosition: 100,
+                phrasePosition: 250,
+                phraseHash: 42,
+                results: new[] { result }));
+
+            Assert.Equal(Ene, update.abbr);
+            Assert.Equal((ulong)42, update.phraseHash);
+            Assert.Equal(150, update.startTick);
+            Assert.Equal(160, update.endTick);
+            Assert.Equal(new[] { 150, 150, 155, 160 }, update.xs);
+            Assert.Equal(new[] { -1, 100, 200, 300 }, update.ys);
+        }
+
+        [Fact]
+        public void ApplyReplacesMatchingPhraseRangeOnly() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            curve.realXs.AddRange(new[] { 0, 0, 10, 100, 100, 110 });
+            curve.realYs.AddRange(new[] { -1, 10, 20, -1, 30, 40 });
+            var update = new RealCurveUpdate(
+                Ene,
+                phraseHash: 42,
+                startTick: 100,
+                endTick: 110,
+                xs: new[] { 100, 100, 105, 110 },
+                ys: new[] { -1, 300, 400, 500 });
+
+            bool changed = RealCurveUpdater.Apply(
+                project,
+                part,
+                new[] { update },
+                new HashSet<ulong> { 42 });
+
+            Assert.True(changed);
+            Assert.Equal(new[] { 0, 0, 10, 100, 100, 105, 110 }, curve.realXs);
+            Assert.Equal(new[] { -1, 10, 20, -1, 300, 400, 500 }, curve.realYs);
+        }
+
+        [Fact]
+        public void ApplySkipsStalePhraseHash() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            curve.realXs.AddRange(new[] { 0, 0, 10 });
+            curve.realYs.AddRange(new[] { -1, 10, 20 });
+            var update = new RealCurveUpdate(
+                Ene,
+                phraseHash: 42,
+                startTick: 0,
+                endTick: 10,
+                xs: new[] { 0, 0, 5 },
+                ys: new[] { -1, 300, 400 });
+
+            bool changed = RealCurveUpdater.Apply(
+                project,
+                part,
+                new[] { update },
+                new HashSet<ulong> { 43 });
+
+            Assert.False(changed);
+            Assert.Equal(new[] { 0, 0, 10 }, curve.realXs);
+            Assert.Equal(new[] { -1, 10, 20 }, curve.realYs);
+        }
+
+        static UProject CreateProjectWithCurve(out UVoicePart part, out UCurve curve) {
+            var project = new UProject();
+            var descriptor = new UExpressionDescriptor("energy", Ene, 0, 100, 0) {
+                type = UExpressionType.Curve,
+            };
+            project.RegisterExpression(descriptor);
+            part = new UVoicePart {
+                trackNo = 0,
+                position = 0,
+                Duration = 480,
+            };
+            project.parts.Add(part);
+            curve = new UCurve(descriptor);
+            part.curves.Add(curve);
+            return project;
+        }
+    }
+}

--- a/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
+++ b/OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Core.Render;
@@ -93,6 +94,44 @@ namespace OpenUtau.Core {
             Assert.False(changed);
             Assert.Equal(new[] { 0, 0, 10 }, curve.realXs);
             Assert.Equal(new[] { -1, 10, 20 }, curve.realYs);
+        }
+
+        [Fact]
+        public void ApplyFullRefreshClearsEveryRealCurveInPart() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            // Stale data from a previous render that covered a wider tick range than the
+            // restored phrase will after undo.
+            curve.realXs.AddRange(new[] { 0, 0, 10, 50, 50, 80 });
+            curve.realYs.AddRange(new[] { -1, 10, 20, -1, 90, 95 });
+
+            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
+
+            Assert.True(changed);
+            Assert.Empty(curve.realXs);
+            Assert.Empty(curve.realYs);
+        }
+
+        [Fact]
+        public void ApplyFullRefreshNoOpWhenAlreadyEmpty() {
+            var project = CreateProjectWithCurve(out var part, out _);
+
+            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
+
+            Assert.False(changed);
+        }
+
+        [Fact]
+        public void ApplyFullRefreshNoOpWhenPartNotInProject() {
+            var project = CreateProjectWithCurve(out var part, out var curve);
+            curve.realXs.AddRange(new[] { 0 });
+            curve.realYs.AddRange(new[] { 1 });
+            project.parts.Remove(part);
+
+            bool changed = RealCurveUpdater.ApplyFullRefresh(project, part, Array.Empty<RealCurveUpdate>());
+
+            Assert.False(changed);
+            Assert.Equal(new[] { 0 }, curve.realXs);
+            Assert.Equal(new[] { 1 }, curve.realYs);
         }
 
         static UProject CreateProjectWithCurve(out UVoicePart part, out UCurve curve) {

--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -78,6 +78,12 @@ namespace OpenUtau.App.Controls {
             circleGeometry = new EllipseGeometry(new Rect(-4.5, -4.5, 9, 9));
             MessageBus.Current.Listen<NotesRefreshEvent>()
                 .Subscribe(_ => InvalidateVisual());
+            MessageBus.Current.Listen<RealCurveRefreshEvent>()
+                .Subscribe(_ => {
+                    if (ShowRealCurve) {
+                        InvalidateVisual();
+                    }
+                });
             MessageBus.Current.Listen<NotesSelectionEvent>()
                 .Subscribe(e => {
                     selectedNotes.Clear();

--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -79,6 +79,12 @@ namespace OpenUtau.App.Controls {
             circleGeometry = new EllipseGeometry(new Rect(-4.5, -4.5, 9, 9));
             MessageBus.Current.Listen<NotesRefreshEvent>()
                 .Subscribe(_ => InvalidateVisual());
+            MessageBus.Current.Listen<RealCurveRefreshEvent>()
+                .Subscribe(_ => {
+                    if (ShowRealCurve) {
+                        InvalidateVisual();
+                    }
+                });
             MessageBus.Current.Listen<NotesSelectionEvent>()
                 .Subscribe(e => {
                     selectedNotes.Clear();

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -1097,8 +1097,6 @@ namespace OpenUtau.App.ViewModels {
                     MessageBus.Current.SendMessage(new WaveformRefreshEvent());
                 } else if (notif is RealCurvesUpdatedNotification && notif.part == Part) {
                     MessageBus.Current.SendMessage(new NotesRefreshEvent());
-                } else if (notif is RealCurveCoverageNotification && notif.part == Part) {
-                    MessageBus.Current.SendMessage(new NotesRefreshEvent());
                 }
             } else if (cmd is PartCommand partCommand) {
                 if (cmd is ReplacePartCommand replacePart) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -1095,6 +1095,8 @@ namespace OpenUtau.App.ViewModels {
                     MessageBus.Current.SendMessage(new NotesRefreshEvent());
                 } else if (notif is PartRenderedNotification && notif.part == Part) {
                     MessageBus.Current.SendMessage(new WaveformRefreshEvent());
+                } else if (notif is RealCurvesUpdatedNotification && notif.part == Part) {
+                    MessageBus.Current.SendMessage(new NotesRefreshEvent());
                 }
             } else if (cmd is PartCommand partCommand) {
                 if (cmd is ReplacePartCommand replacePart) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -24,6 +24,7 @@ using SharpCompress;
 
 namespace OpenUtau.App.ViewModels {
     public class NotesRefreshEvent { }
+    public class RealCurveRefreshEvent { }
     public class NotesSelectionEvent {
         public readonly UNote[] selectedNotes;
         public readonly UNote[] tempSelectedNotes;
@@ -1096,7 +1097,9 @@ namespace OpenUtau.App.ViewModels {
                 } else if (notif is PartRenderedNotification && notif.part == Part) {
                     MessageBus.Current.SendMessage(new WaveformRefreshEvent());
                 } else if (notif is RealCurvesUpdatedNotification && notif.part == Part) {
-                    MessageBus.Current.SendMessage(new NotesRefreshEvent());
+                    MessageBus.Current.SendMessage(new RealCurveRefreshEvent());
+                } else if (notif is RealCurveCoverageNotification && notif.part == Part) {
+                    MessageBus.Current.SendMessage(new RealCurveRefreshEvent());
                 }
             } else if (cmd is PartCommand partCommand) {
                 if (cmd is ReplacePartCommand replacePart) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -1097,6 +1097,8 @@ namespace OpenUtau.App.ViewModels {
                     MessageBus.Current.SendMessage(new WaveformRefreshEvent());
                 } else if (notif is RealCurvesUpdatedNotification && notif.part == Part) {
                     MessageBus.Current.SendMessage(new NotesRefreshEvent());
+                } else if (notif is RealCurveCoverageNotification && notif.part == Part) {
+                    MessageBus.Current.SendMessage(new NotesRefreshEvent());
                 }
             } else if (cmd is PartCommand partCommand) {
                 if (cmd is ReplacePartCommand replacePart) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -1102,6 +1102,8 @@ namespace OpenUtau.App.ViewModels {
                     MessageBus.Current.SendMessage(new WaveformRefreshEvent());
                 } else if (notif is RealCurvesUpdatedNotification && notif.part == Part) {
                     MessageBus.Current.SendMessage(new NotesRefreshEvent());
+                } else if (notif is RealCurveCoverageNotification && notif.part == Part) {
+                    MessageBus.Current.SendMessage(new NotesRefreshEvent());
                 }
             } else if (cmd is PartCommand partCommand) {
                 if (cmd is ReplacePartCommand replacePart) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -1100,6 +1100,8 @@ namespace OpenUtau.App.ViewModels {
                     MessageBus.Current.SendMessage(new NotesRefreshEvent());
                 } else if (notif is PartRenderedNotification && notif.part == Part) {
                     MessageBus.Current.SendMessage(new WaveformRefreshEvent());
+                } else if (notif is RealCurvesUpdatedNotification && notif.part == Part) {
+                    MessageBus.Current.SendMessage(new NotesRefreshEvent());
                 }
             } else if (cmd is PartCommand partCommand) {
                 if (cmd is ReplacePartCommand replacePart) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -1102,8 +1102,6 @@ namespace OpenUtau.App.ViewModels {
                     MessageBus.Current.SendMessage(new WaveformRefreshEvent());
                 } else if (notif is RealCurvesUpdatedNotification && notif.part == Part) {
                     MessageBus.Current.SendMessage(new NotesRefreshEvent());
-                } else if (notif is RealCurveCoverageNotification && notif.part == Part) {
-                    MessageBus.Current.SendMessage(new NotesRefreshEvent());
                 }
             } else if (cmd is PartCommand partCommand) {
                 if (cmd is ReplacePartCommand replacePart) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -23,6 +23,7 @@ using static ReactiveUI.Primitives.SubscribeExtensions;
 
 namespace OpenUtau.App.ViewModels {
     public class NotesRefreshEvent { }
+    public class RealCurveRefreshEvent { }
     public class NotesSelectionEvent {
         public readonly UNote[] selectedNotes;
         public readonly UNote[] tempSelectedNotes;
@@ -1101,7 +1102,9 @@ namespace OpenUtau.App.ViewModels {
                 } else if (notif is PartRenderedNotification && notif.part == Part) {
                     MessageBus.Current.SendMessage(new WaveformRefreshEvent());
                 } else if (notif is RealCurvesUpdatedNotification && notif.part == Part) {
-                    MessageBus.Current.SendMessage(new NotesRefreshEvent());
+                    MessageBus.Current.SendMessage(new RealCurveRefreshEvent());
+                } else if (notif is RealCurveCoverageNotification && notif.part == Part) {
+                    MessageBus.Current.SendMessage(new RealCurveRefreshEvent());
                 }
             } else if (cmd is PartCommand partCommand) {
                 if (cmd is ReplacePartCommand replacePart) {


### PR DESCRIPTION
  本改动解决的问题是：DiffSinger 等支持 real curve 的 renderer 在渲染完成后，UCurve.realXs / realYs 不会自动更新，用户必须手动点击“Refresh Real Curves”批量编辑功能才能看到最新 variance/real curve。现在每个
  phrase 渲染完成后会自动尝试刷新对应 phrase 的 real curve，减少手动操作。

  改动逻辑

  新增了 phrase 级渲染完成 API：

  - PhraseRenderedNotification
  - RealCurvesUpdatedNotification

  渲染流程变为：

  1. RenderEngine 完成单个 phrase 渲染。
  2. 发送 PhraseRenderedNotification，供后续渲染进度类功能复用。
  3. 如果 renderer 支持 SupportsRealCurve，尝试调用 LoadRenderedRealCurves(phrase)。
  4. RealCurveUpdater 将结果转换成 part-local tick，并只替换该 phrase 对应的 real curve 区间。
  5. DocManager 在 UI 线程应用 realXs / realYs 更新。
  6. NotesViewModel 收到更新通知后发送 NotesRefreshEvent，表达曲线画布自动重绘。

  自动刷新失败时不会影响渲染；异常只被跳过/记录，不弹窗、不打断音频渲染。

  保留的行为

  - 原来的 RefreshRealCurves 按钮/批量编辑入口保留。
  - 原按钮仍可作为 fallback 手动刷新全部 real curve。
  - 未修改 DiffSinger ONNX 输入构建。
  - 未引入第一阶段插队调度。
  - 未实现第三阶段 variance 对 pitch 编辑范围的局部 patch。

  文件变更

  OpenUtau.Core/Commands/Notifications.cs
  新增 PhraseRenderedNotification 和 RealCurvesUpdatedNotification。

  OpenUtau.Core/Render/RenderEngine.cs
  phrase 渲染完成后发送 phrase 通知，并尝试生成 real curve 更新。

  OpenUtau.Core/Render/RealCurveUpdater.cs
  新增 real curve 转换和局部替换逻辑，包含 phrase hash stale-check。

  OpenUtau.Core/DocManager.cs
  处理 RealCurvesUpdatedNotification，在发布通知前应用 real curve 数据。

  OpenUtau/ViewModels/NotesViewModel.cs
  收到 real curve 更新后触发表达曲线重绘。

  OpenUtau.Core/Properties/AssemblyInfo.cs
  开放 internal 给测试项目。

  OpenUtau.Test/Core/Render/RealCurveUpdaterTest.cs
  测试坐标转换、局部替换、stale hash 跳过逻辑。