### PR TITLE
Fix KoreanCVPhonemizer crashing when kocvS is null

### DIFF
--- a/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
@@ -192,6 +192,10 @@ namespace OpenUtau.Plugin.Builtin {
             string thisMidVowelHead;
             string thisMidVowelTail;
 
+            if (kocvS == null) {
+                return GenerateResult(FindInOto(notes[0].lyric, notes[0])); // If kocvS is null, return the original lyric's phoneme
+            }
+
             int totalDuration = notes.Sum(n => n.duration);
             Note note = notes[0];
             bool isItNeedsFrontCV;


### PR DESCRIPTION
I Fixed KoreanCVPhonemizer's bug: crashing when kocvS is null.
This bug is reproduced when using KOCV phonemizer to create an ustx, and open an ustx without that KOCV singer.