### PR TITLE
Reduce playback latency to improve playhead synchronization

### DIFF
--- a/OpenUtau/NAudioOutput.cs
+++ b/OpenUtau/NAudioOutput.cs
@@ -17,6 +17,7 @@ namespace OpenUtau.App {
 #else
     public class NAudioOutput : IAudioOutput {
         const int Channels = 2;
+        const int PlaybackLatencyMs = 50;
 
         private readonly object lockObj = new object();
         private WaveOutEvent? waveOutEvent;
@@ -84,7 +85,7 @@ namespace OpenUtau.App {
                         wasapiOut.Stop();
                         wasapiOut.Dispose();
                     }
-                    wasapiOut = new WasapiOut(AudioClientShareMode.Shared, 200);
+                    wasapiOut = new WasapiOut(AudioClientShareMode.Shared, PlaybackLatencyMs);
                     wasapiOut.PlaybackStopped += OnWasapiPlaybackStopped;
                     wasapiOut.Init(sampleProvider);
                 } else {
@@ -94,6 +95,8 @@ namespace OpenUtau.App {
                     }
                     waveOutEvent = new WaveOutEvent() {
                         DeviceNumber = deviceNumber,
+                        DesiredLatency = PlaybackLatencyMs,
+                        NumberOfBuffers = 2,
                     };
                     waveOutEvent.Init(sampleProvider);
                 }


### PR DESCRIPTION
Reduce audio output latency to minimize desynchronization between the playhead and audible playback.

- Use a shared 50 ms playback latency setting for WASAPI and WaveOut.
- Configure WaveOut with two buffers to keep its playback queue short.

before:
https://github.com/user-attachments/assets/b75a0d02-159e-4147-9cfd-3b2f2fead545

after:
https://github.com/user-attachments/assets/b0d31823-c8b7-4d82-9f0b-7fb1192771cf


