### PR TITLE
Add DiffSinger variance local pitch patch

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -35,6 +35,7 @@ namespace OpenUtau.Core.DiffSinger{
         IG2p g2p;
         float frameMs;
         DiffSingerSpeakerEmbedManager speakerEmbedManager;
+        readonly Dictionary<ulong, VariancePatchState> variancePatchStates = new Dictionary<ulong, VariancePatchState>();
 
         public float FrameMs => frameMs;
 
@@ -195,34 +196,41 @@ namespace OpenUtau.Core.DiffSinger{
             pitch = pitch.Zip(toneShift, (x, d) => x + d).ToArray();
 
             var varianceInputs = new List<NamedOnnxValue>();
-            varianceInputs.Add(NamedOnnxValue.CreateFromTensor("encoder_out", encoder_out));
-            varianceInputs.Add(NamedOnnxValue.CreateFromTensor("ph_dur",
+            var variancePatchInputs = new List<NamedOnnxValue>();
+            void AddVarianceInput(NamedOnnxValue input, bool includeInPatchKey = true) {
+                varianceInputs.Add(input);
+                if (includeInPatchKey) {
+                    variancePatchInputs.Add(input);
+                }
+            }
+            AddVarianceInput(NamedOnnxValue.CreateFromTensor("encoder_out", encoder_out));
+            AddVarianceInput(NamedOnnxValue.CreateFromTensor("ph_dur",
                 new DenseTensor<Int64>(ph_dur.Select(x=>(Int64)x).ToArray(), new int[] { ph_dur.Length }, false)
                 .Reshape(new int[] { 1, ph_dur.Length })));
-            varianceInputs.Add(NamedOnnxValue.CreateFromTensor("pitch",
+            AddVarianceInput(NamedOnnxValue.CreateFromTensor("pitch",
                 new DenseTensor<float>(pitch, new int[] { pitch.Length }, false)
-                .Reshape(new int[] { 1, totalFrames })));
+                .Reshape(new int[] { 1, totalFrames })), includeInPatchKey: false);
             if (dsConfig.predict_energy) {
                 var energy = Enumerable.Repeat(0f, totalFrames).ToArray();
-                varianceInputs.Add(NamedOnnxValue.CreateFromTensor("energy",
+                AddVarianceInput(NamedOnnxValue.CreateFromTensor("energy",
                     new DenseTensor<float>(energy, new int[] { energy.Length }, false)
                         .Reshape(new int[] { 1, totalFrames })));
             }
             if (dsConfig.predict_breathiness) {
                 var breathiness = Enumerable.Repeat(0f, totalFrames).ToArray();
-                varianceInputs.Add(NamedOnnxValue.CreateFromTensor("breathiness",
+                AddVarianceInput(NamedOnnxValue.CreateFromTensor("breathiness",
                     new DenseTensor<float>(breathiness, new int[] { breathiness.Length }, false)
                         .Reshape(new int[] { 1, totalFrames })));
             }
             if (dsConfig.predict_voicing) {
                 var voicing = Enumerable.Repeat(0f, totalFrames).ToArray();
-                varianceInputs.Add(NamedOnnxValue.CreateFromTensor("voicing",
+                AddVarianceInput(NamedOnnxValue.CreateFromTensor("voicing",
                     new DenseTensor<float>(voicing, new int[] { voicing.Length }, false)
                         .Reshape(new int[] { 1, totalFrames })));
             }
             if (dsConfig.predict_tension) {
                 var tension = Enumerable.Repeat(0f, totalFrames).ToArray();
-                varianceInputs.Add(NamedOnnxValue.CreateFromTensor("tension",
+                AddVarianceInput(NamedOnnxValue.CreateFromTensor("tension",
                     new DenseTensor<float>(tension, new int[] { tension.Length }, false)
                         .Reshape(new int[] { 1, totalFrames })));
             }
@@ -234,12 +242,12 @@ namespace OpenUtau.Core.DiffSinger{
                 dsConfig.predict_tension,
             }.Sum(Convert.ToInt32);
             var retake = Enumerable.Repeat(true, totalFrames * numVariances).ToArray();
-            varianceInputs.Add(NamedOnnxValue.CreateFromTensor("retake",
+            AddVarianceInput(NamedOnnxValue.CreateFromTensor("retake",
                 new DenseTensor<bool>(retake, new int[] { retake.Length }, false)
                 .Reshape(new int[] { 1, totalFrames, numVariances })));
             var steps = Preferences.Default.DiffSingerStepsVariance;
             if (dsConfig.useContinuousAcceleration) {
-                varianceInputs.Add(NamedOnnxValue.CreateFromTensor("steps",
+                AddVarianceInput(NamedOnnxValue.CreateFromTensor("steps",
                     new DenseTensor<long>(new long[] { steps }, new int[] { 1 }, false)));
             } else {
                 // find a largest integer speedup that are less than 1000 / steps and is a factor of 1000
@@ -247,14 +255,20 @@ namespace OpenUtau.Core.DiffSinger{
                 while (1000 % speedup != 0 && speedup > 1) {
                     speedup--;
                 }
-                varianceInputs.Add(NamedOnnxValue.CreateFromTensor("speedup",
+                AddVarianceInput(NamedOnnxValue.CreateFromTensor("speedup",
                     new DenseTensor<long>(new long[] { speedup }, new int[] { 1 },false)));
             }
             //Speaker
             if(dsConfig.speakers != null) {
                 var speakerEmbedManager = getSpeakerEmbedManager();
                 var spkEmbedTensor = speakerEmbedManager.PhraseSpeakerEmbedByFrame(phrase, ph_dur, frameMs, totalFrames, headFrames, tailFrames);
-                varianceInputs.Add(NamedOnnxValue.CreateFromTensor("spk_embed", spkEmbedTensor));
+                AddVarianceInput(NamedOnnxValue.CreateFromTensor("spk_embed", spkEmbedTensor));
+            }
+            ulong? variancePatchKey = null;
+            if (Preferences.Default.DiffSingerTensorCache &&
+                Preferences.Default.DiffSingerVarianceLocalPitchPatch) {
+                var baseHash = new DiffSingerCache(varianceHash, variancePatchInputs).Hash;
+                variancePatchKey = DiffSingerVariancePatch.BuildStateKey(baseHash, phrase.position, phrase.end);
             }
             Onnx.VerifyInputNames(varianceModel, varianceInputs);
             var varianceCache = Preferences.Default.DiffSingerTensorCache
@@ -290,7 +304,7 @@ namespace OpenUtau.Core.DiffSinger{
                     .First()
                     .AsTensor<float>()
                 : null;
-            return new VarianceResult{
+            var result = new VarianceResult{
                 energy = energy_pred?.ToArray(),
                 breathiness = breathiness_pred?.ToArray(),
                 voicing = voicing_pred?.ToArray(),
@@ -300,6 +314,23 @@ namespace OpenUtau.Core.DiffSinger{
                 tailFrames = tailFrames,
                 totalFrames = totalFrames,
             };
+            if (variancePatchKey.HasValue) {
+                result = ApplyVariancePatch(variancePatchKey.Value, pitch, result);
+            }
+            return result;
+        }
+
+        VarianceResult ApplyVariancePatch(ulong patchKey, float[] pitch, VarianceResult result) {
+            try {
+                variancePatchStates.TryGetValue(patchKey, out var previous);
+                var merged = DiffSingerVariancePatch.Merge(previous, pitch, result);
+                variancePatchStates[patchKey] = new VariancePatchState(pitch, merged);
+                return merged;
+            } catch (Exception e) {
+                Log.Warning(e, "Failed to apply DiffSinger variance local pitch patch.");
+                variancePatchStates[patchKey] = new VariancePatchState(pitch, result);
+                return result;
+            }
         }
 
         private bool disposedValue;

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariancePatch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariancePatch.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenUtau.Core.DiffSinger {
+    internal readonly struct VariancePatchRange {
+        public readonly int start;
+        public readonly int end;
+
+        public VariancePatchRange(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+    }
+
+    internal class VariancePatchState {
+        public readonly float[] pitch;
+        public readonly VarianceResult result;
+
+        public VariancePatchState(float[] pitch, VarianceResult result) {
+            this.pitch = pitch.ToArray();
+            this.result = DiffSingerVariancePatch.CloneResult(result);
+        }
+    }
+
+    internal static class DiffSingerVariancePatch {
+        const float PitchEpsilon = 1e-4f;
+        const float CrossfadeMs = 50f;
+
+        public static ulong BuildStateKey(ulong baseHash, int phrasePosition, int phraseEnd) {
+            unchecked {
+                ulong hash = baseHash;
+                hash = (hash ^ (uint)phrasePosition) * 1099511628211UL;
+                hash = (hash ^ (uint)phraseEnd) * 1099511628211UL;
+                return hash;
+            }
+        }
+
+        public static VarianceResult Merge(
+            VariancePatchState? previous,
+            float[] currentPitch,
+            VarianceResult current) {
+            if (previous == null ||
+                previous.pitch.Length != currentPitch.Length ||
+                !IsMetadataCompatible(previous.result, current)) {
+                return CloneResult(current);
+            }
+            var ranges = FindChangedRanges(previous.pitch, currentPitch, PitchEpsilon);
+            if (ranges.Count == 0) {
+                return CloneResult(previous.result);
+            }
+            int crossfadeFrames = Math.Clamp((int)Math.Round(CrossfadeMs / current.frameMs), 1, 20);
+            var weights = BuildWeights(currentPitch.Length, ranges, crossfadeFrames);
+            return new VarianceResult {
+                energy = Blend(previous.result.energy, current.energy, weights),
+                breathiness = Blend(previous.result.breathiness, current.breathiness, weights),
+                voicing = Blend(previous.result.voicing, current.voicing, weights),
+                tension = Blend(previous.result.tension, current.tension, weights),
+                frameMs = current.frameMs,
+                headFrames = current.headFrames,
+                tailFrames = current.tailFrames,
+                totalFrames = current.totalFrames,
+            };
+        }
+
+        internal static List<VariancePatchRange> FindChangedRanges(
+            IReadOnlyList<float> previousPitch,
+            IReadOnlyList<float> currentPitch,
+            float epsilon) {
+            var ranges = new List<VariancePatchRange>();
+            int length = Math.Min(previousPitch.Count, currentPitch.Count);
+            int start = -1;
+            for (int i = 0; i < length; ++i) {
+                bool changed = Math.Abs(previousPitch[i] - currentPitch[i]) > epsilon;
+                if (changed && start < 0) {
+                    start = i;
+                } else if (!changed && start >= 0) {
+                    ranges.Add(new VariancePatchRange(start, i));
+                    start = -1;
+                }
+            }
+            if (start >= 0) {
+                ranges.Add(new VariancePatchRange(start, length));
+            }
+            return ranges;
+        }
+
+        internal static float[] BuildWeights(int length, IReadOnlyList<VariancePatchRange> ranges, int crossfadeFrames) {
+            var weights = new float[length];
+            foreach (var range in ranges) {
+                int start = Math.Clamp(range.start, 0, length);
+                int end = Math.Clamp(range.end, start, length);
+                for (int i = start; i < end; ++i) {
+                    weights[i] = 1f;
+                }
+                int leftStart = Math.Max(0, start - crossfadeFrames);
+                int leftLength = start - leftStart;
+                for (int i = leftStart; i < start; ++i) {
+                    float weight = (float)(i - leftStart + 1) / (leftLength + 1);
+                    weights[i] = Math.Max(weights[i], weight);
+                }
+                int rightEnd = Math.Min(length, end + crossfadeFrames);
+                int rightLength = rightEnd - end;
+                for (int i = end; i < rightEnd; ++i) {
+                    float weight = 1f - (float)(i - end + 1) / (rightLength + 1);
+                    weights[i] = Math.Max(weights[i], weight);
+                }
+            }
+            return weights;
+        }
+
+        internal static float[]? Blend(float[]? previous, float[]? current, IReadOnlyList<float> weights) {
+            if (previous == null || current == null || previous.Length != current.Length || previous.Length != weights.Count) {
+                return current?.ToArray();
+            }
+            var result = new float[current.Length];
+            for (int i = 0; i < result.Length; ++i) {
+                result[i] = previous[i] * (1f - weights[i]) + current[i] * weights[i];
+            }
+            return result;
+        }
+
+        internal static VarianceResult CloneResult(VarianceResult result) {
+            return new VarianceResult {
+                energy = result.energy?.ToArray(),
+                breathiness = result.breathiness?.ToArray(),
+                voicing = result.voicing?.ToArray(),
+                tension = result.tension?.ToArray(),
+                frameMs = result.frameMs,
+                headFrames = result.headFrames,
+                tailFrames = result.tailFrames,
+                totalFrames = result.totalFrames,
+            };
+        }
+
+        static bool IsMetadataCompatible(VarianceResult previous, VarianceResult current) {
+            return previous.totalFrames == current.totalFrames &&
+                previous.headFrames == current.headFrames &&
+                previous.tailFrames == current.tailFrames &&
+                Math.Abs(previous.frameMs - current.frameMs) < 1e-4f;
+        }
+    }
+}

--- a/OpenUtau.Core/Properties/AssemblyInfo.cs
+++ b/OpenUtau.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpenUtau.Test")]

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -165,6 +165,7 @@ namespace OpenUtau.Core.Util {
             public int DiffSingerStepsVariance = 20;
             public int DiffSingerStepsPitch = 10;
             public bool DiffSingerTensorCache = true;
+            public bool DiffSingerVarianceLocalPitchPatch = false;
             public bool DiffSingerLangCodeHide = false;
             public bool SkipRenderingMutedTracks = false;
             public string Language = string.Empty;

--- a/OpenUtau.Test/Core/DiffSinger/DiffSingerVariancePatchTest.cs
+++ b/OpenUtau.Test/Core/DiffSinger/DiffSingerVariancePatchTest.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using OpenUtau.Core.DiffSinger;
+using Xunit;
+
+namespace OpenUtau.Core {
+    public class DiffSingerVariancePatchTest {
+        [Fact]
+        public void FindChangedRangesGroupsContiguousPitchChanges() {
+            var previous = new[] { 1f, 1f, 1f, 1f, 1f, 1f };
+            var current = new[] { 1f, 2f, 2f, 1f, 2f, 1f };
+
+            var ranges = DiffSingerVariancePatch.FindChangedRanges(previous, current, 1e-4f);
+
+            Assert.Equal(2, ranges.Count);
+            Assert.Equal(1, ranges[0].start);
+            Assert.Equal(3, ranges[0].end);
+            Assert.Equal(4, ranges[1].start);
+            Assert.Equal(5, ranges[1].end);
+        }
+
+        [Fact]
+        public void MergeKeepsPreviousResultWhenPitchDoesNotChange() {
+            var previousResult = Result(new[] { 1f, 2f, 3f });
+            var currentResult = Result(new[] { 10f, 20f, 30f });
+            var previous = new VariancePatchState(new[] { 60f, 61f, 62f }, previousResult);
+
+            var merged = DiffSingerVariancePatch.Merge(previous, new[] { 60f, 61f, 62f }, currentResult);
+
+            Assert.Equal(previousResult.energy!, merged.energy!);
+        }
+
+        [Fact]
+        public void MergeBlendsOnlyChangedPitchRange() {
+            var previousResult = Result(Enumerable.Repeat(0f, 6).ToArray(), frameMs: 50);
+            var currentResult = Result(Enumerable.Repeat(10f, 6).ToArray(), frameMs: 50);
+            var previous = new VariancePatchState(
+                new[] { 60f, 60f, 60f, 60f, 60f, 60f },
+                previousResult);
+
+            var merged = DiffSingerVariancePatch.Merge(
+                previous,
+                new[] { 60f, 60f, 61f, 61f, 60f, 60f },
+                currentResult);
+
+            Assert.Equal(new[] { 0f, 5f, 10f, 10f, 5f, 0f }, merged.energy!);
+        }
+
+        [Fact]
+        public void MergeFallsBackToCurrentResultWhenMetadataChanges() {
+            var previousResult = Result(new[] { 1f, 2f, 3f }, frameMs: 50);
+            var currentResult = Result(new[] { 10f, 20f, 30f }, frameMs: 60);
+            var previous = new VariancePatchState(new[] { 60f, 61f, 62f }, previousResult);
+
+            var merged = DiffSingerVariancePatch.Merge(previous, new[] { 60f, 62f, 62f }, currentResult);
+
+            Assert.Equal(currentResult.energy!, merged.energy!);
+        }
+
+        static VarianceResult Result(float[] energy, float frameMs = 50) {
+            return new VarianceResult {
+                energy = energy,
+                frameMs = frameMs,
+                headFrames = 1,
+                tailFrames = 1,
+                totalFrames = energy.Length,
+            };
+        }
+    }
+}

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -627,6 +627,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>
+  <system:String x:Key="prefs.rendering.diffsingervariancelocalpitchpatch">DiffSinger Local Variance Update for Pitch Edits</system:String>
   <system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>
   <system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -120,6 +120,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int DiffSingerStepsPitch { get; set; }
         [Reactive] public double DiffSingerDepth { get; set; }
         [Reactive] public bool DiffSingerTensorCache { get; set; }
+        [Reactive] public bool DiffSingerVarianceLocalPitchPatch { get; set; }
         [Reactive] public bool DiffSingerLangCodeHide { get; set; }
 
         // Advanced
@@ -174,6 +175,7 @@ namespace OpenUtau.App.ViewModels {
             DiffSingerStepsVariance = Preferences.Default.DiffSingerStepsVariance;
             DiffSingerStepsPitch = Preferences.Default.DiffSingerStepsPitch;
             DiffSingerTensorCache = Preferences.Default.DiffSingerTensorCache;
+            DiffSingerVarianceLocalPitchPatch = Preferences.Default.DiffSingerVarianceLocalPitchPatch;
             DiffSingerLangCodeHide = Preferences.Default.DiffSingerLangCodeHide;
             SkipRenderingMutedTracks = Preferences.Default.SkipRenderingMutedTracks;
             ThemeName = Preferences.Default.ThemeName;
@@ -391,6 +393,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.DiffSingerTensorCache)
                 .Subscribe(useCache => {
                     Preferences.Default.DiffSingerTensorCache = useCache;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.DiffSingerVarianceLocalPitchPatch)
+                .Subscribe(useLocalPatch => {
+                    Preferences.Default.DiffSingerVarianceLocalPitchPatch = useLocalPatch;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.DiffSingerLangCodeHide)

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -326,6 +326,10 @@
             <ToggleSwitch IsChecked="{Binding DiffSingerTensorCache}" />
           </Grid>
           <Grid Margin="0,5,0,0">
+            <TextBlock Text="{DynamicResource prefs.rendering.diffsingervariancelocalpitchpatch}" HorizontalAlignment="Left" />
+            <ToggleSwitch IsChecked="{Binding DiffSingerVarianceLocalPitchPatch}" IsEnabled="{Binding DiffSingerTensorCache}" />
+          </Grid>
+          <Grid Margin="0,5,0,0">
             <TextBlock Text="{DynamicResource prefs.appearance.diffsingerlangcodehide}" HorizontalAlignment="Left" />
             <ToggleSwitch IsChecked="{Binding DiffSingerLangCodeHide}" />
           </Grid>


### PR DESCRIPTION
  解决的问题

  原始行为中，用户修改 pitch 后，DiffSinger variance model 会重新生成整段 variance 曲线。由于 variance model 输出存在一定随机性或全局联动，未被用户修改的 pitch 区域也可能发生变化，这会偏离用户预期。

  本改动提供一个默认关闭的新选项：只在用户开启后，对 pitch 发生变化的区域应用新的 variance 输出，未变化区域保留上一次结果。

  核心逻辑

  - 新增 DiffSinger 专用的局部 patch 逻辑。
  - 通过缓存前后两次 variance model 的 pitch 输入数组，比较得到 pitch 发生变化的帧范围。
  - variance model 仍然完整运行一次，不修改 ONNX 输入构建，也不使用无效的 retake 输入。
  - 输出阶段只把变化范围附近的新 variance 曲线拼接进旧结果。
  - 拼接边界使用短交叉淡化，避免明显断点。
  - 如果没有历史状态、长度/metadata 不一致、合并异常等情况，自动 fallback 到原始完整 variance 结果。

  开关与约束

  - 新选项默认关闭：DiffSingerVarianceLocalPitchPatch = false
  - 该功能依赖 DiffSinger Tensor Cache。
  - 当 DiffSingerTensorCache 未开启时：
      - UI 中该选项不可用。
      - 运行时也不会启用局部 patch。

  - 这样可以避免在无缓存状态下引入不稳定行为。

  改动文件

  - OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
      - 接入局部 variance patch。
      - 构建不含 pitch 的 patch key。
      - 在 variance 输出后执行局部合并。
      - 保留失败 fallback。

  - OpenUtau.Core/DiffSinger/DiffSingerVariancePatch.cs
      - 新增 DiffSinger variance 局部合并 helper。
      - 包含 pitch 差异范围检测、权重生成、交叉淡化、结果 clone/fallback。

  - OpenUtau.Core/Util/Preferences.cs
      - 新增默认关闭的偏好项。

  - OpenUtau/ViewModels/PreferencesViewModel.cs
      - 新增偏好项绑定与保存逻辑。

  - OpenUtau/Views/PreferencesDialog.axaml
      - 在 DiffSinger 设置区新增开关。
      - 开关受 DiffSingerTensorCache 启用状态控制。

  - OpenUtau/Strings/Strings.axaml
      - 新增英文资源键。
      - 中文资源因编码环境不确定，本次未修改，后续可补。

  - OpenUtau.Core/Properties/AssemblyInfo.cs
      - 新增测试程序集 internal 可见性，保持 patch helper 不暴露为公开 API。

  - OpenUtau.Test/Core/DiffSinger/DiffSingerVariancePatchTest.cs
      - 覆盖 pitch 改动范围检测、无 pitch 改动保留旧结果、局部 blend、metadata 不一致 fallback。