### PR TITLE
Log unhandled exceptions

### DIFF
--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -46,6 +46,8 @@ namespace OpenUtau.Core {
 
         public void Initialize(Thread mainThread, TaskScheduler mainScheduler) {
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler((sender, args) => {
+                var ex = args.ExceptionObject as Exception;
+                Log.Error(ex, "Unhandled exception");
                 CrashSave();
             });
             SearchAllPlugins();


### PR DESCRIPTION
During testing, I confirmed that unexpected exceptions in the main window can be logged. However, it is highly likely that errors occurring before startup is complete will not be captured.