### PR TITLE
Fix silent crash when dragging invalid .oudep file onto window

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -986,7 +986,14 @@ namespace OpenUtau.App.Views {
                     ThemeManager.GetString("dialogs.installdependency.caption"),
                     MessageBox.MessageBoxButtons.OkCancel);
                 if (result == MessageBox.MessageBoxResult.Ok) {
-                    await PackageManager.Inst.InstallFromFileAsync(file);
+                    try {
+                        await PackageManager.Inst.InstallFromFileAsync(file);
+                    } catch (Exception e) {
+                        Log.Error(e, $"Failed to install dependency {file}");
+                        _ = await MessageBox.ShowError(this, new MessageCustomizableException(
+                            $"Failed to install dependency {file}",
+                            $"<translate:errors.failed.installdependency>: {file}", e));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

Dragging an invalid or malformed `.oudep` file onto the OpenUtau window causes a silent crash (application exit without error message).

**Root cause:** The OUDEP drag-and-drop handler in `MainWindow.OnDrop` calls `PackageManager.InstallFromFileAsync` without any `try/catch`. Since async void methods have no caller to catch exceptions, any validation failure (missing `oudep.yaml`, empty `entrypoints`, missing `@class`, invalid package id) becomes an unhandled exception that terminates the process.

## Fix

Wrap the `InstallFromFileAsync` call in a `try/catch` block, log the error, and display a message box to the user — matching the same pattern already used in `OnMenuInstallSinger` (line 586-608 of the same file).

## Testing

- `dotnet build OpenUtau.sln` — 0 errors
- Before: dragging an invalid `.oudep` → immediate crash
- After: dragging an invalid `.oudep` → error message box with details, app continues running