### PR TITLE
Rule-based auto-merge for small PRs

### DIFF
--- a/.github/PR_REVIEW_CHECKLIST.md
+++ b/.github/PR_REVIEW_CHECKLIST.md
@@ -1,0 +1,88 @@
+# PR Review Checklist
+
+For collaborators who review PRs without owning the affected area. Your job
+is to catch what the author's tunnel vision hides: correctness, breakage,
+scope creep, and things that don't survive contact with a real build.
+
+Not all PRs are handled the same way:
+
+- **Small, low-risk changes** (think: a few files, a few dozen lines, within
+  an area like translations or docs) may be set up to auto-merge after a
+  couple of approvals — check the PR page for merge requirements. On PRs like
+  that, **your approval may be what merges the code**, so only give it when
+  you've actually done the checks below.
+- **Everything else** goes through the maintainers, who make the final call;
+  your review is input to theirs.
+
+## 1. Scope and intent
+
+- [ ] The PR is in scope for the project — it fits what OpenUtau is and how
+      it's headed. If you're not sure, leave it alone: don't review or
+      approve, let the maintainers take it.
+- [ ] The PR does what the description claims and nothing else: every changed
+      file is explainable by the PR's purpose (unrelated files → request
+      changes, ask for a split), and the linked issue, if any, is genuinely
+      resolved by this diff and referenced so it closes on merge.
+- [ ] For bug fixes: the fix addresses the cause, not just the symptom — check
+      the logic actually covers the reported repro.
+
+## 2. Read the diff
+
+- [ ] Follow the changed logic through its callers (does the change alter their
+      behavior?) and probe edge cases: null/empty inputs, missing files or
+      voice models, zero-length ranges, CJK or very long file names; failures
+      should be caught and surfaced in user-understandable terms, not
+      swallowed or dumped as stack traces.
+- [ ] Consistency with the surrounding code: naming, patterns, and behavior
+      match how the same area is already written; UI changes use the localized
+      string tables (no hard-coded strings), and layout behaves at different
+      window sizes / DPI if layout is touched.
+- [ ] Nothing accidental in the diff: no debug leftovers (`Debug.WriteLine`,
+      test `MessageBox.Show`/`Console.WriteLine`, `TODO`/`FIXME`,
+      commented-out code), no personal data (absolute paths, machine names,
+      local test assets), no binaries or large assets committed.
+
+## 3. Build and run
+
+- [ ] Build the PR branch (or use the CI artifact) — compiles. Reproduce the
+      original bug on the pre-PR build when feasible, then verify the fix on
+      the PR build.
+- [ ] Exercise the feature beyond the happy path: undo/redo, canceling dialogs,
+      repeated toggling, corner cases.
+
+## 4. Regression smoke test
+
+The minimum bar before approving a non-trivial PR — and for PRs touching a
+subsystem, also smoke-test adjacent features, not just the changed one:
+
+- [ ] Open an existing project, load a singer / voice model
+- [ ] Move some notes / pitch points, play back
+
+## 5. When to defer to the maintainers
+
+If you are uncertain in any way, do not approve — post your notes as a
+comment and let the maintainers decide. Typical cases:
+
+- [ ] New dependencies, or build/CI changes. (Upgraded dependencies are fine
+      to approve yourself, as long as you tested the build.)
+- [ ] Large changes touching many files, including "chore" PRs touching
+      hundreds of files
+- [ ] A new major feature, or behavior beyond the PR's description
+- [ ] Platform-sensitive changes that you could only test on one platform —
+      these need testing on all platforms before approval. Say which platform
+      you tested on, so others know what's still missing
+- [ ] Anything you couldn't fully follow
+
+## 6. Verdict
+
+- **Approve** — only when you are confident: you read the diff, built it,
+  tested the change and the smoke test, and can explain the change if asked.
+- **Leave it to the maintainers** — if any of section 5 applies, or anything
+  else leaves you uncertain; comment instead of approving.
+- **Request changes** — scope creep, correctness problem, or a regression you
+  reproduced. Each point must be specific (file/line or repro steps), not a
+  general concern.
+- **Make it clear what you actually did** — if you built and tested the PR,
+  say so and note how (OS, source build or CI artifact, what you tried); if
+  you only read the diff, say that too. An untested review should never look
+  like a tested one.

--- a/.github/auto-merge-rules.json
+++ b/.github/auto-merge-rules.json
@@ -1,0 +1,21 @@
+{
+  "_comment": [
+    "Rules for .github/workflows/auto-merge.yml. This file is read from the BASE",
+    "branch checkout, so a PR cannot change the rules that decide its own fate.",
+    "Any PR touching .github/ is refused auto-merge outright (see auto-merge.mjs).",
+    "",
+    "paths:      a trailing '/' means 'this directory and everything below',",
+    "            otherwise it must be the exact file name",
+    "max_lines:  strict upper bound of added+removed lines, counted per rule",
+    "            over the files inside that rule's paths only",
+    "max_files:  strict upper bound on file count, same counting"
+  ],
+  "merge_method": "squash",
+  "approvers_team": "approvers",
+  "allow_forks": false,
+  "gating_workflow": "pr-test",
+  "rules": [
+    { "name": "translations", "paths": ["OpenUtau/Strings/"], "max_files": 8, "max_lines": 64, "required_approvals": 1 },
+    { "name": "phonemizers", "paths": ["OpenUtau.Plugin.Builtin/"], "max_files": 4, "max_lines": 128, "required_approvals": 2 }
+  ]
+}

--- a/.github/scripts/auto-merge.mjs
+++ b/.github/scripts/auto-merge.mjs
@@ -4,10 +4,11 @@
 // GITHUB_TOKEN cannot stand in for. Prints the full decision trail and
 // appends it to the job summary.
 //
