### PR TITLE
Cap DiffSinger vocoder num_mel_bins at 255

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -149,6 +149,19 @@ namespace OpenUtau.Core.DiffSinger {
 
             var vocoder = singer.getVocoder();
             //mel specification validity checks
+            //num_mel_bins must be a sane vocoder value. This is a hard-coded
+            //upper bound (see DsVocoderConfig.MaxMelBins): voicebank authors
+            //cannot override it. Not checking this lets a malformed vocoder
+            //smuggle in a non-vocoder onnx model that requires an unusually
+            //large mel tensor for inputs.
+            if (vocoder.num_mel_bins < 1 || vocoder.num_mel_bins > DsVocoderConfig.MaxMelBins) {
+                throw new Exception(
+                    $"Vocoder num_mel_bins must be between 1 and {DsVocoderConfig.MaxMelBins}, but got {vocoder.num_mel_bins}");
+            }
+            if (singer.dsConfig.num_mel_bins < 1 || singer.dsConfig.num_mel_bins > DsVocoderConfig.MaxMelBins) {
+                throw new Exception(
+                    $"Acoustic model num_mel_bins must be between 1 and {DsVocoderConfig.MaxMelBins}, but got {singer.dsConfig.num_mel_bins}");
+            }
             //mel base must be 10 or e
             if (vocoder.mel_base != "10" && vocoder.mel_base != "e") {
                 throw new Exception(

--- a/OpenUtau.Core/DiffSinger/DiffSingerVocoder.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVocoder.cs
@@ -38,6 +38,15 @@ namespace OpenUtau.Core.DiffSinger {
                     true,
                     new string[] { Path.GetFileName(location), "https://github.com/xunmengshe/OpenUtau/wiki/Vocoders" });
             }
+            if (config.num_mel_bins < 1 || config.num_mel_bins > DsVocoderConfig.MaxMelBins) {
+                throw new MessageCustomizableException(
+                    $"Invalid num_mel_bins in \"{Path.Combine(location, "vocoder.yaml")}\"",
+                    $"<translate:errors.diffsinger.downloadvocoder>",
+                    new Exception(
+                        $"num_mel_bins must be between 1 and {DsVocoderConfig.MaxMelBins}, got {config.num_mel_bins}"),
+                    true,
+                    new string[] { Path.GetFileName(location), "https://github.com/xunmengshe/OpenUtau/wiki/Vocoders" });
+            }
             hash = XXH64.DigestOf(model);
             session = Onnx.getInferenceSession(model);
         }
@@ -66,6 +75,15 @@ namespace OpenUtau.Core.DiffSinger {
 
     [Serializable]
     public class DsVocoderConfig {
+        // Hard cap on the number of mel bins a vocoder may declare. DiffSinger
+        // vocoders in the wild use 80, 128 or similar values; values larger than
+        // this are treated as invalid so that vocoders cannot smuggle through
+        // onnx models that are actually something else (e.g. a full DiffSinger
+        // acoustic model masquerading as a vocoder). Kept as a hard-coded
+        // constant rather than a configurable field on purpose: lowering it
+        // here is a deliberate code change, not something the voicebank author
+        // can override.
+        public const int MaxMelBins = 255;
         public string name = "vocoder";
         public string model = "model.onnx";
         public int sample_rate = 44100;


### PR DESCRIPTION
## Problem

The DiffSinger vocoder currently loads any onnx model that exposes a `mel` input plus optional `f0`, with no bounds checking on its declared configuration. As a result, a malformed voicebank can ship a vocoder slot that points at a non-vocoder onnx model (for example, a DiffSinger acoustic model masquerading as a vocoder, or some other graph that requires an extra-large mel tensor to drive its internal logic).

Real DiffSinger vocoders in the wild use 80 or 128 mel bins.

## Fix

Add a hard-coded upper bound `DsVocoderConfig.MaxMelBins = 255` and reject both the vocoder and the acoustic-model dsconfig when `num_mel_bins` falls outside `[1, 255]`.

The check fires in two places:

- `DsVocoder` constructor: rejects the voicebank at load time with the same `MessageCustomizableException` other vocoder load failures use, so the entry never reaches the onnx session.
- `DiffSingerRenderer.InvokeDiffsinger`: redundant runtime check on both the vocoder and the acoustic model cfg, alongside the existing `mel_base` / `mel_scale` validations, as defense in depth.

The threshold is intentionally hard-coded rather than a yaml field: lowering it is a deliberate code change, not something a voicebank author can override.