### PR TITLE
Improve envelope logic

### DIFF
--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -126,8 +126,6 @@ namespace OpenUtau.Core.Ustx {
                         if (autoPreutter - autoOverlap > prevDur * 0.5f) {
                             maxPreutter = prevDur * 0.5f / (autoPreutter - autoOverlap) * autoPreutter;
                         }
-                    } else { // Plosive consonants
-                        maxPreutter = Math.Min(maxPreutter, prevDur * 0.9);
                     }
                     maxPreutter = Math.Min(maxPreutter, prevDur);
                     if (Prev.preutter < 5) {
@@ -148,6 +146,10 @@ namespace OpenUtau.Core.Ustx {
             preutter = Math.Max(0, autoPreutter + (preutterDelta ?? 0));
             overlap = autoOverlap + (overlapDelta ?? 0);
             if (Prev != null) {
+                if (Prev.DurationMs - preutter < 5) {
+                    var minOverlap = 5 - (Prev.DurationMs - preutter);
+                    overlap = Math.Max(overlap, minOverlap);
+                }
                 Prev.tailIntrude = adjacent ? Math.Max(preutter, preutter - overlap) : 0;
                 Prev.tailOverlap = adjacent ? Math.Max(overlap, 0) : 0;
                 overlapped = adjacent && overlap > 0;


### PR DESCRIPTION
1. Revert preutter limit for VC
In ver 0.1.568, there were no restrictions on preutter.
Since PR #2236 introduced a 90% limit on preutter accidentally, so I'm reverting it back to 100% in this PR.

2. Ensure minimum length for VC envelope
Due to the change above, the length between point 2 (VC position) and point 4 (end of fade-out) becomes 0 when overlap is 0. I added a 5ms minimum to this section to prevent it from disappearing.