-// This file and RULES_FILE are checked out from the base branch, and any PR
-// touching .github/ is refused below, so a PR cannot influence its own
-// decision. Never read policy out of the environment: the workflow file that
-// sets it is taken from the PR's own merge commit.
+// This file and RULES_FILE are checked out from the base branch, the workflow
+// triggers on pull_request_target so it is read from the base branch too, and
+// any PR touching .github/ is refused below: a PR cannot influence its own
+// decision. Keep policy in RULES_FILE rather than in the environment, so that
+// stays true even if the trigger is ever changed back to pull_request.
 import fs from 'node:fs';
 
 const TOKEN = process.env.GITHUB_TOKEN;
@@ -142,7 +143,7 @@ const CHECKLIST_LINK =
 // what they require, based on the diff at that moment. Posted at most once
 // (marker comment), no matter how the diff changes afterwards.
 const becameReady =
-  EVENT.name === 'pull_request' &&
+  EVENT.name === 'pull_request_target' &&
   ((EVENT.action === 'opened' && !pr.draft) || EVENT.action === 'ready_for_review');
 if (becameReady) {
   const alreadyCommented = await (async () => {
@@ -187,7 +188,7 @@ if (becameReady) {
       `Reviewing this PR? Please work through the ${CHECKLIST_LINK} — it covers what to check ` +
         'before approving, and when to leave the call to the maintainers.'
     );
-    await fetch(`https://api.github.com/repos/${REPO}/issues/${PR}/comments`, {
+    const posted = await fetch(`https://api.github.com/repos/${REPO}/issues/${PR}/comments`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${TOKEN}`,
@@ -196,7 +197,10 @@ if (becameReady) {
       },
       body: JSON.stringify({ body: lines.join('\n') }),
     });
-    report('posted auto-merge rules comment');
+    // Non-fatal: the comment is informational, the decision below stands
+    // either way. But say so, rather than claiming a post that never landed.
+    if (posted.ok) report('posted auto-merge rules comment');
+    else report(`failed to post rules comment (${posted.status}): ${(await posted.text()).slice(0, 300)}`);
   } else {
     report('rules comment already exists, skipping');
   }

--- a/.github/scripts/auto-merge.mjs
+++ b/.github/scripts/auto-merge.mjs
@@ -62,6 +62,7 @@ const [commits, reviews, files] = await Promise.all([
 ]);
 if (commits === null) notEligible('PR has more than 300 commits');
 if (files === null) notEligible('PR changes more than 300 files');
+if (reviews === null) notEligible('PR has more than 300 reviews');
 
 // Who wrote the PR: the head author plus every commit author. Their
 // approvals never count.
@@ -92,11 +93,11 @@ const approvals = [
   ).values(),
 ];
 
-// A file belongs to a rule if it equals a path, or is below a directory path.
+// A file belongs to a rule if it equals a path, or is below a directory
+// path. Only paths with a trailing "/" act as directory prefixes; anything
+// else must be the exact file name.
 const inRule = (filename, rule) =>
-  rule.paths.some(
-    (p) => p === filename || (p.endsWith('/') && filename.startsWith(p)) || filename.startsWith(p + '/')
-  );
+  rule.paths.some((p) => (p.endsWith('/') ? filename.startsWith(p) : filename === p));
 
 const perRule = CFG.rules.map((rule) => {
   const rs = files.filter((f) => inRule(f.filename, rule));
@@ -208,8 +209,12 @@ report(
 if (teamApprovals.length < required)
   notEligible(`needs ${required} approval(s) from @${org}/${CFG.approvers_team}, has ${teamApprovals.length}`);
 
-// CI gate: every check run on the head commit must be completed and passing.
-// Runs are re-created on each push, so this always reflects the latest head.
+// CI gate: every pr-test check run on the head commit must be completed and
+// passing. Only the gating workflow's runs are considered — in particular
+// NOT this auto-merge workflow's own check run, which is in_progress while
+// we are deciding and would deadlock the merge. Runs are re-created on each
+// push, so this always reflects the latest head.
+const GATING_WORKFLOW = process.env.GATING_WORKFLOW || 'pr-test';
 async function getCheckRuns(sha) {
   let runs = [];
   for (let page = 1; page <= 5; page++) {
@@ -217,14 +222,15 @@ async function getCheckRuns(sha) {
     runs = runs.concat(data.check_runs);
     if (data.check_runs.length < 100 || runs.length >= data.total_count) break;
   }
-  return runs;
+  // Check-run names are "<job id> (<matrix summary>)".
+  return runs.filter((r) => r.name.startsWith(`${GATING_WORKFLOW} `) || r.name === GATING_WORKFLOW);
 }
 const runs = await getCheckRuns(pr.head.sha);
 if (runs.length === 0) notEligible('no CI check runs on the head commit yet — waiting for CI');
 const pending = runs.filter((r) => r.status !== 'completed');
 if (pending.length > 0)
   notEligible(`CI still running: ${pending.map((r) => r.name).join(', ')}`);
-const failing = runs.filter((r) => !['success', 'neutral'].includes(r.conclusion));
+const failing = runs.filter((r) => !['success', 'neutral', 'skipped'].includes(r.conclusion));
 if (failing.length > 0)
   notEligible(`CI failing: ${failing.map((r) => `${r.name} (${r.conclusion})`).join(', ')}`);
 report(`CI ok: ${runs.length} check(s) passed on ${pr.head.sha.slice(0, 7)}`);

--- a/.github/scripts/auto-merge.mjs
+++ b/.github/scripts/auto-merge.mjs
@@ -1,13 +1,21 @@
 // Auto-merge decision for small PRs. See .github/workflows/auto-merge.yml.
-// Runs with the workflow GITHUB_TOKEN (needs pull-requests:write,
-// organization:read). Prints the full decision trail and appends it to the
-// job summary.
+// Runs with the workflow GITHUB_TOKEN (needs contents:write and
+// pull-requests:write); the approvers-team lookup needs TEAM_TOKEN, which
+// GITHUB_TOKEN cannot stand in for. Prints the full decision trail and
+// appends it to the job summary.
+//
+// This file and RULES_FILE are checked out from the base branch, and any PR
+// touching .github/ is refused below, so a PR cannot influence its own
+// decision. Never read policy out of the environment: the workflow file that
+// sets it is taken from the PR's own merge commit.
 import fs from 'node:fs';
 
 const TOKEN = process.env.GITHUB_TOKEN;
+const TEAM_TOKEN = process.env.TEAM_TOKEN;
 const REPO = process.env.GITHUB_REPOSITORY;
 const PR = Number(process.env.PR_NUMBER);
-const CFG = JSON.parse(process.env.RULES_JSON);
+const RULES_FILE = '.github/auto-merge-rules.json';
+const CFG = JSON.parse(fs.readFileSync(RULES_FILE, 'utf8'));
 const org = REPO.split('/')[0];
 const EVENT = { name: process.env.EVENT_NAME, action: process.env.EVENT_ACTION };
 const MARKER = '<!-- auto-merge-rules -->';
@@ -52,8 +60,10 @@ async function getAll(path) {
 const pr = await getJSON(`/repos/${REPO}/pulls/${PR}`);
 if (pr.state !== 'open') notEligible(`PR is ${pr.state}`);
 if (pr.draft) notEligible('PR is a draft');
-if (!CFG.allow_forks && pr.head.repo && pr.head.repo.full_name !== REPO)
-  notEligible('PR comes from a fork');
+// head.repo is null when the source fork was deleted or is invisible to the
+// token; that is not this repo, so it must be rejected too.
+if (!CFG.allow_forks && pr.head.repo?.full_name !== REPO)
+  notEligible('PR does not come from a branch of this repository');
 
 const [commits, reviews, files] = await Promise.all([
   getAll(`/repos/${REPO}/pulls/${PR}/commits`),
@@ -71,12 +81,14 @@ for (const c of commits) {
   if (c.author && c.author.login) authors.add(c.author.login);
 }
 
-// Reviews only count if submitted after the last push (a push voids
-// earlier approvals, mirroring the UI).
-const lastPush = new Date(commits[commits.length - 1].commit.committer.date);
+// Reviews only count if they were made against the current head commit (a
+// push voids earlier reviews, mirroring the UI). Commit dates are NOT usable
+// for this: committer dates are client-supplied and can be backdated, and the
+// commits endpoint truncates, so the last listed commit need not be the head.
+const onHead = (r) => r.commit_id === pr.head.sha;
 
-if (reviews.some((r) => r.state === 'CHANGES_REQUESTED' && new Date(r.submitted_at) > lastPush))
-  notEligible('changes requested after the last push');
+if (reviews.some((r) => r.state === 'CHANGES_REQUESTED' && onHead(r)))
+  notEligible('changes requested on the current head commit');
 
 const approvals = [
   ...new Map(
@@ -84,7 +96,7 @@ const approvals = [
       .filter(
         (r) =>
           r.state === 'APPROVED' &&
-          new Date(r.submitted_at) > lastPush &&
+          onHead(r) &&
           r.user &&
           !r.user.login.endsWith('[bot]') &&
           !authors.has(r.user.login)
@@ -99,12 +111,19 @@ const approvals = [
 const inRule = (filename, rule) =>
   rule.paths.some((p) => (p.endsWith('/') ? filename.startsWith(p) : filename === p));
 
+// GitHub reports additions/deletions as 0 for binary blobs, pure renames and
+// mode-only changes, so line counts cannot bound them. Such files are never
+// auto-mergeable, whichever rule they fall under.
+const opaque = (f) =>
+  f.status === 'renamed' || (f.additions || 0) + (f.deletions || 0) === 0;
+
 const perRule = CFG.rules.map((rule) => {
   const rs = files.filter((f) => inRule(f.filename, rule));
   return {
     rule,
     files: rs.length,
     lines: rs.reduce((s, f) => s + (f.additions || 0) + (f.deletions || 0), 0),
+    opaque: rs.filter(opaque).map((f) => f.filename),
   };
 });
 
@@ -113,6 +132,11 @@ const perRule = CFG.rules.map((rule) => {
 const touched = perRule.filter((p) => p.files > 0);
 const withinLimits = (p) =>
   (p.rule.max_files === undefined || p.files < p.rule.max_files) && p.lines < p.rule.max_lines;
+
+// Team pages are org-members-only, so spell the team out as well as link it.
+const TEAM_LINK = `[@${org}/${CFG.approvers_team}](https://github.com/orgs/${org}/teams/${CFG.approvers_team})`;
+const CHECKLIST_LINK =
+  `[PR review checklist](https://github.com/${REPO}/blob/${pr.base.ref}/.github/PR_REVIEW_CHECKLIST.md)`;
 
 // One-shot comment: when the PR becomes ready, explain which rules apply and
 // what they require, based on the diff at that moment. Posted at most once
@@ -150,13 +174,19 @@ if (becameReady) {
       if (allOk) {
         const required = Math.max(...touched.map((p) => p.rule.required_approvals));
         lines.push(
-          `- Auto-merges once **${required} approval${required > 1 ? 's' : ''}** from @${org}/${CFG.approvers_team} ` +
-            `(excluding the PR author) ${required > 1 ? 'are' : 'is'} in place.`
+          `- Auto-merges once **${required} approval${required > 1 ? 's' : ''}** ${required > 1 ? 'are' : 'is'} in place, ` +
+            `from members of ${TEAM_LINK}. Approvals from anyone who authored a commit here never count, ` +
+            'and only reviews of the latest commit count — a new push voids earlier approvals.'
         );
       } else {
         lines.push('- Size limits not met — a maintainer will merge this PR.');
       }
     }
+    lines.push(
+      '',
+      `Reviewing this PR? Please work through the ${CHECKLIST_LINK} — it covers what to check ` +
+        'before approving, and when to leave the call to the maintainers.'
+    );
     await fetch(`https://api.github.com/repos/${REPO}/issues/${PR}/comments`, {
       method: 'POST',
       headers: {
@@ -172,11 +202,19 @@ if (becameReady) {
   }
 }
 
+// Belt and braces: this workflow, its script and its rules must never be
+// auto-merged, whatever the rules happen to say.
+const ci = files.filter((f) => f.filename.startsWith('.github/'));
+if (ci.length > 0)
+  notEligible(`PR modifies CI configuration: ${ci.map((f) => f.filename).join(', ')}`);
+
 // Every changed file must be covered by at least one rule.
 if (!files.every((f) => perRule.some((p) => inRule(f.filename, p.rule))))
   notEligible('changes outside all rule paths');
 
 for (const p of touched) {
+  if (p.opaque.length > 0)
+    notEligible(`rule "${p.rule.name}": binary or renamed files cannot be size-checked: ${p.opaque.join(', ')}`);
   if (p.rule.max_files !== undefined && p.files >= p.rule.max_files)
     notEligible(`rule "${p.rule.name}": touches ${p.files} files (must be < ${p.rule.max_files})`);
   if (p.lines >= p.rule.max_lines)
@@ -191,18 +229,27 @@ report(
     `; required approvals: ${required}`
 );
 
-// Count approvals that come from members of the approvers team.
+// Count approvals that come from members of the approvers team. GITHUB_TOKEN
+// has no org scope and always fails here, so this needs TEAM_TOKEN.
+if (!TEAM_TOKEN)
+  notEligible('AUTO_MERGE_TEAM_TOKEN is not configured, cannot verify approvers-team membership');
 const teamApprovals = [];
 for (const r of approvals) {
   const res = await fetch(`https://api.github.com/orgs/${org}/teams/${CFG.approvers_team}/memberships/${r.user.login}`, {
-    headers: { Authorization: `Bearer ${TOKEN}`, Accept: 'application/vnd.github+json' },
+    headers: { Authorization: `Bearer ${TEAM_TOKEN}`, Accept: 'application/vnd.github+json' },
   });
-  if (res.status === 200) teamApprovals.push(r.user.login);
-  else if (res.status !== 404)
-    throw new Error(`team membership check failed: ${res.status} for ${r.user.login}`);
+  // A 200 also covers invitations that have not been accepted yet; only
+  // "active" membership makes someone an approver.
+  if (res.status === 200) {
+    const m = await res.json();
+    if (m.state === 'active') teamApprovals.push(r.user.login);
+    else report(`ignoring ${r.user.login}: team membership is "${m.state}"`);
+  } else if (res.status !== 404) {
+    notEligible(`team membership check failed: ${res.status} for ${r.user.login}`);
+  }
 }
 report(
-  `approvals after last push: ${approvals.map((r) => r.user.login).join(', ') || 'none'}; ` +
+  `approvals on ${pr.head.sha.slice(0, 7)}: ${approvals.map((r) => r.user.login).join(', ') || 'none'}; ` +
     `from @${org}/${CFG.approvers_team}: ${teamApprovals.join(', ') || 'none'}`
 );
 
@@ -214,7 +261,7 @@ if (teamApprovals.length < required)
 // NOT this auto-merge workflow's own check run, which is in_progress while
 // we are deciding and would deadlock the merge. Runs are re-created on each
 // push, so this always reflects the latest head.
-const GATING_WORKFLOW = process.env.GATING_WORKFLOW || 'pr-test';
+const GATING_WORKFLOW = CFG.gating_workflow || 'pr-test';
 async function getCheckRuns(sha) {
   let runs = [];
   for (let page = 1; page <= 5; page++) {
@@ -243,7 +290,9 @@ const res = await fetch(`https://api.github.com/repos/${REPO}/pulls/${PR}/merge`
     Accept: 'application/vnd.github+json',
     'Content-Type': 'application/json',
   },
-  body: JSON.stringify({ merge_method: CFG.merge_method }),
+  // sha pins the merge to the commit whose approvals and CI we just checked;
+  // GitHub refuses the merge if the head moved while we were deciding.
+  body: JSON.stringify({ merge_method: CFG.merge_method, sha: pr.head.sha }),
 });
 if (res.ok) {
   report('merged');

--- a/.github/scripts/auto-merge.mjs
+++ b/.github/scripts/auto-merge.mjs
@@ -1,0 +1,247 @@
+// Auto-merge decision for small PRs. See .github/workflows/auto-merge.yml.
+// Runs with the workflow GITHUB_TOKEN (needs pull-requests:write,
+// organization:read). Prints the full decision trail and appends it to the
+// job summary.
+import fs from 'node:fs';
+
+const TOKEN = process.env.GITHUB_TOKEN;
+const REPO = process.env.GITHUB_REPOSITORY;
+const PR = Number(process.env.PR_NUMBER);
+const CFG = JSON.parse(process.env.RULES_JSON);
+const org = REPO.split('/')[0];
+const EVENT = { name: process.env.EVENT_NAME, action: process.env.EVENT_ACTION };
+const MARKER = '<!-- auto-merge-rules -->';
+
+const report = (line) => {
+  console.log('[auto-merge] ' + line);
+  if (process.env.GITHUB_STEP_SUMMARY) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, line + '\n');
+};
+const notEligible = (reason) => {
+  report(`NOT ELIGIBLE: ${reason}`);
+  process.exit(0);
+};
+
+async function getJSON(path) {
+  const res = await fetch('https://api.github.com' + path, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'openutau-auto-merge',
+    },
+  });
+  if (!res.ok) {
+    const err = new Error(`API ${res.status} ${path}: ${(await res.text()).slice(0, 300)}`);
+    err.status = res.status;
+    throw err;
+  }
+  return res.json();
+}
+
+// Paginated GET (100/page). Returns null when the result set exceeds 300
+// items, since the API caps list endpoints there.
+async function getAll(path) {
+  let items = [];
+  for (let page = 1; page <= 3; page++) {
+    const batch = await getJSON(`${path}?per_page=100&page=${page}`);
+    items = items.concat(batch);
+    if (batch.length < 100) return items;
+  }
+  return null;
+}
+
+const pr = await getJSON(`/repos/${REPO}/pulls/${PR}`);
+if (pr.state !== 'open') notEligible(`PR is ${pr.state}`);
+if (pr.draft) notEligible('PR is a draft');
+if (!CFG.allow_forks && pr.head.repo && pr.head.repo.full_name !== REPO)
+  notEligible('PR comes from a fork');
+
+const [commits, reviews, files] = await Promise.all([
+  getAll(`/repos/${REPO}/pulls/${PR}/commits`),
+  getAll(`/repos/${REPO}/pulls/${PR}/reviews`),
+  getAll(`/repos/${REPO}/pulls/${PR}/files`),
+]);
+if (commits === null) notEligible('PR has more than 300 commits');
+if (files === null) notEligible('PR changes more than 300 files');
+
+// Who wrote the PR: the head author plus every commit author. Their
+// approvals never count.
+const authors = new Set([pr.user.login]);
+for (const c of commits) {
+  if (c.author && c.author.login) authors.add(c.author.login);
+}
+
+// Reviews only count if submitted after the last push (a push voids
+// earlier approvals, mirroring the UI).
+const lastPush = new Date(commits[commits.length - 1].commit.committer.date);
+
+if (reviews.some((r) => r.state === 'CHANGES_REQUESTED' && new Date(r.submitted_at) > lastPush))
+  notEligible('changes requested after the last push');
+
+const approvals = [
+  ...new Map(
+    reviews
+      .filter(
+        (r) =>
+          r.state === 'APPROVED' &&
+          new Date(r.submitted_at) > lastPush &&
+          r.user &&
+          !r.user.login.endsWith('[bot]') &&
+          !authors.has(r.user.login)
+      )
+      .map((r) => [r.user.login, r])
+  ).values(),
+];
+
+// A file belongs to a rule if it equals a path, or is below a directory path.
+const inRule = (filename, rule) =>
+  rule.paths.some(
+    (p) => p === filename || (p.endsWith('/') && filename.startsWith(p)) || filename.startsWith(p + '/')
+  );
+
+const perRule = CFG.rules.map((rule) => {
+  const rs = files.filter((f) => inRule(f.filename, rule));
+  return {
+    rule,
+    files: rs.length,
+    lines: rs.reduce((s, f) => s + (f.additions || 0) + (f.deletions || 0), 0),
+  };
+});
+
+// Which touched rules meet their own file/line limits, counted over the
+// files in their paths only?
+const touched = perRule.filter((p) => p.files > 0);
+const withinLimits = (p) =>
+  (p.rule.max_files === undefined || p.files < p.rule.max_files) && p.lines < p.rule.max_lines;
+
+// One-shot comment: when the PR becomes ready, explain which rules apply and
+// what they require, based on the diff at that moment. Posted at most once
+// (marker comment), no matter how the diff changes afterwards.
+const becameReady =
+  EVENT.name === 'pull_request' &&
+  ((EVENT.action === 'opened' && !pr.draft) || EVENT.action === 'ready_for_review');
+if (becameReady) {
+  const alreadyCommented = await (async () => {
+    for (let page = 1; page <= 20; page++) {
+      const comments = await getJSON(`/repos/${REPO}/issues/${PR}/comments?per_page=100&page=${page}`);
+      if (comments.some((c) => (c.body || '').includes(MARKER))) return true;
+      if (comments.length < 100) return false;
+    }
+    return true; // give up rather than risk a duplicate
+  })();
+  if (!alreadyCommented) {
+    const lines = [MARKER, '**Auto-merge rules** (checked when this PR became ready; posted once, not updated):', ''];
+    const covered = files.every((f) => touched.some((p) => inRule(f.filename, p.rule)));
+    if (touched.length === 0 || !covered) {
+      lines.push('- This PR changes files outside the auto-merge rule paths — a maintainer will merge it.');
+    } else {
+      for (const p of touched) {
+        const filePart =
+          p.rule.max_files === undefined
+            ? `${p.files} files (no limit)`
+            : `${p.files} files (max ${p.rule.max_files - 1})`;
+        const linePart = `${p.lines} lines (max ${p.rule.max_lines - 1})`;
+        lines.push(
+          `- ${p.rule.name} (${p.rule.paths.join(', ')}): ${filePart}, ${linePart} — ` +
+            (withinLimits(p) ? 'within limits' : '**exceeds a limit**')
+        );
+      }
+      const allOk = touched.every(withinLimits);
+      if (allOk) {
+        const required = Math.max(...touched.map((p) => p.rule.required_approvals));
+        lines.push(
+          `- Auto-merges once **${required} approval${required > 1 ? 's' : ''}** from @${org}/${CFG.approvers_team} ` +
+            `(excluding the PR author) ${required > 1 ? 'are' : 'is'} in place.`
+        );
+      } else {
+        lines.push('- Size limits not met — a maintainer will merge this PR.');
+      }
+    }
+    await fetch(`https://api.github.com/repos/${REPO}/issues/${PR}/comments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ body: lines.join('\n') }),
+    });
+    report('posted auto-merge rules comment');
+  } else {
+    report('rules comment already exists, skipping');
+  }
+}
+
+// Every changed file must be covered by at least one rule.
+if (!files.every((f) => perRule.some((p) => inRule(f.filename, p.rule))))
+  notEligible('changes outside all rule paths');
+
+for (const p of touched) {
+  if (p.rule.max_files !== undefined && p.files >= p.rule.max_files)
+    notEligible(`rule "${p.rule.name}": touches ${p.files} files (must be < ${p.rule.max_files})`);
+  if (p.lines >= p.rule.max_lines)
+    notEligible(`rule "${p.rule.name}": ${p.lines} changed lines (must be < ${p.rule.max_lines})`);
+}
+if (touched.length === 0) notEligible('no changed files');
+// The strictest approval requirement among the touched rules applies.
+const required = Math.max(...touched.map((p) => p.rule.required_approvals));
+report(
+  'size ok: ' +
+    touched.map((p) => `"${p.rule.name}" ${p.files} files / ${p.lines} lines`).join(', ') +
+    `; required approvals: ${required}`
+);
+
+// Count approvals that come from members of the approvers team.
+const teamApprovals = [];
+for (const r of approvals) {
+  const res = await fetch(`https://api.github.com/orgs/${org}/teams/${CFG.approvers_team}/memberships/${r.user.login}`, {
+    headers: { Authorization: `Bearer ${TOKEN}`, Accept: 'application/vnd.github+json' },
+  });
+  if (res.status === 200) teamApprovals.push(r.user.login);
+  else if (res.status !== 404)
+    throw new Error(`team membership check failed: ${res.status} for ${r.user.login}`);
+}
+report(
+  `approvals after last push: ${approvals.map((r) => r.user.login).join(', ') || 'none'}; ` +
+    `from @${org}/${CFG.approvers_team}: ${teamApprovals.join(', ') || 'none'}`
+);
+
+if (teamApprovals.length < required)
+  notEligible(`needs ${required} approval(s) from @${org}/${CFG.approvers_team}, has ${teamApprovals.length}`);
+
+// CI gate: every check run on the head commit must be completed and passing.
+// Runs are re-created on each push, so this always reflects the latest head.
+async function getCheckRuns(sha) {
+  let runs = [];
+  for (let page = 1; page <= 5; page++) {
+    const data = await getJSON(`/repos/${REPO}/commits/${sha}/check-runs?per_page=100&page=${page}`);
+    runs = runs.concat(data.check_runs);
+    if (data.check_runs.length < 100 || runs.length >= data.total_count) break;
+  }
+  return runs;
+}
+const runs = await getCheckRuns(pr.head.sha);
+if (runs.length === 0) notEligible('no CI check runs on the head commit yet — waiting for CI');
+const pending = runs.filter((r) => r.status !== 'completed');
+if (pending.length > 0)
+  notEligible(`CI still running: ${pending.map((r) => r.name).join(', ')}`);
+const failing = runs.filter((r) => !['success', 'neutral'].includes(r.conclusion));
+if (failing.length > 0)
+  notEligible(`CI failing: ${failing.map((r) => `${r.name} (${r.conclusion})`).join(', ')}`);
+report(`CI ok: ${runs.length} check(s) passed on ${pr.head.sha.slice(0, 7)}`);
+
+report(`ELIGIBLE -> merging with "${CFG.merge_method}"`);
+const res = await fetch(`https://api.github.com/repos/${REPO}/pulls/${PR}/merge`, {
+  method: 'PUT',
+  headers: {
+    Authorization: `Bearer ${TOKEN}`,
+    Accept: 'application/vnd.github+json',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({ merge_method: CFG.merge_method }),
+});
+if (res.ok) {
+  report('merged');
+} else {
+  // e.g. merge conflict, or branch-protection checks outside our control
+  report(`merge failed (${res.status}): ${(await res.text()).slice(0, 300)} — left for manual merge`);
+}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -52,6 +52,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event.action == 'submitted' || github.event.action == 'dismissed'
     runs-on: ubuntu-latest
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       EVENT_NAME: ${{ github.event_name }}
       EVENT_ACTION: ${{ github.event.action }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -40,17 +40,23 @@ permissions:
   checks: read
 
 concurrency:
-  group: auto-merge-${{ github.event.pull_request.number || github.event.review.pull_request.number }}
+  # github.event.pull_request exists at the top level for BOTH the
+  # pull_request and pull_request_review events.
+  group: auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   auto-merge:
-    if: github.event_name == 'pull_request' || github.event.review.action == 'submitted' || github.event.review.action == 'dismissed'
+    # github.event.action: opened/synchronize/... for pull_request events,
+    # submitted/dismissed for pull_request_review events.
+    if: github.event_name == 'pull_request' || github.event.action == 'submitted' || github.event.action == 'dismissed'
     runs-on: ubuntu-latest
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number || github.event.review.pull_request.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
       EVENT_NAME: ${{ github.event_name }}
       EVENT_ACTION: ${{ github.event.action }}
+      # Workflow whose check runs gate the merge (job name prefix).
+      GATING_WORKFLOW: pr-test
       # ---- rules live here; add as many as you like ------------------------
       # paths: a trailing "/" means "this directory and everything below",
       #        otherwise it must be the exact file name
@@ -71,7 +77,7 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.event.review.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Evaluate and auto-merge
         run: node .github/scripts/auto-merge.mjs

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,9 +3,12 @@
 #   - for each rule touched: changed lines < max_lines AND (if the rule has a
 #     max_files) changed files < max_files — counted per rule over the files
 #     in that rule's paths only
-#   - no CHANGES_REQUESTED review after the last push
+#   - no CHANGES_REQUESTED review on the current head commit
 #   - at least `required_approvals` distinct approvals (max over all touched rules)
-#     from members of the approvers team, excluding the PR author(s)
+#     of the current head commit, from active members of the approvers team,
+#     excluding the PR author(s)
+#   - no binary, renamed or mode-only file changes (their size cannot be bounded)
+#   - nothing under .github/ is touched
 #   - PR is open, not a draft, and not from a fork
 #
 # When a PR touches multiple rules, it is mergeable once the strictest of the
@@ -17,8 +20,11 @@
 # are, based on the diff at that moment. It is never posted twice, even if
 # the diff changes afterwards.
 #
-# The decision script is checked out from the BASE branch so a PR can never
-# modify the rules that decide its own fate.
+# The decision script AND the rules (.github/auto-merge-rules.json) are checked
+# out from the BASE branch, and any PR touching .github/ is refused outright, so
+# a PR can never modify the rules that decide its own fate. Nothing configured
+# in this file may affect the decision: for pull_request events GitHub reads
+# this workflow from the PR's own merge commit.
 #
 # The merge additionally requires all CI check runs on the head commit
 # (pr-test.yml) to be completed and passing; it never merges over red or
@@ -33,10 +39,14 @@ on:
     branches: [ master ]
     types: [ submitted, dismissed ]
 
+# The merge REST endpoint writes to the repo, so contents:write is required.
+# Reading org team membership is NOT expressible as a workflow permission and
+# GITHUB_TOKEN cannot do it at all; that one call uses AUTO_MERGE_TEAM_TOKEN
+# (a PAT or GitHub App token with org "Members: read"). Without that secret the
+# workflow refuses to merge.
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
-  organization: read
   checks: read
 
 concurrency:
@@ -56,24 +66,12 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       EVENT_NAME: ${{ github.event_name }}
       EVENT_ACTION: ${{ github.event.action }}
-      # Workflow whose check runs gate the merge (job name prefix).
-      GATING_WORKFLOW: pr-test
-      # ---- rules live here; add as many as you like ------------------------
-      # paths: a trailing "/" means "this directory and everything below",
-      #        otherwise it must be the exact file name
-      # max_lines: strict upper bound of added+removed lines, counted per rule
-      #        over the files inside that rule's paths only
-      # max_files: optional, same counting; omit for no file-count limit
-      # NOTE: keep this as one folded expression (newlines fold to spaces).
-      RULES_JSON: '${{ toJSON({
-        merge_method: "squash",
-        approvers_team: "approvers",
-        allow_forks: false,
-        rules: [
-          { name: "translations", paths: ["OpenUtau/Strings/"], max_lines: 64, required_approvals: 1 },
-          { name: "phonemizers", paths: ["OpenUtau.Plugin.Builtin/"], max_files: 4, max_lines: 128, required_approvals: 2 }
-        ]
-      }) }}'
+      # Team-membership lookups only; see the permissions note above.
+      TEAM_TOKEN: ${{ secrets.AUTO_MERGE_TEAM_TOKEN }}
+      # NOTE: the rules themselves live in .github/auto-merge-rules.json, which
+      # is read from the base checkout below. They are deliberately NOT set
+      # here: for pull_request events GitHub reads this workflow file from the
+      # PR's own merge commit, so anything configured here is PR-controlled.
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4
@@ -81,4 +79,9 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Evaluate and auto-merge
-        run: node .github/scripts/auto-merge.mjs
+        run: |
+          if [ ! -f .github/scripts/auto-merge.mjs ] || [ ! -f .github/auto-merge-rules.json ]; then
+            echo "auto-merge script/rules not present on the base commit - skipping."
+            exit 0
+          fi
+          node .github/scripts/auto-merge.mjs

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,11 +20,13 @@
 # are, based on the diff at that moment. It is never posted twice, even if
 # the diff changes afterwards.
 #
-# The decision script AND the rules (.github/auto-merge-rules.json) are checked
-# out from the BASE branch, and any PR touching .github/ is refused outright, so
-# a PR can never modify the rules that decide its own fate. Nothing configured
-# in this file may affect the decision: for pull_request events GitHub reads
-# this workflow from the PR's own merge commit.
+# A PR can never influence the decision made about it:
+#   - the trigger is pull_request_target, so THIS file is read from the base
+#     branch, not from the PR (that is the whole reason for _target here; note
+#     it is safe only because nothing below ever checks out or runs PR code)
+#   - the decision script and the rules (.github/auto-merge-rules.json) are
+#     checked out from the base branch too
+#   - any PR touching .github/ is refused outright
 #
 # The merge additionally requires all CI check runs on the head commit
 # (pr-test.yml) to be completed and passing; it never merges over red or
@@ -32,7 +34,9 @@
 name: Auto-merge small PRs
 
 on:
-  pull_request:
+  # pull_request_target, not pull_request: the workflow definition, the token
+  # and the secrets must not come from the PR under evaluation.
+  pull_request_target:
     branches: [ master ]
     types: [ opened, synchronize, reopened, ready_for_review, closed ]
   pull_request_review:
@@ -51,15 +55,15 @@ permissions:
 
 concurrency:
   # github.event.pull_request exists at the top level for BOTH the
-  # pull_request and pull_request_review events.
+  # pull_request_target and pull_request_review events.
   group: auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   auto-merge:
-    # github.event.action: opened/synchronize/... for pull_request events,
-    # submitted/dismissed for pull_request_review events.
-    if: github.event_name == 'pull_request' || github.event.action == 'submitted' || github.event.action == 'dismissed'
+    # github.event.action: opened/synchronize/... for pull_request_target
+    # events, submitted/dismissed for pull_request_review events.
+    if: github.event_name == 'pull_request_target' || github.event.action == 'submitted' || github.event.action == 'dismissed'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,10 +72,10 @@ jobs:
       EVENT_ACTION: ${{ github.event.action }}
       # Team-membership lookups only; see the permissions note above.
       TEAM_TOKEN: ${{ secrets.AUTO_MERGE_TEAM_TOKEN }}
-      # NOTE: the rules themselves live in .github/auto-merge-rules.json, which
-      # is read from the base checkout below. They are deliberately NOT set
-      # here: for pull_request events GitHub reads this workflow file from the
-      # PR's own merge commit, so anything configured here is PR-controlled.
+      # NOTE: the rules themselves live in .github/auto-merge-rules.json, read
+      # from the base checkout below. Keeping them out of this file means the
+      # policy stays put even if the trigger above is ever changed back to
+      # pull_request, which would make everything here PR-controlled.
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,77 @@
+# Auto-merge small PRs that meet all of:
+#   - every changed file falls inside some rule's paths
+#   - for each rule touched: changed lines < max_lines AND (if the rule has a
+#     max_files) changed files < max_files — counted per rule over the files
+#     in that rule's paths only
+#   - no CHANGES_REQUESTED review after the last push
+#   - at least `required_approvals` distinct approvals (max over all touched rules)
+#     from members of the approvers team, excluding the PR author(s)
+#   - PR is open, not a draft, and not from a fork
+#
+# When a PR touches multiple rules, it is mergeable once the strictest of the
+# touched rules is satisfied (e.g. rule A needs 1 approval, rule B needs 2,
+# a PR touching both needs 2 approvals).
+#
+# When a PR is opened as ready or flipped from draft to ready, a one-shot
+# comment is posted explaining which rules apply and what the requirements
+# are, based on the diff at that moment. It is never posted twice, even if
+# the diff changes afterwards.
+#
+# The decision script is checked out from the BASE branch so a PR can never
+# modify the rules that decide its own fate.
+#
+# The merge additionally requires all CI check runs on the head commit
+# (pr-test.yml) to be completed and passing; it never merges over red or
+# still-running CI.
+name: Auto-merge small PRs
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, ready_for_review, closed ]
+  pull_request_review:
+    branches: [ master ]
+    types: [ submitted, dismissed ]
+
+permissions:
+  contents: read
+  pull-requests: write
+  organization: read
+  checks: read
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number || github.event.review.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    if: github.event_name == 'pull_request' || github.event.review.action == 'submitted' || github.event.review.action == 'dismissed'
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.review.pull_request.number }}
+      EVENT_NAME: ${{ github.event_name }}
+      EVENT_ACTION: ${{ github.event.action }}
+      # ---- rules live here; add as many as you like ------------------------
+      # paths: a trailing "/" means "this directory and everything below",
+      #        otherwise it must be the exact file name
+      # max_lines: strict upper bound of added+removed lines, counted per rule
+      #        over the files inside that rule's paths only
+      # max_files: optional, same counting; omit for no file-count limit
+      # NOTE: keep this as one folded expression (newlines fold to spaces).
+      RULES_JSON: '${{ toJSON({
+        merge_method: "squash",
+        approvers_team: "approvers",
+        allow_forks: false,
+        rules: [
+          { name: "translations", paths: ["OpenUtau/Strings/"], max_lines: 64, required_approvals: 1 },
+          { name: "phonemizers", paths: ["OpenUtau.Plugin.Builtin/"], max_files: 4, max_lines: 128, required_approvals: 2 }
+        ]
+      }) }}'
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.event.review.pull_request.base.sha }}
+
+      - name: Evaluate and auto-merge
+        run: node .github/scripts/auto-merge.mjs


