### PR TITLE
Fix out of index error when closing project and create new one

### DIFF
--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -43,9 +43,9 @@ namespace OpenUtau.App.ViewModels {
                 string? targetId = PhonemizerOverride;
                 bool isDefault = string.IsNullOrEmpty(targetId);
                 if (isDefault) {
-                    if (Part == null) return "Default";
+                    if (Part == null || Part.trackNo >= DocManager.Inst.Project.tracks.Count) return "Default";
                     var track = DocManager.Inst.Project.tracks[Part.trackNo];
-                    string trackId = track.Phonemizer.GetType().FullName ?? "";
+                    string trackId = track.Phonemizer.GetType().FullName ?? string.Empty;
                     return $"Default ({GetPhonemizerDisplayName(trackId)})";
                 }
                 var factory = OpenUtau.Api.PhonemizerFactory.GetAll().FirstOrDefault(f => 


### PR DESCRIPTION
I fixed an issue where, if there were multiple tracks in a project that was already open, closing that project and attempting to create a new one would result in an error because there weren't enough tracks available temporarily.