### PR TITLE
feat: add explicit playback loop toggle

### DIFF
--- a/OpenUtau.Core/PlaybackManager.cs
+++ b/OpenUtau.Core/PlaybackManager.cs
@@ -189,14 +189,17 @@ namespace OpenUtau.Core {
         public int StartTick => DocManager.Inst.Project.timeAxis.MsPosToTickPos(startMs);
         CancellationTokenSource renderCancellation;
 
-        // Loop playback state
-        private int loopStartTick = 0;
-        private int loopEndTick = -1;
+        // Active playback range captured when playback starts. Its end remains a stop
+        // boundary even when looping is disabled.
+        private int playbackRangeStartTick = 0;
+        private int playbackRangeEndTick = -1;
+        private bool loopProjectOnPlaybackEnd;
 
         public Audio.IAudioOutput AudioOutput { get; set; } = new Audio.DummyAudioOutput();
         public bool OutputActive => AudioOutput.PlaybackState == PlaybackState.Playing;
         public bool StartingToPlay { get; private set; }
         public bool PlayingMaster { get; private set; }
+        public bool LoopPlayback { get; set; }
 
         public void PlayTestSound() {
             masterMix = null;
@@ -246,17 +249,23 @@ namespace OpenUtau.Core {
             } else {
                 int rangeStart = DocManager.Inst.rangeStartTick;
                 int rangeEnd = DocManager.Inst.rangeEndTick;
-                if (rangeEnd > rangeStart) {
+                if (endTick == -1 && rangeEnd > rangeStart) {
                     int playPos = DocManager.Inst.playPosTick;
-                    loopStartTick = rangeStart;
-                    loopEndTick = rangeEnd;
+                    playbackRangeStartTick = rangeStart;
+                    playbackRangeEndTick = rangeEnd;
+                    loopProjectOnPlaybackEnd = false;
                     Play(
                         DocManager.Inst.Project,
-                        tick: tick == -1 ? ((playPos >= rangeStart && playPos < rangeEnd) ? playPos : rangeStart) : tick,
-                        endTick: endTick == -1 ? rangeEnd : endTick,
+                        tick: tick == -1
+                            ? ((playPos >= rangeStart && playPos < rangeEnd) ? playPos : rangeStart)
+                            : tick,
+                        endTick: rangeEnd,
                         trackNo: trackNo);
                 } else {
-                    loopEndTick = -1;
+                    playbackRangeEndTick = -1;
+                    // Explicit bounds are used for one-shot previews such as Alt+Space
+                    // on selected notes; they must not fall through to project looping.
+                    loopProjectOnPlaybackEnd = endTick == -1;
                     Play(
                         DocManager.Inst.Project,
                         tick: tick == -1 ? DocManager.Inst.playPosTick : tick,
@@ -273,21 +282,25 @@ namespace OpenUtau.Core {
                 return;
             }
             AudioOutput.Stop();
-            Render(project, tick, endTick, trackNo);
             StartingToPlay = true;
             PlayingMaster = true;
+            Render(project, tick, endTick, trackNo);
         }
 
         public void StopPlayback() {
             AudioOutput.Stop();
+            StartingToPlay = false;
             PlayingMaster = false;
-            loopEndTick = -1;
+            playbackRangeEndTick = -1;
+            loopProjectOnPlaybackEnd = false;
         }
 
         public void PausePlayback() {
             AudioOutput.Pause();
+            StartingToPlay = false;
             PlayingMaster = false;
-            loopEndTick = -1;
+            playbackRangeEndTick = -1;
+            loopProjectOnPlaybackEnd = false;
         }
 
         private void StartPlayback(double startMs, MasterAdapter masterAdapter) {
@@ -323,18 +336,39 @@ namespace OpenUtau.Core {
             if (AudioOutput != null && AudioOutput.PlaybackState == PlaybackState.Playing && PlayingMaster) {
                 double ms = (AudioOutput.GetPosition() / sizeof(float) - masterMix.Waited / 2) * 1000.0 / 44100;
                 int tick = DocManager.Inst.Project.timeAxis.MsPosToTickPos(startMs + ms);
-                if (loopEndTick > 0 && tick >= loopEndTick) {
-                    // Loop back to range start
-                    Play(DocManager.Inst.Project, tick: loopStartTick, endTick: loopEndTick);
+                if (playbackRangeEndTick > 0 && tick >= playbackRangeEndTick) {
+                    HandlePlaybackBoundary(hasPlaybackRange: true);
                     return;
                 }
                 DocManager.Inst.ExecuteCmd(new SetPlayPosTickNotification(tick, masterMix.IsWaiting));
-            } else if (AudioOutput != null && AudioOutput.PlaybackState == PlaybackState.Stopped && PlayingMaster) {
-                // Playback stopped (e.g. silence at end). Check if we should loop.
-                if (loopEndTick > 0) {
-                    Play(DocManager.Inst.Project, tick: loopStartTick, endTick: loopEndTick);
+            } else if (AudioOutput != null &&
+                AudioOutput.PlaybackState == PlaybackState.Stopped &&
+                PlayingMaster &&
+                !StartingToPlay) {
+                HandlePlaybackBoundary(hasPlaybackRange: playbackRangeEndTick > 0);
+            }
+        }
+
+        private void HandlePlaybackBoundary(bool hasPlaybackRange) {
+            if (LoopPlayback) {
+                if (hasPlaybackRange) {
+                    Play(
+                        DocManager.Inst.Project,
+                        tick: playbackRangeStartTick,
+                        endTick: playbackRangeEndTick);
                     return;
                 }
+                if (loopProjectOnPlaybackEnd && DocManager.Inst.Project.EndTick > 0) {
+                    Play(DocManager.Inst.Project, tick: 0);
+                    return;
+                }
+            }
+            if (hasPlaybackRange) {
+                int endTick = playbackRangeEndTick;
+                StopPlayback();
+                DocManager.Inst.ExecuteCmd(new SetPlayPosTickNotification(endTick));
+            } else {
+                StopPlayback();
             }
         }
 

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -139,8 +139,11 @@ namespace OpenUtau.Core.Render {
         // for playback
         public Tuple<MasterAdapter, List<Fader>> RenderProject(TaskScheduler uiScheduler, ref CancellationTokenSource cancellation) {
             double startMs = project.timeAxis.TickPosToMsPos(startTick);
+            double endMs = endTick == -1
+                ? double.PositiveInfinity
+                : project.timeAxis.TickPosToMsPos(endTick);
             var renderMixdownResult = RenderMixdown(uiScheduler, ref cancellation, wait: false);
-            var master = new MasterAdapter(renderMixdownResult.Item1);
+            var master = new MasterAdapter(renderMixdownResult.Item1, endMs);
             master.SetPosition((int)(startMs * 44100 / 1000) * 2);
             return Tuple.Create(master, renderMixdownResult.Item2);
         }

--- a/OpenUtau.Core/SignalChain/MasterAdapter.cs
+++ b/OpenUtau.Core/SignalChain/MasterAdapter.cs
@@ -3,19 +3,36 @@ using NAudio.Wave;
 
 namespace OpenUtau.Core.SignalChain {
     class MasterAdapter : ISampleProvider {
+        private const int SampleRate = 44100;
+        private const int Channels = 2;
+        // Short edge fades prevent clicks without mixing audio past the playback end.
+        private const int FadeMilliseconds = 3;
+        private const int FadeFrames = SampleRate * FadeMilliseconds / 1000;
+
         private readonly WaveFormat waveFormat;
         private readonly ISignalSource source;
+        private readonly int endPosition;
         private int position;
+        private int startPosition;
 
         public WaveFormat WaveFormat => waveFormat;
         public int Waited { get; private set; }
         public bool IsWaiting { get; private set; }
-        public MasterAdapter(ISignalSource source) {
-            waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(44100, 2);
+        public MasterAdapter(ISignalSource source, double endMs = double.PositiveInfinity) {
+            waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(SampleRate, Channels);
             this.source = source;
+            endPosition = double.IsPositiveInfinity(endMs)
+                ? -1
+                : (int)(endMs * SampleRate / 1000) * Channels;
         }
 
         public int Read(float[] buffer, int offset, int count) {
+            if (endPosition >= 0) {
+                count = Math.Min(count, endPosition - position);
+                if (count <= 0) {
+                    return 0;
+                }
+            }
             for (int i = offset; i < offset + count; ++i) {
                 buffer[i] = 0;
             }
@@ -24,9 +41,34 @@ namespace OpenUtau.Core.SignalChain {
                 IsWaiting = true;
                 return count;
             } else {
+                int readPosition = position;
                 int pos = source.Mix(position, buffer, offset, count);
                 int n = Math.Max(0, pos - position);
                 position = pos;
+                int startFrame = startPosition / Channels;
+                int endFrame = endPosition / Channels;
+                for (int i = 0; i < n; ++i) {
+                    int frame = (readPosition + i) / Channels;
+                    int elapsedFrames = frame - startFrame;
+                    float gain = Math.Clamp(
+                        elapsedFrames / (FadeFrames - 1f),
+                        0,
+                        1);
+                    if (endPosition >= 0) {
+                        int remainingFrames = endFrame - (readPosition + i) / Channels;
+                        if (remainingFrames <= FadeFrames) {
+                            gain = Math.Min(
+                                gain,
+                                Math.Clamp(
+                                    (remainingFrames - 1f) / (FadeFrames - 1),
+                                    0,
+                                    1));
+                        }
+                    }
+                    if (gain < 1) {
+                        buffer[offset + i] *= gain;
+                    }
+                }
                 IsWaiting = false;
                 return n;
             }
@@ -34,6 +76,7 @@ namespace OpenUtau.Core.SignalChain {
 
         public void SetPosition(int position) {
             this.position = position;
+            startPosition = position;
             Waited = 0;
         }
     }

--- a/OpenUtau.Test/Core/SignalChain/WaveSourceTest.cs
+++ b/OpenUtau.Test/Core/SignalChain/WaveSourceTest.cs
@@ -73,5 +73,24 @@ namespace OpenUtau.Core.SignalChain {
             Assert.True(source.IsReady(len - 100 + 1, 100));
             Assert.True(source.IsReady(len * 2 - 1, 100));
         }
+
+        [Fact]
+        public void MasterAdapterFadesAndStopsAtEndTest() {
+            var source = new WaveSource(0, 20, 0, 2);
+            var samples = new float[44100 * 20 / 1000 * 2];
+            System.Array.Fill(samples, 1f);
+            source.SetSamples(samples);
+            var adapter = new MasterAdapter(source, endMs: 10);
+            adapter.SetPosition(0);
+            var buffer = new float[2048];
+
+            int read = adapter.Read(buffer, 0, buffer.Length);
+
+            Assert.Equal(44100 * 10 / 1000 * 2, read);
+            Assert.Equal(0, buffer[0]);
+            Assert.Equal(1, buffer[440]);
+            Assert.Equal(0, buffer[read - 2]);
+            Assert.Equal(0, adapter.Read(buffer, 0, buffer.Length));
+        }
     }
 }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -777,6 +777,7 @@ General
     Space: Play</system:String>
   <system:String x:Key="tip.notes.zoomx">◀ Scroll here to zoom horizontally ▶</system:String>
   <system:String x:Key="tip.notes.zoomy">Scroll here to zoom vertically ▶</system:String>
+  <system:String x:Key="tip.playback.loop">Loop playback</system:String>
 
   <system:String x:Key="tracks.duplicate">Duplicate Track</system:String>
   <system:String x:Key="tracks.duplicatesettings">Duplicate Track Settings</system:String>

--- a/OpenUtau/Styles/Styles.axaml
+++ b/OpenUtau/Styles/Styles.axaml
@@ -302,12 +302,15 @@
     <Setter Property="VerticalAlignment" Value="Center"/>
     <Setter Property="HorizontalAlignment" Value="Center"/>
   </Style>
-  <Style Selector="Border.playback Button">
+  <Style Selector="Border.playback Button, Border.playback ToggleButton">
     <Setter Property="Margin" Value="0"/>
     <Setter Property="Padding" Value="0"/>
     <Setter Property="Width" Value="21"/>
     <Setter Property="Height" Value="19"/>
     <Setter Property="Background" Value="Transparent"/>
+  </Style>
+  <Style Selector="Border.playback ToggleButton:checked /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushSemi}"/>
   </Style>
 
   <Style Selector="Border.tips">

--- a/OpenUtau/ViewModels/PlaybackViewModel.cs
+++ b/OpenUtau/ViewModels/PlaybackViewModel.cs
@@ -19,6 +19,15 @@ namespace OpenUtau.App.ViewModels {
         public bool HasRangeSelection => DocManager.Inst.rangeEndTick > DocManager.Inst.rangeStartTick;
         public bool IsPlaying => PlaybackManager.Inst.PlayingMaster;
         public bool ShowPlayPosHighlight => !IsPlaying || HasRangeSelection;
+        public bool LoopPlayback {
+            get => PlaybackManager.Inst.LoopPlayback;
+            set {
+                if (PlaybackManager.Inst.LoopPlayback != value) {
+                    PlaybackManager.Inst.LoopPlayback = value;
+                    this.RaisePropertyChanged(nameof(LoopPlayback));
+                }
+            }
+        }
 
         public PlaybackViewModel() {
             DocManager.Inst.AddSubscriber(this);

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -241,7 +241,7 @@
                 </TextBlock>
               </Grid>
             </Border>
-            <Border Classes="playback" Width="88" HorizontalAlignment="Center">
+            <Border Classes="playback" Width="109" HorizontalAlignment="Center">
               <StackPanel Orientation="Horizontal">
                 <Button Command="{Binding PlaybackViewModel.SeekStart}">
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
@@ -259,6 +259,11 @@
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
                         Data="M 0 0 L 5 4.5 L 0 9 Z M 5 0 L 7 0 L 7 9 L 5 9 Z"/>
                 </Button>
+                <ToggleButton IsChecked="{Binding PlaybackViewModel.LoopPlayback}"
+                              ToolTip.Tip="{DynamicResource tip.playback.loop}">
+                  <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
+                        Data="M 1 2 L 8 2 L 8 0 L 11 3 L 8 6 L 8 4 L 2 4 L 2 6 L 0 6 L 0 4 C 0 2.9 0.4 2 1 2 Z M 10 10 L 3 10 L 3 12 L 0 9 L 3 6 L 3 8 L 9 8 L 9 6 L 11 6 L 11 8 C 11 9.1 10.6 10 10 10 Z"/>
+                </ToggleButton>
               </StackPanel>
             </Border>
             <Border Classes="playback" Width="72" HorizontalAlignment="Right" Margin="4,0">


### PR DESCRIPTION
Appearance:
<img width="220" height="21" alt="image" src="https://github.com/user-attachments/assets/e5786ae4-0e12-4967-8e0b-fc9f5e6a69af" />


Closes #2327 .

## Summary

Adds an explicit **Loop playback** toggle to the main playback controls. Loop is off by default and can be changed during playback, taking effect at the next playback boundary.

The selected timeline range now defines playback boundaries independently of looping:

- Loop off: play the range once and stop at its end. The next Play action starts from the range start.
- Loop on: loop the selected range.
- Without a range, Loop repeats the project from tick 0.

Explicit selected-note audition with `Alt+Space` remains one-shot and takes precedence over the timeline range.

This changes the implicit range-looping behavior introduced in #2222 as described in #2327.

## Testing

```text
dotnet test OpenUtau.Test/OpenUtau.Test.csproj --configuration Debug
```

Result:

```text
Passed: 206
Failed: 0
Skipped: 0
```