### PR TITLE
Knife Tool: split notes inherit the previous expression

### DIFF
--- a/OpenUtau/Views/NoteEditStates.cs
+++ b/OpenUtau/Views/NoteEditStates.cs
@@ -457,6 +457,9 @@ namespace OpenUtau.App.Views {
             if (newNote == null) {
                 return;
             }
+            foreach (var exp in note.phonemeExpressions.OrderBy(exp => exp.index)) {
+                DocManager.Inst.ExecuteCmd(new SetNoteExpressionCommand(project, project.tracks[part.trackNo], part, newNote, exp.abbr, new float?[] { exp.value }));
+            }
             DocManager.Inst.ExecuteCmd(new ChangeNoteLyricCommand(part, newNote, NotePresets.Default.SplittedLyric));
         }
 


### PR DESCRIPTION
For now, notes split using the Knife tool always inherit the previous expression, but I don't think this needs to be an option.