### PR TITLE
Fix presamp: add MakePhonemeList call to exception handling

### DIFF
--- a/OpenUtau.Core/Classic/Presamp.cs
+++ b/OpenUtau.Core/Classic/Presamp.cs
@@ -231,12 +231,12 @@ namespace Classic {
                         }
                     }
                 }
-                
+
+                MakePhonemeList();
+
             } catch (Exception e) {
                 Log.Error(e, "failed to load presamp.ini");
             }
-
-            MakePhonemeList();
         }
 
         public bool TryGetLinesFromIniBrocks(List<IniBlock> blocks, string header, out List<IniLine> lines) {


### PR DESCRIPTION
Modified the exception handling to include a call to MakePhonemeList.

Changed the call location of MakePhonemeList() and added exception handling.
This ensures that exceptions occurring during the execution of MakePhonemeList() are now properly recorded in the log.