### PR TITLE
Bug fixes for envelopes, including crashes

### DIFF
--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -542,7 +542,7 @@ namespace OpenUtau.Core {
             }
             max = Math.Max(0, max);
             double min = -phoneme.autoPreutter;
-            newDelta = (float)Math.Clamp(delta, min, max);
+            newDelta = (float)Math.Max(Math.Min(delta, max), min);
         }
         public override void Execute() {
             var o = note.GetPhonemeOverride(index);
@@ -574,7 +574,7 @@ namespace OpenUtau.Core {
             double overlap = phoneme.preutter - phoneme.autoOverlap;
             double max = phoneme.envelope.data[3].X + overlap;
             double min = -phoneme.Prev?.DurationMs + 5 + overlap ?? 0;
-            newDelta = (float)Math.Clamp(delta, min, max);
+            newDelta = (float)Math.Max(Math.Min(delta, max), min);
         }
         public override void Execute() {
             var o = note.GetPhonemeOverride(index);
@@ -605,7 +605,7 @@ namespace OpenUtau.Core {
 
             double max = phoneme.autoPreutter - phoneme.GetFadeIn() + phoneme.envelope.data[3].X;
             double min = -phoneme.GetFadeIn() + 5;
-            newDelta = (float)Math.Clamp(delta, min, max);
+            newDelta = (float)Math.Max(Math.Min(delta, max), min);
         }
         public override void Execute() {
             var o = note.GetPhonemeOverride(index);
@@ -637,7 +637,7 @@ namespace OpenUtau.Core {
             var p3x = phoneme.envelope.data[4].X - phoneme.GetFadeOut();
             double max = p3x - phoneme.envelope.data[2].X;
             double min = -phoneme.GetFadeOut() + 5;
-            newDelta = (float)Math.Clamp(delta, min, max);
+            newDelta = (float)Math.Max(Math.Min(delta, max), min);
         }
         public override void Execute() {
             var o = note.GetPhonemeOverride(index);

--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -652,7 +652,7 @@ namespace OpenUtau.Core {
 
     public class ClearPhonemeTimingCommand : NoteCommand {
         readonly UNote note;
-        readonly Tuple<int, int?, float?, float?>[] oldValues;
+        readonly Tuple<int, int?, float?, float?, float?, float?>[] oldValues;
         public override ValidateOptions ValidateOptions => new ValidateOptions {
             SkipTiming = true,
             Part = Part,
@@ -661,7 +661,7 @@ namespace OpenUtau.Core {
         public ClearPhonemeTimingCommand(UVoicePart part, UNote note) : base(part, note) {
             this.note = note;
             oldValues = note.phonemeOverrides
-                .Select(o => Tuple.Create(o.index, o.offset, o.preutterDelta, o.overlapDelta))
+                .Select(o => Tuple.Create(o.index, o.offset, o.preutterDelta, o.overlapDelta, o.attackTimeDelta, o.releaseTimeDelta))
                 .ToArray();
         }
 
@@ -670,6 +670,8 @@ namespace OpenUtau.Core {
                 o.offset = null;
                 o.preutterDelta = null;
                 o.overlapDelta = null;
+                o.attackTimeDelta = null;
+                o.releaseTimeDelta = null;
             }
         }
         public override void Unexecute() {
@@ -678,6 +680,8 @@ namespace OpenUtau.Core {
                 o.offset = t.Item2;
                 o.preutterDelta = t.Item3;
                 o.overlapDelta = t.Item4;
+                o.attackTimeDelta = t.Item5;
+                o.releaseTimeDelta = t.Item6;
             }
         }
         public override string ToString() => "Clear phoneme timing";

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -313,10 +313,13 @@ namespace OpenUtau.Core.Editing {
             foreach (var note in notes) {
                 foreach (UPhoneme phoneme in part.phonemes) {
                     if (phoneme.Parent == note && phoneme.Prev != null && phoneme.PositionMs == phoneme.Prev.EndMs) {
-                        docManager.ExecuteCmd(new PhonemePreutterCommand(part, note, phoneme.index, phoneme, (float)phoneme.maxOtoPreutter));
-                        var overlap = phoneme.preutter * ratio;
-                        if (overlap > phoneme.autoOverlap) {
-                            docManager.ExecuteCmd(new PhonemeOverlapCommand(part, note, phoneme.index, phoneme, (float)(overlap - phoneme.autoOverlap)));
+                        var max = Math.Min(phoneme.maxOtoPreutter, phoneme.Prev.DurationMs - 5);
+                        docManager.ExecuteCmd(new PhonemePreutterCommand(part, note, phoneme.index, phoneme, (float)(max - phoneme.autoPreutter)));
+                        if (phoneme.autoOverlap > 0) {
+                            var overlap = max * ratio;
+                            if (overlap > phoneme.autoOverlap) {
+                                docManager.ExecuteCmd(new PhonemeOverlapCommand(part, note, phoneme.index, phoneme, (float)(overlap - phoneme.autoOverlap)));
+                            }
                         }
                     }
                 }

--- a/OpenUtau/Controls/PianoRoll.axaml.cs
+++ b/OpenUtau/Controls/PianoRoll.axaml.cs
@@ -1258,8 +1258,7 @@ namespace OpenUtau.App.Controls {
                 return;
             }
             var hitInfo = ViewModel.NotesViewModel.HitTest.HitTestPhoneme(point.Position);
-            var adjacent = hitInfo.phoneme != null && hitInfo.phoneme.Next != null && hitInfo.phoneme.Next.adjacent;
-            if (hitInfo.hitPosition || hitInfo.hitPreutter || (hitInfo.hitOverlap && adjacent) || hitInfo.hitAttackTime || hitInfo.hitReleaseTime) {
+            if (hitInfo.hitPosition || hitInfo.hitPreutter || hitInfo.hitOverlap || hitInfo.hitAttackTime || hitInfo.hitReleaseTime) {
                 Cursor = ViewConstants.cursorSizeWE;
                 ViewModel.MouseoverPhoneme(null);
                 return;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -482,7 +482,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.all">Reset notes to default</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.allparameters">Reset all parameters</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.exps">Reset all expressions</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">Reset phoneme timings</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">Reset phoneme timings and envelopes</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">Reset pitch bends</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.vibratos">Reset vibratos</system:String>
   <system:String x:Key="pianoroll.menu.part">Part</system:String>

--- a/OpenUtau/ViewModels/NotesViewModelHitTest.cs
+++ b/OpenUtau/ViewModels/NotesViewModelHitTest.cs
@@ -386,6 +386,7 @@ namespace OpenUtau.App.ViewModels {
                     return result;
                 }
                 // p4 Overlap
+                if (phoneme.Next == null || phoneme.Next.position != phoneme.End) continue;
                 int p4Tick = timeAxis.MsPosToTickPos(phoneme.PositionMs + phoneme.envelope.data[4].X) - viewModel.Part.position;
                 double p4x = viewModel.TickToneToPoint(p4Tick, 0).X;
                 point = new Point(p4x, 60 - phoneme.envelope.data[4].Y * 0.24 - 1);


### PR DESCRIPTION
- Fixed an edge case where the editor would crash if unexpected values were present in the envelope parameters (such as when using an older version of ustx) and the user performed an invalid operation.
- Added attack/release time delta to the scope of the phoneme reset menu in case the envelope knobs overlap and the values cannot be reset.
- Fixed a minor bug in the “Lengthen Crossfades” feature and improved the logic
- Improved the hit-test logic for overlap points