### PR DESCRIPTION
Adds a workflow that auto-merges PRs meeting per-rule conditions, so small low-risk changes (translations, phonemizer tweaks) don't wait on maintainer availability.

## Rules (configured in `.github/auto-merge-rules.json`)

| rule | paths | limits | approvals |
|---|---|---|---|
| translations | `OpenUtau/Strings/` | < 8 files, < 64 lines | 1 |
| phonemizers | `OpenUtau.Plugin.Builtin/` | < 4 files, < 128 lines | 2 |

Multiple rules can coexist; a PR touching several needs the strictest approval count, and each rule's file/line limits are counted over the files in its own paths only.

## Merge conditions (all must hold)

- every changed file is inside some rule's paths, and each touched rule is within its limits
- nothing under `.github/` is touched — CI configuration is never auto-merged
- no binary, renamed or mode-only file changes (GitHub reports those as 0 lines, so the size limits cannot bound them)
- at least the required number of approvals from **@openutau/approvers** team members, with membership `active` — PR author(s) never count
- no *Request changes* review on the current head commit
- all CI check runs (pr-test) on the head commit completed and passing
- not a draft, not from a fork

Reviews are keyed to the head commit: only reviews of the latest commit count, so any push voids earlier approvals. The merge itself is pinned to that same SHA, so a push landing mid-run cannot be merged unreviewed.

