### PR TITLE
Add GGML backend for GAME transcription

### DIFF
--- a/OpenUtau.Core/Analysis/Game.cs
+++ b/OpenUtau.Core/Analysis/Game.cs
@@ -72,7 +72,9 @@ public class Game : MidiExtractor<GameOptions> {
     /// Check if any GAME backend is installed (ONNX or GGML) without loading models.
     /// </summary>
     public static bool IsInstalled(string? location = null) {
-        return GameBackendFactory.IsAnyInstalled();
+        return location != null
+            ? GameOnnxBackend.IsInstalled(location)
+            : GameBackendFactory.IsAnyInstalled();
     }
 
     /// <summary>

--- a/OpenUtau.Core/Analysis/Game.cs
+++ b/OpenUtau.Core/Analysis/Game.cs
@@ -1,11 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.ML.OnnxRuntime;
-using Microsoft.ML.OnnxRuntime.Tensors;
 using OpenUtau.Core.Util;
 using Serilog;
 
@@ -39,37 +36,47 @@ public class GameOptions {
 
     /// <summary>Note presence threshold (--est-threshold). Default: 0.2</summary>
     public float ScoreThreshold { get; set; } = 0.2f;
+
+    /// <summary>
+    /// RNG seed driving the D3PM stochastic boundary removal. 0 = random per
+    /// inference. Honored by the GGML backend for reproducible runs; the ONNX
+    /// path reads its own RNG stream and ignores this.
+    /// </summary>
+    public ulong Seed { get; set; } = 0;
 }
 
+/// <summary>
+/// GAME MIDI extractor. This class is a thin <see cref="MidiExtractor{TOptions}"/>
+/// orchestrator over a pluggable <see cref="IGameBackend"/> (ONNX or GGML).
+/// Audio chunking, resampling, batching and note→tick mapping live in the base
+/// class; the inference contract is delegated entirely to the active backend,
+/// selected via <see cref="GameBackendFactory"/> from the user's preferences.
+/// </summary>
 public class Game : MidiExtractor<GameOptions> {
     private const string PackageId = "game";
     public const string DownloadUrl = "https://github.com/openvpi/GAME/releases/tag/oudep";
 
-    InferenceSession? encoderSession;
-    InferenceSession? segmenterSession;
-    InferenceSession? estimatorSession;
-    InferenceSession? bd2durSession;
-    RunOptions? runOptions;
-    bool sessionsLoaded = false;
+    readonly IGameBackend backend;
+    readonly GameConfig config;
     bool disposed = false;
     volatile bool stopping = false;
-    GameConfig config;
-    string Location;
 
     protected override int ExpectedSampleRate => config.SampleRate;
     public float Timestep => config.Timestep;
     public IReadOnlyDictionary<string, int>? Languages => config.Languages;
 
+    /// <summary>The resolved backend's display name (e.g. "GGML").</summary>
+    public string BackendName => backend.Name;
+
     /// <summary>
-    /// Check if GAME is installed (config.json is present) without loading models.
+    /// Check if any GAME backend is installed (ONNX or GGML) without loading models.
     /// </summary>
     public static bool IsInstalled(string? location = null) {
-        location ??= PackageManager.Inst.GetInstalledPath(PackageId);
-        return location != null && File.Exists(Path.Combine(location, "config.json"));
+        return GameBackendFactory.IsAnyInstalled();
     }
 
     /// <summary>
-    /// Load only the config (no ONNX sessions). Safe to call before showing a UI dialog.
+    /// Load only the config (no model sessions). Safe to call before showing a UI dialog.
     /// Throws if config.json is missing.
     /// </summary>
     public static GameConfig LoadConfig(string? modelPath = null) {
@@ -81,263 +88,46 @@ public class Game : MidiExtractor<GameOptions> {
     }
 
     /// <summary>
+    /// Create a GAME instance using the user's preferred backend.
     /// </summary>
     public Game() : this(null) { }
 
-    /// <summary>
-    /// Create GAME instance with specified model path and parameters.
-    /// Sessions are loaded lazily on first Transcribe call.
-    /// </summary>
-    /// <param name="location">Path to model directory, or null for default (Dependencies/game)</param>
+    /// <summary>Create a GAME instance with an explicit ONNX model directory override.</summary>
     public Game(string? location) {
-        Location = location ?? PackageManager.Inst.GetInstalledPath(PackageId)!;
-        Log.Information("GAME: Model location = {Location}", Location);
-        config = LoadConfig(location);
+        if (!string.IsNullOrEmpty(location) && GameOnnxBackend.IsInstalled(location)) {
+            config = LoadConfig(location);
+            backend = new GameOnnxBackend(config, location);
+        } else {
+            backend = GameBackendFactory.Create();
+            string cfgLocation = PackageManager.Inst.GetInstalledPath(PackageId);
+            config = cfgLocation != null
+                ? LoadConfig(cfgLocation)
+                : new GameConfig();
+        }
+        Log.Information("GAME: active backend = {Backend}", backend.Name);
     }
 
-    /// <summary>
-    /// Ensure ONNX sessions are loaded. Called lazily before inference.
-    /// </summary>
-    private void EnsureSessionsLoaded() {
-        if (sessionsLoaded) return;
-        if (stopping) {
-            throw new OperationCanceledException();
-        }
-        runOptions = new RunOptions();
-        if (stopping) {
-            runOptions.Terminate = true;
-            throw new OperationCanceledException();
-        }
-        encoderSession = CreateSession("encoder.onnx", OnnxRunnerChoice.CPUForCoreML);
-        segmenterSession = CreateSession("segmenter.onnx", OnnxRunnerChoice.Default);
-        estimatorSession = CreateSession("estimator.onnx", OnnxRunnerChoice.Default);
-        bd2durSession = CreateSession("bd2dur.onnx", OnnxRunnerChoice.Default);
-        sessionsLoaded = true;
-        if (stopping) {
-            runOptions.Terminate = true;
-            throw new OperationCanceledException();
-        }
-    }
-
-    protected override bool SupportsBatch => true;
+    protected override bool SupportsBatch =>
+        backend is GameOnnxBackend;  // only ONNX has native batching today
 
     protected override List<List<TranscribedNote>> TranscribeWaveformBatch(List<float[]> batch, GameOptions options) {
-        EnsureSessionsLoaded();
-        return RunPipeline(batch, options);
+        if (stopping) throw new OperationCanceledException();
+        return backend.RunInferenceBatch(batch, options);
     }
 
     protected override List<TranscribedNote> TranscribeWaveform(float[] samples, GameOptions options) {
-        EnsureSessionsLoaded();
-        return RunPipeline(new List<float[]> { samples }, options)[0];
-    }
-
-    private List<List<TranscribedNote>> RunPipeline(List<float[]> batch, GameOptions options) {
-        int B = batch.Count;
-        int maxLen = batch.Max(s => s.Length);
-
-        var waveformData = new float[B * maxLen];
-        var durationData = new float[B];
-        for (int b = 0; b < B; b++) {
-            var s = batch[b];
-            s.CopyTo(waveformData, b * maxLen);
-            durationData[b] = (float)s.Length / config.SampleRate;
-        }
-
-        var waveform = new DenseTensor<float>(waveformData, new[] { B, maxLen });
-        var duration = new DenseTensor<float>(durationData, new[] { B });
-
-        try {
-            // 1. Encoder
-            var (xSeg, xEst, maskT) = RunEncoder(waveform, duration);
-
-            // 2. Segmentation (D3PM loop)
-            int T = xSeg.Dimensions[1];
-            Tensor<bool> knownBoundaries = new DenseTensor<bool>(new[] { B, T });
-            Tensor<bool> boundaries = new DenseTensor<bool>(new[] { B, T });
-
-            Tensor<long>? language = null;
-            if (config.Languages != null) {
-                int languageId = ResolveLanguageId(options.LanguageCode);
-                language = new DenseTensor<long>(
-                    Enumerable.Repeat((long)languageId, B).ToArray(), new[] { B });
-            }
-
-            var segThreshold = new DenseTensor<float>(new[] { options.BoundaryThreshold }, Array.Empty<int>());
-            var radius = new DenseTensor<long>(new long[] { options.BoundaryRadius }, Array.Empty<int>());
-
-            if (config.Loop) {
-                float step = 1.0f / options.SamplingSteps;
-                for (int i = 0; i < options.SamplingSteps; i++) {
-                    var t = new DenseTensor<float>(
-                        Enumerable.Repeat(i * step, B).ToArray(), new[] { B });
-                    boundaries = RunSegmenter(xSeg, knownBoundaries, boundaries, t, maskT, language, segThreshold, radius);
-                }
-            } else {
-                boundaries = RunSegmenter(xSeg, knownBoundaries, null, null, maskT, language, segThreshold, radius);
-            }
-
-            // 3. Boundaries to durations
-            var (durations, maskN) = RunBd2Dur(boundaries, maskT);
-            int N = maskN.Dimensions[1];
-
-            // 4. Estimation
-            var scoreThreshold = new DenseTensor<float>(new[] { options.ScoreThreshold }, Array.Empty<int>());
-            var (presence, scores) = RunEstimator(xEst, boundaries, maskT, maskN, scoreThreshold);
-
-            // 5. Split results per batch item
-            var results = new List<List<TranscribedNote>>(B);
-            for (int b = 0; b < B; b++) {
-                var notes = new List<TranscribedNote>(N);
-                for (int i = 0; i < N; i++) {
-                    if (!maskN[b, i]) break;
-                    notes.Add(new TranscribedNote(durations[b, i], scores[b, i], presence[b, i]));
-                }
-
-                results.Add(notes);
-            }
-
-            return results;
-        } catch (OnnxRuntimeException) {
-            if (runOptions != null && runOptions.Terminate) {
-                throw new OperationCanceledException();
-            }
-            throw;
-        }
+        if (stopping) throw new OperationCanceledException();
+        return backend.RunInference(samples, options);
     }
 
     public override void Interrupt() {
         stopping = true;
-        if (!disposed && runOptions != null) {
-            runOptions.Terminate = true;
-        }
+        backend.Interrupt();
     }
 
     protected override void DisposeManaged() {
         if (disposed) return;
         disposed = true;
-        runOptions?.Dispose();
-        encoderSession?.Dispose();
-        segmenterSession?.Dispose();
-        estimatorSession?.Dispose();
-        bd2durSession?.Dispose();
-        sessionsLoaded = false;
-    }
-
-    // -------------------------------------------------------------------------
-    // Implementation details: session creation and low-level ONNX runners
-    // -------------------------------------------------------------------------
-
-    /// <summary>
-    /// Create an ONNX session for the given model file.
-    /// </summary>
-    private InferenceSession CreateSession(string modelFile, OnnxRunnerChoice runnerChoice) {
-        string modelPath = Path.Combine(Location, modelFile);
-        Log.Information("GAME: Loading model {ModelPath} (exists={Exists})",
-            modelPath, File.Exists(modelPath));
-        return Onnx.getInferenceSession(modelPath, runnerChoice);
-    }
-
-    /// <summary>
-    /// Resolve a language code string to an integer ID using the config's language map.
-    /// Returns 0 (universal) if the code is null or not found.
-    /// </summary>
-    private int ResolveLanguageId(string? languageCode) {
-        if (languageCode != null && config.Languages != null &&
-            config.Languages.TryGetValue(languageCode, out int id)) {
-            return id;
-        }
-
-        return 0;
-    }
-
-    /// <summary>
-    /// Run encoder: waveform -> x_seg, x_est, maskT
-    /// </summary>
-    private (Tensor<float> x_seg, Tensor<float> x_est, Tensor<bool> maskT)
-        RunEncoder(Tensor<float> waveform, Tensor<float> duration) {
-        var inputs = new List<NamedOnnxValue> {
-            NamedOnnxValue.CreateFromTensor("waveform", waveform),
-            NamedOnnxValue.CreateFromTensor("duration", duration),
-        };
-
-        using var outputs = encoderSession!.Run(inputs, encoderSession.OutputNames, runOptions);
-
-        var xSeg = outputs.First(o => o.Name == "x_seg").AsTensor<float>().ToDenseTensor();
-        var xEst = outputs.First(o => o.Name == "x_est").AsTensor<float>().ToDenseTensor();
-        var maskT = outputs.First(o => o.Name == "maskT").AsTensor<bool>().ToDenseTensor();
-
-        return (xSeg, xEst, maskT);
-    }
-
-    /// <summary>
-    /// Run a single segmenter step (D3PM sampling iteration)
-    /// </summary>
-    private Tensor<bool> RunSegmenter(
-        Tensor<float> xSeg,
-        Tensor<bool> knownBoundaries, Tensor<bool>? prevBoundaries,
-        Tensor<float>? t, Tensor<bool> maskT,
-        Tensor<long>? language,
-        Tensor<float> threshold, Tensor<long> radius) {
-        var inputs = new List<NamedOnnxValue>();
-        inputs.Add(NamedOnnxValue.CreateFromTensor("x_seg", xSeg));
-
-        if (language != null) {
-            inputs.Add(NamedOnnxValue.CreateFromTensor("language", language));
-        }
-
-        inputs.Add(NamedOnnxValue.CreateFromTensor("known_boundaries", knownBoundaries));
-
-        if (prevBoundaries != null) {
-            inputs.Add(NamedOnnxValue.CreateFromTensor("prev_boundaries", prevBoundaries));
-        }
-
-        if (t != null) {
-            inputs.Add(NamedOnnxValue.CreateFromTensor("t", t));
-        }
-
-        inputs.Add(NamedOnnxValue.CreateFromTensor("maskT", maskT));
-        inputs.Add(NamedOnnxValue.CreateFromTensor("threshold", threshold));
-        inputs.Add(NamedOnnxValue.CreateFromTensor("radius", radius));
-
-        using var outputs = segmenterSession!.Run(inputs, segmenterSession.OutputNames, runOptions);
-        var boundaries = outputs.First(o => o.Name == "boundaries").AsTensor<bool>().ToDenseTensor();
-        return boundaries;
-    }
-
-    /// <summary>
-    /// Run bd2dur: boundaries -> durations (seconds) + maskN
-    /// </summary>
-    private (Tensor<float> durations, Tensor<bool> maskN)
-        RunBd2Dur(Tensor<bool> boundaries, Tensor<bool> maskT) {
-        var inputs = new List<NamedOnnxValue> {
-            NamedOnnxValue.CreateFromTensor("boundaries", boundaries),
-            NamedOnnxValue.CreateFromTensor("maskT", maskT),
-        };
-
-        using var outputs = bd2durSession!.Run(inputs, bd2durSession.OutputNames, runOptions);
-        var durations = outputs.First(o => o.Name == "durations").AsTensor<float>().ToDenseTensor();
-        var maskN = outputs.First(o => o.Name == "maskN").AsTensor<bool>().ToDenseTensor();
-
-        return (durations, maskN);
-    }
-
-    /// <summary>
-    /// Run estimator: predict note presence and pitch scores
-    /// </summary>
-    private (Tensor<bool> presence, Tensor<float> scores)
-        RunEstimator(Tensor<float> xEst, Tensor<bool> boundaries, Tensor<bool> maskT,
-            Tensor<bool> maskN, Tensor<float> threshold) {
-        var inputs = new List<NamedOnnxValue> {
-            NamedOnnxValue.CreateFromTensor("x_est", xEst),
-            NamedOnnxValue.CreateFromTensor("boundaries", boundaries),
-            NamedOnnxValue.CreateFromTensor("maskT", maskT),
-            NamedOnnxValue.CreateFromTensor("maskN", maskN),
-            NamedOnnxValue.CreateFromTensor("threshold", threshold),
-        };
-
-        using var outputs = estimatorSession!.Run(inputs, estimatorSession.OutputNames, runOptions);
-        var presence = outputs.First(o => o.Name == "presence").AsTensor<bool>().ToDenseTensor();
-        var scores = outputs.First(o => o.Name == "scores").AsTensor<float>().ToDenseTensor();
-        return (presence, scores);
+        backend.Dispose();
     }
 }

--- a/OpenUtau.Core/Analysis/Game.cs
+++ b/OpenUtau.Core/Analysis/Game.cs
@@ -99,10 +99,7 @@ public class Game : MidiExtractor<GameOptions> {
             backend = new GameOnnxBackend(config, location);
         } else {
             backend = GameBackendFactory.Create();
-            string cfgLocation = PackageManager.Inst.GetInstalledPath(PackageId);
-            config = cfgLocation != null
-                ? LoadConfig(cfgLocation)
-                : new GameConfig();
+            config = backend.Config;
         }
         Log.Information("GAME: active backend = {Backend}", backend.Name);
     }

--- a/OpenUtau.Core/Analysis/GameBackendFactory.cs
+++ b/OpenUtau.Core/Analysis/GameBackendFactory.cs
@@ -45,6 +45,23 @@ public static class GameBackendFactory {
     };
 
     /// <summary>
+    /// Load the configuration belonging to the backend that will actually be used.
+    /// This must not fall back to the ONNX package when only GGML is installed.
+    /// </summary>
+    public static GameConfig LoadResolvedConfig() {
+        string choice = ResolveChoice();
+        if (choice == OnnxValue) {
+            string location = PackageManager.Inst.GetInstalledPath("game")!;
+            return Game.LoadConfig(location);
+        }
+        if (choice == GgmlValue) {
+            return GameGgmlBackend.LoadConfig();
+        }
+        throw new InvalidOperationException(
+            "No GAME backend is installed. Install the GAME ONNX or GGML weights via the Package Manager.");
+    }
+
+    /// <summary>
     /// Construct the resolved backend and load its config from the installed
     /// GAME weights directory.
     /// </summary>

--- a/OpenUtau.Core/Analysis/GameBackendFactory.cs
+++ b/OpenUtau.Core/Analysis/GameBackendFactory.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using OpenUtau.Core.Util;
+using Serilog;
+
+namespace OpenUtau.Core.Analysis;
+
+/// <summary>
+/// Selects and constructs the active <see cref="IGameBackend"/> for a GAME
+/// inference request, based on user preferences and which backend is installed.
+///
+/// Preference resolution order:
+///  1. <see cref="SerializablePreferences.GameBackend"/> (the user's explicit choice) —
+///     used if that backend is installed.
+///  2. Fall back to whichever backend *is* installed (ONNX preferred over GGML,
+///     since ONNX is the trusted baseline).
+///  3. If neither is installed, throw — callers should have guarded with
+///     <see cref="IsAnyInstalled"/>.
+/// </summary>
+public static class GameBackendFactory {
+    public const string OnnxValue = "onnx";
+    public const string GgmlValue = "ggml";
+
+    /// <summary>True when at least one backend's weights + binaries are in place.</summary>
+    public static bool IsAnyInstalled() {
+        return GameOnnxBackend.IsInstalled() || GameGgmlBackend.IsInstalled();
+    }
+
+    /// <summary>The backend id that will actually be used given prefs + installs.</summary>
+    public static string ResolveChoice() {
+        string pref = Preferences.Default.GameBackend ?? "";
+        if (pref == GgmlValue && GameGgmlBackend.IsInstalled()) return GgmlValue;
+        if (pref == OnnxValue && GameOnnxBackend.IsInstalled()) return OnnxValue;
+        // Fall back to whatever is installed, preferring ONNX.
+        if (GameOnnxBackend.IsInstalled()) return OnnxValue;
+        if (GameGgmlBackend.IsInstalled()) return GgmlValue;
+        return "";  // none
+    }
+
+    /// <summary>The display name ("ONNX" / "GGML") for the resolved backend.</summary>
+    public static string ResolvedBackendName() => ResolveChoice() switch {
+        GgmlValue => "GGML",
+        OnnxValue => "ONNX",
+        _ => "(none)",
+    };
+
+    /// <summary>
+    /// Construct the resolved backend and load its config from the installed
+    /// GAME weights directory.
+    /// </summary>
+    public static IGameBackend Create() {
+        string choice = ResolveChoice();
+        Log.Information("GAME: backend choice resolved to {Choice}", choice);
+        if (choice == OnnxValue) {
+            string location = PackageManager.Inst.GetInstalledPath("game")!;
+            var config = Game.LoadConfig(location);
+            return new GameOnnxBackend(config, location);
+        }
+        if (choice == GgmlValue) {
+            return GameGgmlBackend.Create();
+        }
+        throw new InvalidOperationException(
+            "No GAME backend is installed. Install the GAME ONNX or GGML weights via the Package Manager.");
+    }
+}

--- a/OpenUtau.Core/Analysis/GameGgmlBackend.cs
+++ b/OpenUtau.Core/Analysis/GameGgmlBackend.cs
@@ -28,7 +28,8 @@ namespace OpenUtau.Core.Analysis;
 /// </summary>
 public class GameGgmlBackend : IGameBackend {
     private const string PackageId = "game";
-    private const string CliPackageId = "game-ggml-cli";
+    // Single oudep package contains both the CLI binary and the GGUF weights.
+    private const string GgmlPackageId = "game-ggml-medium";
 
     // Must match serv_proto::MAGIC_INFERENCE / MAGIC_QUIT in src/cli/main.cpp.
     private const uint MAGIC_INFERENCE = 0x53455256u;  // "VRES"
@@ -58,25 +59,33 @@ public class GameGgmlBackend : IGameBackend {
     public static string? ResolveCliPath() {
         string dep = PathManager.Inst.DependencyPath;
         string exeName = OS.IsWindows() ? "game_ggml_cli.exe" : "game_ggml_cli";
-        // First: dedicated oudep package directory.
-        string cliDir = Path.Combine(dep, CliPackageId);
+        // The game-ggml-medium oudep package ships the CLI under its root.
+        string cliDir = Path.Combine(dep, GgmlPackageId);
         string exe = Path.Combine(cliDir, exeName);
-        if (File.Exists(exe)) return exe;
-        // Fallback: a shared bin directory.
-        string binDir = Path.Combine(dep, "bin");
-        exe = Path.Combine(binDir, exeName);
         if (File.Exists(exe)) return exe;
         return null;
     }
 
-    /// <summary>Locate the first .gguf weight file inside the GAME dependency package.</summary>
+    /// <summary>Locate the first .gguf weight file. Checks the dedicated
+    /// game-ggml-medium package first, then falls back to the shared game
+    /// package (so GGUF weights can coexist alongside the ONNX .onnx files).</summary>
     public static string? ResolveGgufPath(string? location = null) {
-        location ??= PackageManager.Inst.GetInstalledPath(PackageId);
-        if (location == null) return null;
-        var gguf = Directory.GetFiles(location, "*.gguf")
-            .OrderByDescending(f => new FileInfo(f).Length)  // prefer the largest (likely medium > small)
-            .FirstOrDefault();
-        return gguf;
+        // 1. Preferred: dedicated ggml package (oudep installs to DependencyPath/game-ggml-medium)
+        string ggmlDir = Path.Combine(PathManager.Inst.DependencyPath, GgmlPackageId);
+        if (Directory.Exists(ggmlDir)) {
+            var gguf = Directory.GetFiles(ggmlDir, "*.gguf")
+                .OrderByDescending(f => new FileInfo(f).Length)
+                .FirstOrDefault();
+            if (gguf != null) return gguf;
+        }
+        // 2. Fallback: shared game package (for users who placed GGUF alongside ONNX files)
+        string? gameLoc = location ?? PackageManager.Inst.GetInstalledPath(PackageId);
+        if (gameLoc != null && Directory.Exists(gameLoc)) {
+            return Directory.GetFiles(gameLoc, "*.gguf")
+                .OrderByDescending(f => new FileInfo(f).Length)
+                .FirstOrDefault();
+        }
+        return null;
     }
 
     /// <summary>True when both the CLI binary and a GGUF weight package are installed.</summary>

--- a/OpenUtau.Core/Analysis/GameGgmlBackend.cs
+++ b/OpenUtau.Core/Analysis/GameGgmlBackend.cs
@@ -48,6 +48,7 @@ public class GameGgmlBackend : IGameBackend {
     volatile bool stopping = false;
 
     public string Name => "GGML";
+    public GameConfig Config => config;
 
     private GameGgmlBackend(GameConfig config, string cliPath, string ggufPath) {
         this.config = config;
@@ -66,31 +67,50 @@ public class GameGgmlBackend : IGameBackend {
         return null;
     }
 
-    /// <summary>Locate the first .gguf weight file. Checks the dedicated
-    /// game-ggml-medium package first, then falls back to the shared game
-    /// package (so GGUF weights can coexist alongside the ONNX .onnx files).</summary>
+    /// <summary>Locate the largest .gguf weight file. An explicit location is
+    /// honored first; otherwise checks the dedicated game-ggml-medium package,
+    /// then the shared game package for backward compatibility.</summary>
     public static string? ResolveGgufPath(string? location = null) {
-        // 1. Preferred: dedicated ggml package (oudep installs to DependencyPath/game-ggml-medium)
+        if (location != null) {
+            return FindLargestGguf(location);
+        }
         string ggmlDir = Path.Combine(PathManager.Inst.DependencyPath, GgmlPackageId);
-        if (Directory.Exists(ggmlDir)) {
-            var gguf = Directory.GetFiles(ggmlDir, "*.gguf")
-                .OrderByDescending(f => new FileInfo(f).Length)
-                .FirstOrDefault();
-            if (gguf != null) return gguf;
-        }
-        // 2. Fallback: shared game package (for users who placed GGUF alongside ONNX files)
-        string? gameLoc = location ?? PackageManager.Inst.GetInstalledPath(PackageId);
-        if (gameLoc != null && Directory.Exists(gameLoc)) {
-            return Directory.GetFiles(gameLoc, "*.gguf")
-                .OrderByDescending(f => new FileInfo(f).Length)
-                .FirstOrDefault();
-        }
-        return null;
+        string? gguf = FindLargestGguf(ggmlDir);
+        if (gguf != null) return gguf;
+
+        string? gameLoc = PackageManager.Inst.GetInstalledPath(PackageId);
+        return gameLoc == null ? null : FindLargestGguf(gameLoc);
     }
 
-    /// <summary>True when both the CLI binary and a GGUF weight package are installed.</summary>
+    private static string? FindLargestGguf(string directory) {
+        if (!Directory.Exists(directory)) return null;
+        return Directory.GetFiles(directory, "*.gguf")
+            .OrderByDescending(f => new FileInfo(f).Length)
+            .FirstOrDefault();
+    }
+
+    /// <summary>True when the CLI, GGUF weights and backend config are installed.</summary>
     public static bool IsInstalled(string? location = null) {
-        return ResolveCliPath() != null && ResolveGgufPath(location) != null;
+        string? gguf = ResolveGgufPath(location);
+        return ResolveCliPath() != null &&
+            gguf != null &&
+            File.Exists(Path.Combine(Path.GetDirectoryName(gguf)!, "config.json"));
+    }
+
+    /// <summary>Load config.json next to the GGUF weights.</summary>
+    public static GameConfig LoadConfig(string? location = null) {
+        string? gguf = ResolveGgufPath(location);
+        if (gguf == null) {
+            throw new InvalidOperationException("GAME GGML backend is missing .gguf weights.");
+        }
+        string configPath = Path.Combine(Path.GetDirectoryName(gguf)!, "config.json");
+        if (!File.Exists(configPath)) {
+            throw new InvalidOperationException(
+                $"GAME GGML backend is missing config.json at {configPath}");
+        }
+        var jsonText = File.ReadAllText(configPath, Encoding.UTF8);
+        return JsonSerializer.Deserialize<GameConfig>(jsonText)
+            ?? throw new InvalidOperationException("Failed to parse GAME config.json");
     }
 
     /// <summary>
@@ -104,18 +124,7 @@ public class GameGgmlBackend : IGameBackend {
             throw new InvalidOperationException(
                 "GAME GGML backend is not installed: missing CLI binary or .gguf weights.");
         }
-        // Load config from the GGML package dir (Dependencies/game-ggml-medium/),
-        // not the ONNX package dir — they are independent oudep packages.
-        string ggmlDir = Path.GetDirectoryName(gguf)!;
-        string configPath = Path.Combine(ggmlDir, "config.json");
-        if (!File.Exists(configPath)) {
-            throw new InvalidOperationException(
-                $"GAME GGML backend is missing config.json at {configPath}");
-        }
-        var jsonText = File.ReadAllText(configPath, System.Text.Encoding.UTF8);
-        GameConfig config = System.Text.Json.JsonSerializer.Deserialize<GameConfig>(jsonText)
-            ?? throw new InvalidOperationException("Failed to parse GAME config.json");
-        return new GameGgmlBackend(config, cli, gguf);
+        return new GameGgmlBackend(LoadConfig(), cli, gguf);
     }
 
     public bool EnsureLoaded() {

--- a/OpenUtau.Core/Analysis/GameGgmlBackend.cs
+++ b/OpenUtau.Core/Analysis/GameGgmlBackend.cs
@@ -131,9 +131,9 @@ public class GameGgmlBackend : IGameBackend {
         if (process != null && !process.HasExited) return true;
 
         Log.Information("GAME(GGML): launching serve subprocess cli={Cli} gguf={Gguf}", cliPath, ggufPath);
+        EnsureExecutable(cliPath);
         var psi = new ProcessStartInfo {
             FileName = cliPath,
-            Arguments = $"serve \"{ggufPath}\"",
             UseShellExecute = false,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
@@ -141,6 +141,8 @@ public class GameGgmlBackend : IGameBackend {
             CreateNoWindow = true,
             StandardOutputEncoding = Encoding.UTF8,
         };
+        psi.ArgumentList.Add("serve");
+        psi.ArgumentList.Add(ggufPath);
         process = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start game_ggml_cli.");
         // Binary stdin: avoid a text writer wrapper to control framing exactly.
@@ -299,6 +301,19 @@ public class GameGgmlBackend : IGameBackend {
                 Log.Information("GAME(GGML)[stderr] {Line}", l);
             }
         });
+    }
+
+    private static void EnsureExecutable(string path) {
+        if (OS.IsWindows()) return;
+        const UnixFileMode executableMode =
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+        try {
+            File.SetUnixFileMode(path, executableMode);
+        } catch (Exception e) {
+            Log.Warning(e, "GAME(GGML): failed to set executable permission on {Cli}", path);
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/OpenUtau.Core/Analysis/GameGgmlBackend.cs
+++ b/OpenUtau.Core/Analysis/GameGgmlBackend.cs
@@ -26,6 +26,26 @@ namespace OpenUtau.Core.Analysis;
 /// One <see cref="GameGgmlBackend"/> instance owns exactly one subprocess; the
 /// subclass <see cref="Game"/> disposes it after the whole transcription.
 /// </summary>
+///
+/// Recommended GGML configuration (7-channel 60 s benchmark, nsteps=8,
+/// frame-level metrics vs torch-CUDA fp32 no-cache baseline — all EPS ≥ 0.97 RPA):
+///
+///   | platform      | GPU           | weights | EP offered by oudep pkg |
+///   |---------------|---------------|---------|--------------------------|
+///   | Windows       | NVIDIA        | F32     | CUDA (fallback Vulkan)   |
+///   | Windows       | Intel/AMD/etc | F32     | Vulkan                   |
+///   | Windows       | integrated    | F32/Q8  | CPU (+ DBCache): 0.44x wall |
+///   | Linux         | NVIDIA        | F32     | CUDA (fallback Vulkan)   |
+///   | Linux         | Nouveau/AMD   | F32     | Vulkan                   |
+///   | macOS         | Apple Silicon | F32     | Metal (only EP)          |
+///   | macOS         | Intel         | F32     | Metal (cross-compiled)   |
+///
+/// Rules of thumb (no user config required — CLI picks backend from GGUF/EP):
+///  * GPU present → F32 weights; CPU-only → CPU EP with DBCache on by default
+///  * on GPU, Vulkan is our smallest-VRAM (≈+0.3 GiB) and CUDA the fastest
+///  * Q8 saves VRAM/RAM (~3.4x smaller weights) at near-lossless quality but may
+///    flip a boundary note on Vulkan — prefer the -full package if you need
+///    bit-consistent output; both are equally valid in practice.
 public class GameGgmlBackend : IGameBackend {
     private const string PackageId = "game";
     // Single oudep package contains both the CLI binary and the GGUF weights.

--- a/OpenUtau.Core/Analysis/GameGgmlBackend.cs
+++ b/OpenUtau.Core/Analysis/GameGgmlBackend.cs
@@ -112,7 +112,9 @@ public class GameGgmlBackend : IGameBackend {
             throw new InvalidOperationException(
                 $"GAME GGML backend is missing config.json at {configPath}");
         }
-        GameConfig config = Game.LoadConfig(configPath);
+        var jsonText = File.ReadAllText(configPath, System.Text.Encoding.UTF8);
+        GameConfig config = System.Text.Json.JsonSerializer.Deserialize<GameConfig>(jsonText)
+            ?? throw new InvalidOperationException("Failed to parse GAME config.json");
         return new GameGgmlBackend(config, cli, gguf);
     }
 

--- a/OpenUtau.Core/Analysis/GameGgmlBackend.cs
+++ b/OpenUtau.Core/Analysis/GameGgmlBackend.cs
@@ -104,7 +104,15 @@ public class GameGgmlBackend : IGameBackend {
             throw new InvalidOperationException(
                 "GAME GGML backend is not installed: missing CLI binary or .gguf weights.");
         }
-        GameConfig config = Game.LoadConfig();
+        // Load config from the GGML package dir (Dependencies/game-ggml-medium/),
+        // not the ONNX package dir — they are independent oudep packages.
+        string ggmlDir = Path.GetDirectoryName(gguf)!;
+        string configPath = Path.Combine(ggmlDir, "config.json");
+        if (!File.Exists(configPath)) {
+            throw new InvalidOperationException(
+                $"GAME GGML backend is missing config.json at {configPath}");
+        }
+        GameConfig config = Game.LoadConfig(configPath);
         return new GameGgmlBackend(config, cli, gguf);
     }
 

--- a/OpenUtau.Core/Analysis/GameGgmlBackend.cs
+++ b/OpenUtau.Core/Analysis/GameGgmlBackend.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Serilog;
+
+namespace OpenUtau.Core.Analysis;
+
+/// <summary>
+/// GAME inference backend that drives the native GAME-ggml CLI in long-lived
+/// <c>serve</c> mode. Communication is a binary stdin → JSON stdout protocol:
+///
+/// On <see cref="EnsureLoaded"/>:
+///   1. Resolve the CLI binary and GGUF weights under the OpenUtau Dependencies folder.
+///   2. Spawn <c>game_ggml_cli serve <gguf></c> with redirected stdin/stdout/stderr.
+///   3. Wait for the <c>{"type":"ready"}</c> line on stdout.
+///
+/// Per inference (<see cref="RunInference"/>):
+///   • Write a 36-byte request header + the float32 waveform to stdin.
+///   • Read one JSON object back describing the transcribed notes for this chunk.
+///
+/// Cancelation (<see cref="Interrupt"/>) writes the quit magic and reaps the process.
+/// One <see cref="GameGgmlBackend"/> instance owns exactly one subprocess; the
+/// subclass <see cref="Game"/> disposes it after the whole transcription.
+/// </summary>
+public class GameGgmlBackend : IGameBackend {
+    private const string PackageId = "game";
+    private const string CliPackageId = "game-ggml-cli";
+
+    // Must match serv_proto::MAGIC_INFERENCE / MAGIC_QUIT in src/cli/main.cpp.
+    private const uint MAGIC_INFERENCE = 0x53455256u;  // "VRES"
+    private const uint MAGIC_QUIT = 0x54495155u;        // "UQIT"
+
+    const int RequestHeaderBytes = 36;
+
+    readonly GameConfig config;
+    readonly string cliPath;
+    readonly string ggufPath;
+
+    Process? process;
+    BinaryWriter? stdinWriter;
+    StreamReader? stdoutReader;
+    volatile bool disposed = false;
+    volatile bool stopping = false;
+
+    public string Name => "GGML";
+
+    private GameGgmlBackend(GameConfig config, string cliPath, string ggufPath) {
+        this.config = config;
+        this.cliPath = cliPath;
+        this.ggufPath = ggufPath;
+    }
+
+    /// <summary>Locate the shipped CLI binary, platform-aware.</summary>
+    public static string? ResolveCliPath() {
+        string dep = PathManager.Inst.DependencyPath;
+        string exeName = OS.IsWindows() ? "game_ggml_cli.exe" : "game_ggml_cli";
+        // First: dedicated oudep package directory.
+        string cliDir = Path.Combine(dep, CliPackageId);
+        string exe = Path.Combine(cliDir, exeName);
+        if (File.Exists(exe)) return exe;
+        // Fallback: a shared bin directory.
+        string binDir = Path.Combine(dep, "bin");
+        exe = Path.Combine(binDir, exeName);
+        if (File.Exists(exe)) return exe;
+        return null;
+    }
+
+    /// <summary>Locate the first .gguf weight file inside the GAME dependency package.</summary>
+    public static string? ResolveGgufPath(string? location = null) {
+        location ??= PackageManager.Inst.GetInstalledPath(PackageId);
+        if (location == null) return null;
+        var gguf = Directory.GetFiles(location, "*.gguf")
+            .OrderByDescending(f => new FileInfo(f).Length)  // prefer the largest (likely medium > small)
+            .FirstOrDefault();
+        return gguf;
+    }
+
+    /// <summary>True when both the CLI binary and a GGUF weight package are installed.</summary>
+    public static bool IsInstalled(string? location = null) {
+        return ResolveCliPath() != null && ResolveGgufPath(location) != null;
+    }
+
+    /// <summary>
+    /// Construct a ready-to-serve backend if installed; otherwise throws so the
+    /// factory can fall back. Model loading is lazy (deferred to EnsureLoaded).
+    /// </summary>
+    public static GameGgmlBackend Create() {
+        string? cli = ResolveCliPath();
+        string? gguf = ResolveGgufPath();
+        if (cli == null || gguf == null) {
+            throw new InvalidOperationException(
+                "GAME GGML backend is not installed: missing CLI binary or .gguf weights.");
+        }
+        GameConfig config = Game.LoadConfig();
+        return new GameGgmlBackend(config, cli, gguf);
+    }
+
+    public bool EnsureLoaded() {
+        if (process != null && !process.HasExited) return true;
+
+        Log.Information("GAME(GGML): launching serve subprocess cli={Cli} gguf={Gguf}", cliPath, ggufPath);
+        var psi = new ProcessStartInfo {
+            FileName = cliPath,
+            Arguments = $"serve \"{ggufPath}\"",
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+        };
+        process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start game_ggml_cli.");
+        // Binary stdin: avoid a text writer wrapper to control framing exactly.
+        stdinWriter = new BinaryWriter(process.StandardInput.BaseStream, Encoding.ASCII, leaveOpen: false);
+        stdoutReader = process.StandardOutput;
+
+        // Drain stderr on a background thread so it can't deadlock the pipe.
+        StartStderrPump();
+
+        // Wait for {"type":"ready"} (or {"type":"error",...}) on stdout.
+        string? first = ReadJsonObject();
+        if (first == null || ParseType(first) == "error") {
+            string msg = first ?? "subprocess closed stdout before ready";
+            if (first != null) msg = ParseError(first) ?? msg;
+            throw new InvalidOperationException($"GAME GGML backend failed to initialize: {msg}");
+        }
+        return true;
+    }
+
+    public List<TranscribedNote> RunInference(float[] samples, GameOptions options) {
+        EnsureLoaded();
+        if (stopping || process == null || process.HasExited) {
+            throw new OperationCanceledException();
+        }
+
+        // Resolve language id.
+        int languageId = 0;
+        if (config.Languages != null && options.LanguageCode != null &&
+            config.Languages.TryGetValue(options.LanguageCode, out int id)) {
+            languageId = id;
+        }
+
+        // Build the request header + waveform, write to stdin.
+        Span<byte> header = stackalloc byte[RequestHeaderBytes];
+        BinaryPrimitivesWriteU32Little(header.Slice(0, 4), MAGIC_INFERENCE);
+        BinaryPrimitivesWriteI32Little(header.Slice(4, 4), languageId);
+        BinaryPrimitivesWriteU64Little(header.Slice(8, 8), (ulong)options.Seed);
+        BinaryPrimitivesWriteI32Little(header.Slice(16, 4), options.SamplingSteps);
+        BinaryPrimitivesWriteFloatLittle(header.Slice(20, 4), options.BoundaryThreshold);
+        BinaryPrimitivesWriteI32Little(header.Slice(24, 4), options.BoundaryRadius);
+        BinaryPrimitivesWriteFloatLittle(header.Slice(28, 4), options.ScoreThreshold);
+        BinaryPrimitivesWriteU32Little(header.Slice(32, 4), (uint)samples.Length);
+
+        var stdin = stdinWriter!;
+        stdin.Write((ReadOnlySpan<byte>)header);
+        // Float32 waveform, little-endian. On x86/x64 .NET float layout is LE.
+        ReadOnlySpan<byte> waveBytes = System.Runtime.InteropServices.MemoryMarshal.AsBytes(samples.AsSpan());
+        stdin.Write(waveBytes);
+        stdin.Flush();
+
+        // Read one JSON object back: {"type":"notes","count":N,"notes":[...]}
+        string? line = ReadJsonObject();
+        if (line == null) throw new OperationCanceledException("GGML subprocess closed stdout during inference.");
+        string type = ParseType(line);
+        if (type == "error") {
+            throw new InvalidOperationException($"GGML inference error: {ParseError(line)}");
+        }
+        if (type != "notes") {
+            throw new InvalidOperationException($"Unexpected GGML response: {line}");
+        }
+        return ParseNotes(line);
+    }
+
+    public void Interrupt() {
+        stopping = true;
+        // Send the quit magic; the subprocess exits cleanly. Fall through to
+        // a hard kill if it hangs.
+        try {
+            if (process != null && !process.HasExited && stdinWriter != null) {
+                Span<byte> quit = stackalloc byte[4];
+                BinaryPrimitivesWriteU32Little(quit, MAGIC_QUIT);
+                stdinWriter.Write(quit);
+                stdinWriter.Flush();
+                if (!process.WaitForExit(3000)) {
+                    try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+                }
+            }
+        } catch {
+            // Cancellation must never throw; swallow IO errors on a dying pipe.
+        }
+    }
+
+    public void Dispose() {
+        if (disposed) return;
+        disposed = true;
+        try {
+            if (process != null && !process.HasExited) {
+                try {
+                    if (stdinWriter != null) {
+                        Span<byte> quit = stackalloc byte[4];
+                        BinaryPrimitivesWriteU32Little(quit, MAGIC_QUIT);
+                        stdinWriter.Write(quit);
+                        stdinWriter.Flush();
+                    }
+                } catch { /* pipe may already be broken */ }
+                if (!process.WaitForExit(2000)) {
+                    try { process.Kill(entireProcessTree: true); } catch { }
+                }
+            }
+        } finally {
+            stdinWriter?.Dispose();
+            stdoutReader?.Dispose();
+            process?.Dispose();
+            process = null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // stdout framing: read exactly one JSON object terminated by '\n'
+    // -------------------------------------------------------------------------
+
+    private string? ReadJsonObject() {
+        // ReadLine blocks until '\n' or EOF; JSON objects are single-line.
+        string? line = stdoutReader!.ReadLine();
+        return string.IsNullOrEmpty(line) ? null : line;
+    }
+
+    private static string? ParseType(string json) {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.TryGetProperty("type", out var t) ? t.GetString() : null;
+    }
+
+    private static string? ParseError(string json) {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.TryGetProperty("message", out var m) ? m.GetString() : null;
+    }
+
+    private static List<TranscribedNote> ParseNotes(string json) {
+        var notes = new List<TranscribedNote>();
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("notes", out var arr)) return notes;
+        // The GGML backend emitted absolute offset_seconds per note, but the
+        // segmenter partitions the chunk into contiguous regions whose lengths
+        // sum exactly to the chunk length — each note already carries its own
+        // duration_seconds. The MidiExtractor base class positions the chunk by
+        // its audio offset and accumulates note durations sequentially, so we
+        // pass duration_seconds through directly and ignore offset_seconds.
+        foreach (var n in arr.EnumerateArray()) {
+            float duration = n.TryGetProperty("d", out var de) ? de.GetSingle() : 0f;
+            float pitch = n.TryGetProperty("p", out var pe) ? pe.GetSingle() : 0f;
+            bool voiced = n.TryGetProperty("v", out var ve) && ve.GetInt32() != 0;
+            if (duration < 0) duration = 0;
+            notes.Add(new TranscribedNote(duration, pitch, voiced));
+        }
+        return notes;
+    }
+
+    // -------------------------------------------------------------------------
+    // stderr pump (keeps the subprocess from blocking on a full error buffer)
+    // -------------------------------------------------------------------------
+    private void StartStderrPump() {
+        var err = process!.StandardError;
+        System.Threading.Tasks.Task.Run(() => {
+            string? l;
+            while ((l = err.ReadLine()) != null) {
+                Log.Information("GAME(GGML)[stderr] {Line}", l);
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Little-endian binary writers (no BitConverter pinned-buffer dance needed)
+    // -------------------------------------------------------------------------
+    private static void BinaryPrimitivesWriteU32Little(Span<byte> dst, uint v) {
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(dst, v);
+    }
+    private static void BinaryPrimitivesWriteI32Little(Span<byte> dst, int v) {
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(dst, v);
+    }
+    private static void BinaryPrimitivesWriteU64Little(Span<byte> dst, ulong v) {
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(dst, v);
+    }
+    private static unsafe void BinaryPrimitivesWriteFloatLittle(Span<byte> dst, float v) {
+        int bits = *(int*)&v;
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(dst, bits);
+    }
+}

--- a/OpenUtau.Core/Analysis/GameOnnxBackend.cs
+++ b/OpenUtau.Core/Analysis/GameOnnxBackend.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using Serilog;
+
+namespace OpenUtau.Core.Analysis;
+
+/// <summary>
+/// ONNX Runtime backend for GAME. Runs the four-model pipeline
+/// (encoder → segmenter (D3PM loop) → bd2dur → estimator) directly in-process.
+/// This is a behavior-preserving extraction of the original single-backend
+/// <see cref="Game"/> implementation; ONNX is always available when the
+/// <c>game</c> dependency package with the <c>.onnx</c> files is installed.
+/// </summary>
+public class GameOnnxBackend : IGameBackend {
+    private const string PackageId = "game";
+
+    InferenceSession? encoderSession;
+    InferenceSession? segmenterSession;
+    InferenceSession? estimatorSession;
+    InferenceSession? bd2durSession;
+    RunOptions? runOptions;
+    bool sessionsLoaded = false;
+    bool disposed = false;
+    volatile bool stopping = false;
+
+    readonly GameConfig config;
+    readonly string Location;
+
+    public string Name => "ONNX";
+
+    public GameOnnxBackend(GameConfig config, string location) {
+        this.config = config;
+        this.Location = location;
+    }
+
+    /// <summary>Check if the ONNX GAME weights are installed without loading models.</summary>
+    public static bool IsInstalled(string? location = null) {
+        location ??= PackageManager.Inst.GetInstalledPath(PackageId);
+        if (location == null) return false;
+        if (!System.IO.File.Exists(System.IO.Path.Combine(location, "config.json"))) return false;
+        // All four ONNX models must be present.
+        return new[] { "encoder.onnx", "segmenter.onnx", "estimator.onnx", "bd2dur.onnx" }
+            .All(f => System.IO.File.Exists(System.IO.Path.Combine(location, f)));
+    }
+
+    public bool EnsureLoaded() {
+        if (sessionsLoaded) return true;
+        runOptions = new RunOptions();
+        encoderSession = CreateSession("encoder.onnx", OnnxRunnerChoice.CPUForCoreML);
+        segmenterSession = CreateSession("segmenter.onnx", OnnxRunnerChoice.Default);
+        estimatorSession = CreateSession("estimator.onnx", OnnxRunnerChoice.Default);
+        bd2durSession = CreateSession("bd2dur.onnx", OnnxRunnerChoice.Default);
+        sessionsLoaded = true;
+        if (stopping) {
+            runOptions.Terminate = true;
+            throw new OperationCanceledException();
+        }
+        return true;
+    }
+
+    public List<TranscribedNote> RunInference(float[] samples, GameOptions options) {
+        EnsureLoaded();
+        return RunPipeline(new List<float[]> { samples }, options)[0];
+    }
+
+    public List<List<TranscribedNote>> RunInferenceBatch(List<float[]> batch, GameOptions options) {
+        EnsureLoaded();
+        return RunPipeline(batch, options);
+    }
+
+    private List<List<TranscribedNote>> RunPipeline(List<float[]> batch, GameOptions options) {
+        int B = batch.Count;
+        int maxLen = batch.Max(s => s.Length);
+
+        var waveformData = new float[B * maxLen];
+        var durationData = new float[B];
+        for (int b = 0; b < B; b++) {
+            var s = batch[b];
+            s.CopyTo(waveformData, b * maxLen);
+            durationData[b] = (float)s.Length / config.SampleRate;
+        }
+
+        var waveform = new DenseTensor<float>(waveformData, new[] { B, maxLen });
+        var duration = new DenseTensor<float>(durationData, new[] { B });
+
+        try {
+            // 1. Encoder
+            var (xSeg, xEst, maskT) = RunEncoder(waveform, duration);
+
+            // 2. Segmentation (D3PM loop)
+            int T = xSeg.Dimensions[1];
+            Tensor<bool> knownBoundaries = new DenseTensor<bool>(new[] { B, T });
+            Tensor<bool> boundaries = new DenseTensor<bool>(new[] { B, T });
+
+            Tensor<long>? language = null;
+            if (config.Languages != null) {
+                int languageId = ResolveLanguageId(options.LanguageCode);
+                language = new DenseTensor<long>(
+                    Enumerable.Repeat((long)languageId, B).ToArray(), new[] { B });
+            }
+
+            var segThreshold = new DenseTensor<float>(new[] { options.BoundaryThreshold }, Array.Empty<int>());
+            var radius = new DenseTensor<long>(new long[] { options.BoundaryRadius }, Array.Empty<int>());
+
+            if (config.Loop) {
+                float step = 1.0f / options.SamplingSteps;
+                for (int i = 0; i < options.SamplingSteps; i++) {
+                    var t = new DenseTensor<float>(
+                        Enumerable.Repeat(i * step, B).ToArray(), new[] { B });
+                    boundaries = RunSegmenter(xSeg, knownBoundaries, boundaries, t, maskT, language, segThreshold, radius);
+                }
+            } else {
+                boundaries = RunSegmenter(xSeg, knownBoundaries, null, null, maskT, language, segThreshold, radius);
+            }
+
+            // 3. Boundaries to durations
+            var (durations, maskN) = RunBd2Dur(boundaries, maskT);
+            int N = maskN.Dimensions[1];
+
+            // 4. Estimation
+            var scoreThreshold = new DenseTensor<float>(new[] { options.ScoreThreshold }, Array.Empty<int>());
+            var (presence, scores) = RunEstimator(xEst, boundaries, maskT, maskN, scoreThreshold);
+
+            // 5. Split results per batch item
+            var results = new List<List<TranscribedNote>>(B);
+            for (int b = 0; b < B; b++) {
+                var notes = new List<TranscribedNote>(N);
+                for (int i = 0; i < N; i++) {
+                    if (!maskN[b, i]) break;
+                    notes.Add(new TranscribedNote(durations[b, i], scores[b, i], presence[b, i]));
+                }
+
+                results.Add(notes);
+            }
+
+            return results;
+        } catch (OnnxRuntimeException) {
+            if (runOptions != null && runOptions.Terminate) {
+                throw new OperationCanceledException();
+            }
+            throw;
+        }
+    }
+
+    public void Interrupt() {
+        stopping = true;
+        if (!disposed && runOptions != null) {
+            runOptions.Terminate = true;
+        }
+    }
+
+    public void Dispose() {
+        if (disposed) return;
+        disposed = true;
+        runOptions?.Dispose();
+        encoderSession?.Dispose();
+        segmenterSession?.Dispose();
+        estimatorSession?.Dispose();
+        bd2durSession?.Dispose();
+        sessionsLoaded = false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Implementation details: session creation and low-level ONNX runners
+    // -------------------------------------------------------------------------
+
+    private InferenceSession CreateSession(string modelFile, OnnxRunnerChoice runnerChoice) {
+        string modelPath = System.IO.Path.Combine(Location, modelFile);
+        Log.Information("GAME(ONNX): Loading model {ModelPath} (exists={Exists})",
+            modelPath, System.IO.File.Exists(modelPath));
+        return Onnx.getInferenceSession(modelPath, runnerChoice);
+    }
+
+    private int ResolveLanguageId(string? languageCode) {
+        if (languageCode != null && config.Languages != null &&
+            config.Languages.TryGetValue(languageCode, out int id)) {
+            return id;
+        }
+
+        return 0;
+    }
+
+    private (Tensor<float> x_seg, Tensor<float> x_est, Tensor<bool> maskT)
+        RunEncoder(Tensor<float> waveform, Tensor<float> duration) {
+        var inputs = new List<NamedOnnxValue> {
+            NamedOnnxValue.CreateFromTensor("waveform", waveform),
+            NamedOnnxValue.CreateFromTensor("duration", duration),
+        };
+
+        using var outputs = encoderSession!.Run(inputs, encoderSession.OutputNames, runOptions);
+
+        var xSeg = outputs.First(o => o.Name == "x_seg").AsTensor<float>().ToDenseTensor();
+        var xEst = outputs.First(o => o.Name == "x_est").AsTensor<float>().ToDenseTensor();
+        var maskT = outputs.First(o => o.Name == "maskT").AsTensor<bool>().ToDenseTensor();
+
+        return (xSeg, xEst, maskT);
+    }
+
+    private Tensor<bool> RunSegmenter(
+        Tensor<float> xSeg,
+        Tensor<bool> knownBoundaries, Tensor<bool>? prevBoundaries,
+        Tensor<float>? t, Tensor<bool> maskT,
+        Tensor<long>? language,
+        Tensor<float> threshold, Tensor<long> radius) {
+        var inputs = new List<NamedOnnxValue>();
+        inputs.Add(NamedOnnxValue.CreateFromTensor("x_seg", xSeg));
+
+        if (language != null) {
+            inputs.Add(NamedOnnxValue.CreateFromTensor("language", language));
+        }
+
+        inputs.Add(NamedOnnxValue.CreateFromTensor("known_boundaries", knownBoundaries));
+
+        if (prevBoundaries != null) {
+            inputs.Add(NamedOnnxValue.CreateFromTensor("prev_boundaries", prevBoundaries));
+        }
+
+        if (t != null) {
+            inputs.Add(NamedOnnxValue.CreateFromTensor("t", t));
+        }
+
+        inputs.Add(NamedOnnxValue.CreateFromTensor("maskT", maskT));
+        inputs.Add(NamedOnnxValue.CreateFromTensor("threshold", threshold));
+        inputs.Add(NamedOnnxValue.CreateFromTensor("radius", radius));
+
+        using var outputs = segmenterSession!.Run(inputs, segmenterSession.OutputNames, runOptions);
+        var boundaries = outputs.First(o => o.Name == "boundaries").AsTensor<bool>().ToDenseTensor();
+        return boundaries;
+    }
+
+    private (Tensor<float> durations, Tensor<bool> maskN)
+        RunBd2Dur(Tensor<bool> boundaries, Tensor<bool> maskT) {
+        var inputs = new List<NamedOnnxValue> {
+            NamedOnnxValue.CreateFromTensor("boundaries", boundaries),
+            NamedOnnxValue.CreateFromTensor("maskT", maskT),
+        };
+
+        using var outputs = bd2durSession!.Run(inputs, bd2durSession.OutputNames, runOptions);
+        var durations = outputs.First(o => o.Name == "durations").AsTensor<float>().ToDenseTensor();
+        var maskN = outputs.First(o => o.Name == "maskN").AsTensor<bool>().ToDenseTensor();
+
+        return (durations, maskN);
+    }
+
+    private (Tensor<bool> presence, Tensor<float> scores)
+        RunEstimator(Tensor<float> xEst, Tensor<bool> boundaries, Tensor<bool> maskT,
+            Tensor<bool> maskN, Tensor<float> threshold) {
+        var inputs = new List<NamedOnnxValue> {
+            NamedOnnxValue.CreateFromTensor("x_est", xEst),
+            NamedOnnxValue.CreateFromTensor("boundaries", boundaries),
+            NamedOnnxValue.CreateFromTensor("maskT", maskT),
+            NamedOnnxValue.CreateFromTensor("maskN", maskN),
+            NamedOnnxValue.CreateFromTensor("threshold", threshold),
+        };
+
+        using var outputs = estimatorSession!.Run(inputs, estimatorSession.OutputNames, runOptions);
+        var presence = outputs.First(o => o.Name == "presence").AsTensor<bool>().ToDenseTensor();
+        var scores = outputs.First(o => o.Name == "scores").AsTensor<float>().ToDenseTensor();
+        return (presence, scores);
+    }
+}

--- a/OpenUtau.Core/Analysis/GameOnnxBackend.cs
+++ b/OpenUtau.Core/Analysis/GameOnnxBackend.cs
@@ -30,6 +30,7 @@ public class GameOnnxBackend : IGameBackend {
     readonly string Location;
 
     public string Name => "ONNX";
+    public GameConfig Config => config;
 
     public GameOnnxBackend(GameConfig config, string location) {
         this.config = config;

--- a/OpenUtau.Core/Analysis/IGameBackend.cs
+++ b/OpenUtau.Core/Analysis/IGameBackend.cs
@@ -18,6 +18,9 @@ public interface IGameBackend : IDisposable {
     /// <summary>Short display name for diagnostics ("ONNX", "GGML").</summary>
     string Name { get; }
 
+    /// <summary>Configuration loaded from this backend's own package.</summary>
+    GameConfig Config { get; }
+
     /// <summary>
     /// Load the model if not already loaded. Called lazily before the first
     /// inference. Returns true if the weights/executable are present and ready.

--- a/OpenUtau.Core/Analysis/IGameBackend.cs
+++ b/OpenUtau.Core/Analysis/IGameBackend.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenUtau.Core.Analysis;
+
+/// <summary>
+/// Pluggable inference backend for the GAME MIDI extractor.
+/// <list type="bullet">
+/// <item><see cref="GameOnnxBackend"/> wraps the ONNX Runtime four-model pipeline.</item>
+/// <item><see cref="GameGgmlBackend"/> drives the native GAME-ggml CLI (<c>serve</c> mode).</item>
+/// </list>
+/// Implementations are responsible for lazily loading their model lifecycle and
+/// for honoring <see cref="Interrupt"/>. Audio chunking, resampling, batching and
+/// the final note→tick mapping are handled by <see cref="MidiExtractor{TOptions}"/>,
+/// so backends only need to transcribe a single preprocessed waveform (or a batch).
+/// </summary>
+public interface IGameBackend : IDisposable {
+    /// <summary>Short display name for diagnostics ("ONNX", "GGML").</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Load the model if not already loaded. Called lazily before the first
+    /// inference. Returns true if the weights/executable are present and ready.
+    /// </summary>
+    bool EnsureLoaded();
+
+    /// <summary>Transcribe a single preprocessed (mono, expected-sample-rate) waveform.</summary>
+    List<TranscribedNote> RunInference(float[] samples, GameOptions options);
+
+    /// <summary>
+    /// Transcribe a batch of waveforms. Default implementation falls back to
+    /// per-chunk calls; backends with native batching override it.
+    /// </summary>
+    List<List<TranscribedNote>> RunInferenceBatch(List<float[]> batch, GameOptions options) {
+        var results = new List<List<TranscribedNote>>(batch.Count);
+        foreach (var samples in batch) {
+            results.Add(RunInference(samples, options));
+        }
+        return results;
+    }
+
+    /// <summary>Request cancellation of any in-flight inference.</summary>
+    void Interrupt();
+}

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -159,6 +159,11 @@ namespace OpenUtau.Core.Util {
             public int WorldlineR = 0;
             public string OnnxRunner = string.Empty;
             public int OnnxGpu = 0;
+            /// <summary>
+            /// GAME MIDI extractor backend preference: "onnx" (default) or "ggml".
+            /// Affects which inference engine Game uses; see GameBackendFactory.
+            /// </summary>
+            public string GameBackend = "onnx";
             public double DiffSingerDepth = 1.0;
             public int DiffSingerSteps = 20;
             public int DiffSingerStepsVariance = 20;

--- a/OpenUtau.Test/Core/Analysis/GameGgmlBackendTest.cs
+++ b/OpenUtau.Test/Core/Analysis/GameGgmlBackendTest.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using OpenUtau.Core.Analysis;
+using Xunit;
+
+namespace OpenUtau.Core {
+    public class GameGgmlBackendTest {
+        [Fact]
+        public void ResolveGgufPathHonorsExplicitLocation() {
+            string directory = CreateTempDirectory();
+            try {
+                string small = Path.Combine(directory, "small.gguf");
+                string medium = Path.Combine(directory, "medium.gguf");
+                File.WriteAllBytes(small, new byte[1]);
+                File.WriteAllBytes(medium, new byte[2]);
+
+                Assert.Equal(medium, GameGgmlBackend.ResolveGgufPath(directory));
+            } finally {
+                Directory.Delete(directory, true);
+            }
+        }
+
+        [Fact]
+        public void LoadConfigReadsConfigNextToGgufWithoutOnnxPackage() {
+            string directory = CreateTempDirectory();
+            try {
+                File.WriteAllBytes(Path.Combine(directory, "model.gguf"), new byte[1]);
+                File.WriteAllText(
+                    Path.Combine(directory, "config.json"),
+                    "{\"samplerate\":32000,\"timestep\":0.02,\"languages\":{\"zh\":1}}");
+
+                GameConfig config = GameGgmlBackend.LoadConfig(directory);
+
+                Assert.Equal(32000, config.SampleRate);
+                Assert.Equal(0.02f, config.Timestep);
+                Assert.Equal(1, config.Languages!["zh"]);
+            } finally {
+                Directory.Delete(directory, true);
+            }
+        }
+
+        [Fact]
+        public void LoadConfigRejectsMissingConfigNextToGguf() {
+            string directory = CreateTempDirectory();
+            try {
+                File.WriteAllBytes(Path.Combine(directory, "model.gguf"), new byte[1]);
+
+                var error = Assert.Throws<InvalidOperationException>(
+                    () => GameGgmlBackend.LoadConfig(directory));
+
+                Assert.Contains("config.json", error.Message);
+            } finally {
+                Directory.Delete(directory, true);
+            }
+        }
+
+        private static string CreateTempDirectory() {
+            string directory = Path.Combine(Path.GetTempPath(), $"OpenUtau.GameGgmlBackendTest.{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+            return directory;
+        }
+    }
+}

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -619,6 +619,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.playback.systemdefault">Use system default device</system:String>
   <system:String x:Key="prefs.playback.test">Test</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>
+  <system:String x:Key="prefs.rendering.gamebackend">GAME Inference Backend</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>
   <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -93,6 +93,10 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public GpuInfo OnnxGpu { get; set; }
         [Reactive] public bool ShowOnnxGpu { get; set; }
 
+        // GAME backend (onnx / ggml)
+        public List<string> GameBackendOptions { get; } = new() { "ONNX", "GGML" };
+        [Reactive] public string GameBackend { get; set; }
+
         // Appearance
         [Reactive] public string ThemeName { get; set; }
         [Reactive] public int DegreeStyle { get; set; }
@@ -170,6 +174,12 @@ namespace OpenUtau.App.ViewModels {
             OnnxGpuOptions = Onnx.getGpuInfo();
             OnnxGpu = OnnxGpuOptions.FirstOrDefault(x => x.deviceId == Preferences.Default.OnnxGpu, OnnxGpuOptions[0]);
             ShowOnnxGpu = OnnxRunner == "DirectML";
+            // GAME backend: ONNX is the default, GGML is available when installed.
+            // The options list always includes both so the ComboBox UX is stable.
+            GameBackend = Preferences.Default.GameBackend switch {
+                "ggml" => "GGML",
+                _ => "ONNX",  // default / empty / unrecognized all map to ONNX
+            };
             DiffSingerDepth = Preferences.Default.DiffSingerDepth * 100;
             DiffSingerSteps = Preferences.Default.DiffSingerSteps;
             DiffSingerStepsVariance = Preferences.Default.DiffSingerStepsVariance;
@@ -342,6 +352,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.OnnxGpu)
                 .Subscribe(index => {
                     Preferences.Default.OnnxGpu = index.deviceId;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.GameBackend)
+                .Subscribe(index => {
+                    Preferences.Default.GameBackend = index == "GGML" ? "ggml" : "onnx";
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.RememberMid)

--- a/OpenUtau/ViewModels/TranscribeViewModel.cs
+++ b/OpenUtau/ViewModels/TranscribeViewModel.cs
@@ -100,11 +100,12 @@ namespace OpenUtau.App.ViewModels {
                 SelectedAlgorithm = TranscribeAlgorithm.SOME;
             }
 
-            // Load GAME config (no model sessions) to populate options
+            // Load config from the backend that will actually run (no model sessions).
+            // In particular, GGML-only installs must not probe the ONNX package.
             GameConfig? gameConfig = null;
             if (GameAvailable) {
                 try {
-                    gameConfig = Game.LoadConfig();
+                    gameConfig = GameBackendFactory.LoadResolvedConfig();
                 } catch {
                     GameAvailable = false;
                 }

--- a/OpenUtau/ViewModels/TranscribeViewModel.cs
+++ b/OpenUtau/ViewModels/TranscribeViewModel.cs
@@ -103,7 +103,11 @@ namespace OpenUtau.App.ViewModels {
             // Load GAME config (no model sessions) to populate options
             GameConfig? gameConfig = null;
             if (GameAvailable) {
-                gameConfig = Game.LoadConfig();
+                try {
+                    gameConfig = Game.LoadConfig();
+                } catch {
+                    GameAvailable = false;
+                }
             }
 
             GameHasLanguages = (gameConfig?.Languages?.Count ?? 0) > 0;

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -207,11 +207,8 @@
             <ComboBox ItemsSource="{Binding OnnxGpuOptions}" SelectedItem="{Binding OnnxGpu}"/>
             <TextBlock Classes="restart"/>
           </StackPanel>
-          <!-- GAME backend selection -->
-          <TextBlock Text="GAME Inference Backend" Margin="0,14,0,0" FontWeight="Bold"/>
+          <TextBlock Text="{DynamicResource prefs.rendering.gamebackend}" Margin="0,10,0,0"/>
           <ComboBox ItemsSource="{Binding GameBackendOptions}" SelectedItem="{Binding GameBackend}"/>
-          <TextBlock Text="Restart transcription after switching."
-                     FontSize="11" Foreground="Gray" TextWrapping="Wrap" Margin="0,0,0,4"/>
         </StackPanel>
 
         <!-- Appearance -->

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -207,6 +207,11 @@
             <ComboBox ItemsSource="{Binding OnnxGpuOptions}" SelectedItem="{Binding OnnxGpu}"/>
             <TextBlock Classes="restart"/>
           </StackPanel>
+          <!-- GAME backend selection -->
+          <TextBlock Text="GAME Inference Backend" Margin="0,14,0,0" FontWeight="Bold"/>
+          <ComboBox ItemsSource="{Binding GameBackendOptions}" SelectedItem="{Binding GameBackend}"/>
+          <TextBlock Text="Restart transcription after switching."
+                     FontSize="11" Foreground="Gray" TextWrapping="Wrap" Margin="0,0,0,4"/>
         </StackPanel>
 
         <!-- Appearance -->


### PR DESCRIPTION
## Summary

- add a pluggable GAME inference backend abstraction while preserving the existing ONNX implementation
- add a native GGML backend using the long-lived `game_ggml_cli serve` protocol
- support independent GGML-only installation through a `game-ggml-medium` `.oudep` package
- add an ONNX/GGML backend selector in Preferences with automatic fallback to an installed backend
- load the active backend's own `config.json`, so GGML does not require the ONNX GAME package
- handle process cancellation, stderr draining, Unix executable permissions, and paths containing spaces

## Origin & Credits

This GGML backend grew out of [KCKT0112/GAME-ggml](https://github.com/KCKT0112/GAME-ggml)
(native C++/ggml GAME inference — CPU/Metal/CUDA/Vulkan) and its web variant
[KCKT0112/web-game](https://github.com/KCKT0112/web-game) (Web Generative
Adaptive MIDI Extractor).  The model, operator set, and weight layout ported
there form the basis of the [game.cpp](https://github.com/KakaruHayate/game.cpp)
backend; the [GAME](https://github.com/openvpi/GAME) PyTorch original remains
the parity reference.

## Motivation

The GGML implementation runs GAME without ONNX Runtime model sessions or a Python runtime. The native backend supports Vulkan/CUDA on Windows and Linux, plus Metal on macOS, and keeps one model process alive for all chunks in a transcription request.

The backend is implemented in a separate project: [KakaruHayate/game.cpp](https://github.com/KakaruHayate/game.cpp). It uses ggml and packages the native executable, runtime libraries, medium GGUF model, and GAME config as one OpenUtau dependency package.

## Official packages (v0.1.1)

Ready-to-install `.oudep` files are published to the
[KakaruHayate/game.cpp Releases](https://github.com/KakaruHayate/game.cpp/releases/tag/v0.1.1):

| platform | full (F32) | q8 (Q8_0) |
|---|---|---|
| Windows x64 | `game_ggml-windows-x64-vulkan.oudep` + `-cuda.oudep` | same names, `-q8` suffix |
| Linux x64 | `...-linux-x64-vulkan.oudep` + `...-cuda.oudep` | same |
| Linux x64 | `...-linux-x64-cpu.oudep` | same |
| macOS | `game_ggml-macos-{arm64,x64}-metal.oudep` | same |

Download the archive for your platform, unzip it in OpenUtau's Dependencies
folder at `Dependencies/game-ggml-medium/` (both the CLI and the GGUF live in
one package), restart OpenUtau, and select the GGML backend in Preferences.

## Recommended GGML configuration

Full measurements in [`docs/benchmark-7channel.md`](https://github.com/KakaruHayate/game.cpp/blob/main/docs/benchmark-7channel.md)
(60 s audio, no slicing, nsteps=8, frame-level metrics vs the torch-CUDA fp32
no-cache baseline — every EP ≥ 0.97 RPA):

| platform | GPU | weights | EP | notes |
|---|---|---|---|---|
| Windows | NVIDIA | F32 | CUDA (fallback Vulkan) | 6–8 s wall |
| Windows | Intel/AMD/etc | F32 | Vulkan | 4–5 s, smallest VRAM (+0.3 GiB) |
| Windows | integrated | F32/Q8 | CPU + DBCache | 48.5→27.1 s (−44 %), quality-neutral |
| Linux | NVIDIA | F32 | CUDA (fallback Vulkan) | as Windows CUDA |
| Linux | Nouveau/AMD | F32 | Vulkan | as Windows Vulkan |
| macOS | Apple Silicon | F32 | Metal (only EP) | CI-built |
| macOS | Intel | F32 | Metal (cross-compiled) | CI-built |

Rules of thumb:
- GPU present → **F32** weights; CPU-only → CPU EP with **DBCache on by default** (−44 % wall, quality-neutral).
- On GPU, Vulkan = smallest VRAM, CUDA = fastest wall.
- Q8 saves ~3.4× VRAM/RAM (near-lossless quality) but may flip a boundary note on Vulkan — use the `-full` package if you need bit-consistent output; both are valid in practice.
- No user escalation needed: CLI picks backend from GGUF/EP and cache defaults by EP (GPU off, CPU auto).

## Design

- `IGameBackend` isolates model lifecycle, inference, cancellation, and configuration.
- `GameOnnxBackend` is a behavior-preserving extraction of the existing four-model ONNX pipeline and retains native batching.
- `GameGgmlBackend` starts `game_ggml_cli serve <model.gguf>` lazily, sends framed float32 waveform requests through stdin, and reads one-line JSON note responses from stdout.
- `GameBackendFactory` resolves the user preference and falls back to an installed backend (ONNX first for compatibility).
- GGML installation is considered valid only when the CLI, GGUF model, and adjacent `config.json` are all present.

## Verification

On current `openutau/OpenUtau:master`:

- `GameGgmlBackendTest`: 3 passed
- `dotnet test OpenUtau.Test`: 209 passed
- `dotnet build OpenUtau.sln`: 0 warnings, 0 errors
- the Windows x64 Vulkan artifact from the linked run was launched with `serve` and returned `{"type":"ready"}`
- the CUDA artifacts are built with CUDA Toolkit 12.6.3 (release architecture 7.5 with forward-compatible PTX) and verified for Toolkit discovery, compilation, linking, packaging, and PE import-table integrity; the GitHub-hosted runner has no NVIDIA driver, so the CUDA startup smoke test runs on a machine with an NVIDIA GPU
- Windows and Linux artifact layouts and `oudep.yaml` manifests were checked against OpenUtau PackageManager expectations
- CI (game.cpp @ main + v0.1.0) is green: prepare-model(F32+Q8) → 7 platform builds → 14 oudep packages → release

## Notes

- ONNX remains the default and preferred fallback when both packages are installed.
- GGML currently processes one chunk per request; OpenUtau disables batch dispatch for this backend.
- The `.oudep` package id is `game-ggml-medium`, independent from the existing ONNX `game` package.

