### PR TITLE
Fix Pitch Overwrite Mode

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModelHitTest.cs
+++ b/OpenUtau/ViewModels/NotesViewModelHitTest.cs
@@ -267,7 +267,9 @@ namespace OpenUtau.App.ViewModels {
                 return null;
             }
             double tick = viewModel.PointToTick(point);
-            var phrase = viewModel.Part.renderPhrases.FirstOrDefault(p => p.end >= tick);
+            double absTick = tick + viewModel.Part.position;
+
+            var phrase = viewModel.Part.renderPhrases.FirstOrDefault(p => p.end >= absTick);
             if (phrase == null) {
                 phrase = viewModel.Part.renderPhrases.Last();
             }
@@ -275,7 +277,8 @@ namespace OpenUtau.App.ViewModels {
                 return null;
             }
             var curve = phrase.pitchesBeforeDeviation;
-            var pitchIndex = (int)Math.Round((tick - phrase.position + phrase.leading) / 5);
+            int phraseStartRel = phrase.position - viewModel.Part.position;
+            var pitchIndex = (int)Math.Round((tick - phraseStartRel + phrase.leading) / 5.0);
             pitchIndex = Math.Clamp(pitchIndex, 0, curve.Length - 1);
             return curve[pitchIndex];
         }


### PR DESCRIPTION
Bug: SampleOverwritePitch mixed part-relative and absolute ticks, causing wrong pitch sampling when a part's position != 0.
Fix: convert the view tick to an absolute tick to select the correct RenderPhrase, and compute the phrase-relative index (phrase.position - part.position) when indexing pitchesBeforeDeviation.
Result: overwrite pitch sampling (DrawPitchState / SmoothenPitchState) returns the correct pitch regardless of part.position.