### PR TITLE
Fix Japanese Presamp alternate fallback

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -338,12 +338,7 @@ namespace OpenUtau.Plugin.Builtin {
             int shift = attr.toneShift ?? GetParentToneShift();
             int? alt = attr.alternate ?? GetParentAlternate();
 
-            var otos = new List<UOto>();
-            foreach (string test in input) {
-                if (singer.TryGetMappedOto(test + alt, note.tone + shift, color, out var otoCandidacy)) {
-                    otos.Add(otoCandidacy);
-                }
-            }
+            var otos = FindOtos(input, note.tone + shift, color, alt);
 
             if (otos.Count > 0) {
                 oto = otos.FirstOrDefault(oto => oto.IsColorMatch(color));
@@ -354,6 +349,19 @@ namespace OpenUtau.Plugin.Builtin {
             }
             return false;
         }
+
+        private List<UOto> FindOtos(List<string> input, int tone, string color, int? alt) {
+            var otos = new List<UOto>();
+            foreach (string test in input) {
+                if (alt != null && singer.TryGetMappedOto(test + alt, tone, color, out var otoAlt)) {
+                    otos.Add(otoAlt);
+                } else if (singer.TryGetMappedOto(test, tone, color, out var otoCandidacy)) {
+                    otos.Add(otoCandidacy);
+                }
+            }
+            return otos;
+        }
+
         private bool checkOtoUntilHit(List<string> input, Note note, int index, out UOto oto, out int? colorIndex) {
             oto = default;
             colorIndex = null;
@@ -363,12 +371,7 @@ namespace OpenUtau.Plugin.Builtin {
             int shift = attr.toneShift ?? attr0.toneShift ?? GetParentToneShift();
             int? alt = attr.alternate ?? GetParentAlternate();
 
-            var otos = new List<UOto>();
-            foreach (string test in input) {
-                if (singer.TryGetMappedOto(test + alt, note.tone + shift, color, out var otoCandidacy)) {
-                    otos.Add(otoCandidacy);
-                }
-            }
+            var otos = FindOtos(input, note.tone + shift, color, alt);
 
             if (otos.Count > 0) {
                 oto = otos.FirstOrDefault(oto => oto.IsColorMatch(color));


### PR DESCRIPTION
## Summary

- restore fallback to the unmodified alias when an alternate alias is unavailable
- keep track-level alternate, tone shift, and voice color resolution
- share the alias lookup logic between main and indexed phoneme paths

## Problem

After #2236, Japanese Presamp only queried `alias + alternate`. When that alias did not exist, it no longer retried the original alias. This breaks the intended fallback behavior and makes `JaPresampTest.ToneShiftAltTest` return the raw lyric `た` instead of `a た_VCV_G4`.

## Verification

- `dotnet test OpenUtau.Test --filter "FullyQualifiedName=OpenUtau.Plugins.JaPresampTest.ToneShiftAltTest"`
- `dotnet test OpenUtau.Test` (206 passed)

Fixes the test regression introduced by #2236.