## Behavior

- When a PR is opened as ready or flipped from draft to ready, a one-shot comment explains which rules apply, the current counts vs limits, what is required, and links the [PR review checklist](.github/PR_REVIEW_CHECKLIST.md). It is posted once and never updated.
- Every run logs the full decision trail to the job summary (why it merged or didn't); merge failures (e.g. conflicts) are reported and left for manual merge.

Re-evaluates on PR open/sync/reopen/ready and on each review submitted/dismissed, so a fresh approval on green CI triggers the merge.

## Why a PR cannot rig its own decision

For `pull_request` events GitHub reads the workflow file from the PR's own merge commit, which would put the rules, permissions and secrets under the control of the PR being judged. So:

- the trigger is **`pull_request_target`**, which reads the workflow from the base branch. That is safe here only because the job never checks out or runs PR code — it checks out `base.sha` and drives the API from a base-branch script.
- the decision script (`.github/scripts/auto-merge.mjs`) and the rules (`.github/auto-merge-rules.json`) are checked out from the base branch.
- any PR touching `.github/` is refused outright, whatever the rules say.

## Setup required before this works

Add a repository secret **`AUTO_MERGE_TEAM_TOKEN`** — a fine-grained PAT with resource owner `openutau` and organization **Members: read**, and nothing else. `GITHUB_TOKEN` has no org scope and cannot check team membership at all.

Without the secret the workflow runs, logs `AUTO_MERGE_TEAM_TOKEN is not configured`, and declines to merge — it fails closed.

Note that `pull_request_target` only takes effect once this is on `master`; it will not run from this branch.
