### PR TITLE
Add a metronome

### DIFF
--- a/OpenUtau.Core/PlaybackManager.cs
+++ b/OpenUtau.Core/PlaybackManager.cs
@@ -6,11 +6,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
+using OpenUtau.Core.Format;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.SignalChain;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
-using OpenUtau.Core.Format;
 using Serilog;
 using System.Collections.Concurrent;
 
@@ -21,6 +21,7 @@ namespace OpenUtau.Core {
 
         private readonly double attackSampleCount;
         private readonly double releaseSampleCount;
+        private int startSampleOffset;
 
         public double freq { get; set; }
 
@@ -42,13 +43,23 @@ namespace OpenUtau.Core {
             releaseSampleCount = (releaseMs / 1000.0f) * waveFormat.SampleRate;
         }
 
+        public SineGenerator(double freq, float gain, int attackMs, int releaseMs, int startSampleOffset)
+            : this(freq, gain, attackMs, releaseMs) {
+            this.startSampleOffset = Math.Max(0, startSampleOffset);
+        }
+
+        public void SetGain(float gain) {
+            this.gain = gain;
+        }
+
         public int Read(float[] buffer, int offset, int count) {
             // Duplicate sample across two channels
             for (int i = 0; i < count / 2; i++) {
-                float sample = GetNextSample();
+                float sample = i < startSampleOffset ? 0 : GetNextSample();
                 buffer[offset + (i * 2)] += (float)sample * gain;
                 buffer[offset + (i * 2) + 1] += (float)sample * gain;
             }
+            startSampleOffset = Math.Max(0, startSampleOffset - count / 2);
             return count;
         }
 
@@ -87,7 +98,7 @@ namespace OpenUtau.Core {
     public class ToneGenerator : ISignalSource {
         private Dictionary<double, SineGenerator> activeFrequencies = new Dictionary<double, SineGenerator>();
         private List<SineGenerator> inactiveFrequencies = new List<SineGenerator>();
-        private readonly float gain = 0.4f;
+        private float gain = 0.4f;
 
         private readonly object _lockObj = new object();
 
@@ -95,6 +106,18 @@ namespace OpenUtau.Core {
 
         public ToneGenerator(float gain) {
             this.gain = gain;
+        }
+
+        public void SetGain(float gain) {
+            this.gain = gain;
+            lock (_lockObj) {
+                foreach (var generator in activeFrequencies.Values) {
+                    generator.SetGain(gain);
+                }
+                foreach (var generator in inactiveFrequencies) {
+                    generator.SetGain(gain);
+                }
+            }
         }
 
         public bool IsReady(int position, int count) {
@@ -118,44 +141,62 @@ namespace OpenUtau.Core {
             return position + count;
         }
         public void StartTone(double freq) {
-            if (activeFrequencies.ContainsKey(freq)) {
-                if (activeFrequencies[freq].isActive) {
-                    // Don't cut off tone to replace with the same frequency
-                    // Should never happen
-                    return;
-                }
-            }
-
             lock (_lockObj) {
+                if (activeFrequencies.ContainsKey(freq)) {
+                    if (activeFrequencies[freq].isActive) {
+                        // Don't cut off tone to replace with the same frequency
+                        // Should never happen
+                        return;
+                    }
+                }
                 activeFrequencies[freq] = new SineGenerator(freq, gain);
             }
         }
 
-        public void EndTone(double freq) {
-            if (activeFrequencies.ContainsKey(freq)) {
-                activeFrequencies[freq].Stop();
+        public void StartTone(double freq, int attackMs, int releaseMs, int startSampleOffset) {
+            lock (_lockObj) {
+                if (activeFrequencies.ContainsKey(freq)) {
+                    if (activeFrequencies[freq].isActive) {
+                        return;
+                    }
+                }
+                activeFrequencies[freq] = new SineGenerator(freq, gain, attackMs, releaseMs, startSampleOffset);
+            }
+        }
 
-                lock (_lockObj) {
+        public void StartTones(int startSampleOffset, params (double freq, int attackMs, int releaseMs)[] tones) {
+            foreach (var tone in tones) {
+                StartTone(tone.freq, tone.attackMs, tone.releaseMs, startSampleOffset);
+            }
+        }
+
+        public void EndTones(params double[] freqs) {
+            foreach (var freq in freqs) {
+                EndTone(freq);
+            }
+        }
+
+        public void EndTone(double freq) {
+
+            lock (_lockObj) {
+                if (activeFrequencies.ContainsKey(freq)) {
+                    activeFrequencies[freq].Stop();
                     // Move to inactive frequencies list
                     inactiveFrequencies.Add(activeFrequencies[freq]);
                     activeFrequencies.Remove(freq);
                 }
             }
-
             CleanupTones();
         }
 
         public void EndAllTones() {
-            foreach (var tone in activeFrequencies) {
-                tone.Value.Stop();
-
-                lock (_lockObj) {
-                    // Move to inactive frequencies list
-                    inactiveFrequencies.Add(tone.Value);
-                    activeFrequencies.Remove(tone.Key);
+            lock (_lockObj) {
+                foreach (var tone in activeFrequencies.Values) {
+                    tone.Stop();
+                    inactiveFrequencies.Add(tone);
                 }
+                activeFrequencies.Clear();
             }
-
 
             CleanupTones();
         }
@@ -164,6 +205,33 @@ namespace OpenUtau.Core {
             lock (_lockObj) {
                 inactiveFrequencies.RemoveAll(gen => !gen.isPlaying);
             }
+        }
+    }
+
+    class PlaybackMix : ISignalSource {
+        private readonly ISignalSource masterSource;
+        private readonly ISignalSource overlaySource;
+        private volatile bool masterExhausted;
+
+        // True once the master source stops producing audio, release tails included.
+        // The overlay can always produce sound, so the mix itself never reports
+        // end-of-stream and playback has to be stopped by play position instead.
+        public bool MasterExhausted => masterExhausted;
+
+        public PlaybackMix(ISignalSource masterSource, ISignalSource overlaySource) {
+            this.masterSource = masterSource;
+            this.overlaySource = overlaySource;
+        }
+
+        public bool IsReady(int position, int count) {
+            return masterSource.IsReady(position, count) && overlaySource.IsReady(position, count);
+        }
+
+        public int Mix(int position, float[] buffer, int offset, int count) {
+            int masterPos = masterSource.Mix(position, buffer, offset, count);
+            int overlayPos = overlaySource.Mix(position, buffer, offset, count);
+            masterExhausted = masterPos <= position;
+            return Math.Max(masterPos, overlayPos);
         }
     }
 
@@ -180,10 +248,13 @@ namespace OpenUtau.Core {
             }
 
             toneGenerator = new ToneGenerator();
+            metronomeEngine = new MetronomeEngine();
+            metronomeEngine.SetEnabled(Preferences.Default.Metronome);
             editingMix = new MasterAdapter(toneGenerator);
         }
 
         public readonly ToneGenerator toneGenerator;
+        private readonly MetronomeEngine metronomeEngine;
         List<Fader> faders;
         MasterAdapter masterMix;
         MasterAdapter editingMix;
@@ -198,6 +269,9 @@ namespace OpenUtau.Core {
         // boundary even when looping is disabled.
         private int playbackRangeStartTick = 0;
         private int playbackRangeEndTick = -1;
+        // Tick where the current playback must end, -1 when unbounded (empty project).
+        private int playbackEndTick = -1;
+        private PlaybackMix playbackMix;
         private bool loopProjectOnPlaybackEnd;
 
         public Audio.IAudioOutput AudioOutput { get; set; } = new Audio.DummyAudioOutput();
@@ -205,6 +279,20 @@ namespace OpenUtau.Core {
         public bool StartingToPlay { get; private set; }
         public bool PlayingMaster { get; private set; }
         public bool LoopPlayback { get; set; }
+        public bool Metronome {
+            get => metronomeEngine.Enabled;
+            set {
+                if (metronomeEngine.Enabled == value) {
+                    return;
+                }
+                Preferences.Default.Metronome = value;
+                Preferences.Save();
+                metronomeEngine.SetEnabled(
+                    value,
+                    PlayingMaster ? DocManager.Inst.Project.timeAxis : null,
+                    PlayingMaster ? DocManager.Inst.playPosTick : -1);
+            }
+        }
 
         public void PlayTestSound() {
             masterMix = null;
@@ -212,6 +300,35 @@ namespace OpenUtau.Core {
             AudioOutput.Stop();
             AudioOutput.Init(new SignalGenerator(44100, 1).Take(TimeSpan.FromSeconds(1)));
             AudioOutput.Play();
+        }
+
+        public void PlayMetronomeClick() {
+            masterMix = null;
+            PlayingMaster = false;
+            toneGenerator.EndAllTones();
+            AudioOutput.Stop();
+            AudioOutput.Init(new MixingSampleProvider(new[] {
+                CreateMetronomePreviewTone(Preferences.Default.MetronomeHighFrequency, TimeSpan.Zero),
+                CreateMetronomePreviewTone(Preferences.Default.MetronomeLowFrequency, TimeSpan.FromMilliseconds(300)),
+            }) {
+                ReadFully = true,
+            });
+            AudioOutput.Play();
+        }
+
+        private static ISampleProvider CreateMetronomePreviewTone(double frequency, TimeSpan delay) {
+            return new OffsetSampleProvider(new SineGenerator(frequency, GetMetronomePreviewGain(), 5, 80)) {
+                DelayBy = delay,
+                Take = TimeSpan.FromMilliseconds(120),
+            };
+        }
+
+        private static float GetMetronomePreviewGain() {
+            return MathF.Sqrt(Math.Clamp(Preferences.Default.MetronomeVolume / 100f, 0f, 1f));
+        }
+
+        public static float GetMetronomeGain() {
+            return GetMetronomePreviewGain();
         }
 
         public void PlayTone(double freq) {
@@ -284,8 +401,10 @@ namespace OpenUtau.Core {
         }
 
         public void Play(UProject project, int tick, int endTick = -1, int trackNo = -1) {
+            playbackEndTick = endTick == -1 ? project.EndTick : endTick;
             if (AudioOutput.PlaybackState == PlaybackState.Paused) {
                 PlayingMaster = true;
+                metronomeEngine.StartPlayback(project.timeAxis, DocManager.Inst.playPosTick);
                 AudioOutput.Play();
                 return;
             }
@@ -298,8 +417,12 @@ namespace OpenUtau.Core {
         public void StopPlayback() {
             AudioOutput.Stop();
             StartingToPlay = false;
+            masterMix = null;
             PlayingMaster = false;
+            metronomeEngine.Stop();
             playbackRangeEndTick = -1;
+            playbackEndTick = -1;
+            playbackMix = null;
             loopProjectOnPlaybackEnd = false;
         }
 
@@ -307,20 +430,24 @@ namespace OpenUtau.Core {
             AudioOutput.Pause();
             StartingToPlay = false;
             PlayingMaster = false;
+            metronomeEngine.Stop();
             playbackRangeEndTick = -1;
             loopProjectOnPlaybackEnd = false;
         }
 
         private void StartPlayback(double startMs, MasterAdapter masterAdapter) {
             toneGenerator.EndAllTones();
-
             this.startMs = startMs;
+            metronomeEngine.StartPlayback(DocManager.Inst.Project.timeAxis, StartTick);
             var start = TimeSpan.FromMilliseconds(startMs);
             Log.Information($"StartPlayback at {start}");
             masterMix = masterAdapter;
             AudioOutput.Stop();
             AudioOutput.Init(masterMix);
             AudioOutput.Play();
+            // Cleared only after playback actually starts. Until then UpdatePlayPos
+            // would see Stopped + PlayingMaster and stop the playback it is starting.
+            StartingToPlay = false;
         }
 
         private void Render(UProject project, int tick, int endTick, int trackNo) {
@@ -334,10 +461,12 @@ namespace OpenUtau.Core {
                     }, CancellationToken.None, TaskCreationOptions.None, DocManager.Inst.MainScheduler);
 
                     RenderEngine engine = new RenderEngine(project, startTick: tick, endTick: endTick, trackNo: trackNo);
-                    var result = engine.RenderProject(DocManager.Inst.MainScheduler, ref renderCancellation);
+                    var result = engine.RenderMixdown(DocManager.Inst.MainScheduler, ref renderCancellation, wait: false);
+                    playbackMix = new PlaybackMix(result.Item1, metronomeEngine);
+                    var playbackAdapter = new MasterAdapter(playbackMix);
+                    playbackAdapter.SetPosition((int)(project.timeAxis.TickPosToMsPos(tick) * 44100 / 1000) * 2);
                     faders = result.Item2;
-                    StartPlayback(project.timeAxis.TickPosToMsPos(tick), result.Item1);
-                    StartingToPlay = false;
+                    StartPlayback(project.timeAxis.TickPosToMsPos(tick), playbackAdapter);
 
                     Task.Factory.StartNew(() => {
                         DocManager.Inst.ExecuteCmd(new WaveformReadyNotification());
@@ -354,11 +483,19 @@ namespace OpenUtau.Core {
         }
 
         public void UpdatePlayPos() {
-            if (AudioOutput != null && AudioOutput.PlaybackState == PlaybackState.Playing && PlayingMaster) {
+            if (AudioOutput != null && AudioOutput.PlaybackState == PlaybackState.Playing && PlayingMaster && masterMix != null) {
+
                 double ms = (AudioOutput.GetPosition() / sizeof(float) - masterMix.Waited / 2) * 1000.0 / 44100;
                 int tick = DocManager.Inst.Project.timeAxis.MsPosToTickPos(startMs + ms);
                 if (playbackRangeEndTick > 0 && tick >= playbackRangeEndTick) {
                     HandlePlaybackBoundary(hasPlaybackRange: true);
+                    return;
+                }
+                if (playbackRangeEndTick <= 0 &&
+                    playbackEndTick > 0 &&
+                    tick >= playbackEndTick &&
+                    (playbackMix == null || playbackMix.MasterExhausted)) {
+                    HandlePlaybackBoundary(hasPlaybackRange: false);
                     return;
                 }
                 DocManager.Inst.ExecuteCmd(new SetPlayPosTickNotification(tick, masterMix.IsWaiting));
@@ -485,6 +622,15 @@ namespace OpenUtau.Core {
                 var _cmd = cmd as PanChangeNotification;
                 if (faders != null && faders.Count > _cmd!.TrackNo) {
                     faders[_cmd.TrackNo].Pan = (float)_cmd.Pan;
+                }
+            } else if (cmd is BpmCommand ||
+                cmd is TimeSignatureCommand ||
+                cmd is AddTempoChangeCommand ||
+                cmd is DelTempoChangeCommand ||
+                cmd is AddTimeSigCommand ||
+                cmd is DelTimeSigCommand) {
+                if (PlayingMaster && Metronome) {
+                    metronomeEngine.UpdateSchedule(DocManager.Inst.Project.timeAxis, DocManager.Inst.playPosTick);
                 }
             } else if (cmd is LoadProjectNotification) {
                 StopPlayback();

--- a/OpenUtau.Core/SignalChain/MetronomeEngine.cs
+++ b/OpenUtau.Core/SignalChain/MetronomeEngine.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using OpenUtau.Core.Util;
+
+namespace OpenUtau.Core.SignalChain {
+    class MetronomeEngine : ISignalSource {
+        private const int SampleRate = 44100;
+        private const int Channels = 2;
+        private const int MetronomeAttackMs = 5;
+        private const int MetronomeBeatReleaseMs = 10;
+        private const int MetronomeBarReleaseMs = 10;
+        private const double AccentFrequencyOffset = 880;
+
+        private readonly ToneGenerator toneGenerator = new ToneGenerator(PlaybackManager.GetMetronomeGain());
+        private readonly MetronomeScheduler scheduler = new MetronomeScheduler();
+        private readonly object lockObj = new object();
+        private TimeAxis? playbackTimeAxis;
+        private float lastGain = float.NaN;
+
+        private static double MetronomeBarFreq => Preferences.Default.MetronomeHighFrequency;
+        private static double MetronomeBeatFreq => Preferences.Default.MetronomeLowFrequency;
+        private static double MetronomeBarAccentFreq => Preferences.Default.MetronomeHighFrequency + AccentFrequencyOffset;
+        private static double MetronomeBeatAccentFreq => Preferences.Default.MetronomeLowFrequency + AccentFrequencyOffset;
+
+        public bool Enabled { get; private set; }
+
+        public MetronomeEngine() {
+            UpdateGain();
+        }
+
+        public bool IsReady(int position, int count) {
+            return toneGenerator.IsReady(position, count);
+        }
+
+        public int Mix(int position, float[] buffer, int offset, int count) {
+            UpdateGain();
+            ScheduleBuffer(position, count);
+            return toneGenerator.Mix(position, buffer, offset, count);
+        }
+
+        public void SetEnabled(bool enabled, TimeAxis? timeAxis = null, int tick = -1) {
+            lock (lockObj) {
+                Enabled = enabled;
+                if (!enabled) {
+                    Stop();
+                    return;
+                }
+                if (timeAxis != null && tick >= 0) {
+                    playbackTimeAxis = timeAxis;
+                    scheduler.Reset(timeAxis, tick);
+                }
+            }
+        }
+
+        public void Stop() {
+            lock (lockObj) {
+                toneGenerator.EndAllTones();
+                scheduler.Clear();
+                playbackTimeAxis = null;
+            }
+        }
+
+        public void StartPlayback(TimeAxis timeAxis, int tick) {
+            ArgumentNullException.ThrowIfNull(timeAxis);
+            lock (lockObj) {
+                toneGenerator.EndAllTones();
+                playbackTimeAxis = timeAxis;
+                if (Enabled) {
+                    scheduler.Reset(timeAxis, tick);
+                } else {
+                    scheduler.Clear();
+                }
+            }
+        }
+
+        public void UpdateSchedule(TimeAxis timeAxis, int tick) {
+            ArgumentNullException.ThrowIfNull(timeAxis);
+            lock (lockObj) {
+                if (!Enabled) {
+                    scheduler.Clear();
+                    return;
+                }
+                playbackTimeAxis = timeAxis;
+                scheduler.Reset(timeAxis, tick);
+            }
+        }
+
+        private void ScheduleBuffer(int position, int count) {
+            lock (lockObj) {
+                if (!Enabled || playbackTimeAxis == null || !scheduler.IsScheduled) {
+                    return;
+                }
+
+                double bufferStartMs = position * 1000.0 / (SampleRate * Channels);
+                double bufferEndMs = (position + count) * 1000.0 / (SampleRate * Channels);
+                while (scheduler.IsScheduled && scheduler.NextMs < bufferStartMs) {
+                    scheduler.Advance(playbackTimeAxis);
+                }
+                while (scheduler.IsScheduled && scheduler.NextMs < bufferEndMs) {
+                    int startSampleOffset = (int)Math.Round((scheduler.NextMs - bufferStartMs) * SampleRate / 1000.0);
+                    PlayClick(scheduler.NextBeat == 0, startSampleOffset);
+                    scheduler.Advance(playbackTimeAxis);
+                }
+            }
+        }
+
+        private void PlayClick(bool accent, int startSampleOffset = 0) {
+            if (accent) {
+                toneGenerator.StartTones(
+                    startSampleOffset,
+                    (MetronomeBarFreq, MetronomeAttackMs, MetronomeBarReleaseMs),
+                    (MetronomeBarAccentFreq, MetronomeAttackMs, MetronomeBeatReleaseMs));
+                toneGenerator.EndTones(MetronomeBarFreq, MetronomeBarAccentFreq);
+            } else {
+                toneGenerator.StartTones(
+                    startSampleOffset,
+                    (MetronomeBeatFreq, MetronomeAttackMs, MetronomeBeatReleaseMs),
+                    (MetronomeBeatAccentFreq, MetronomeAttackMs, MetronomeBeatReleaseMs / 2));
+                toneGenerator.EndTones(MetronomeBeatFreq, MetronomeBeatAccentFreq);
+            }
+        }
+
+        private void UpdateGain() {
+            float gain = PlaybackManager.GetMetronomeGain();
+            if (gain != lastGain) {
+                lastGain = gain;
+                toneGenerator.SetGain(gain);
+            }
+        }
+    }
+}

--- a/OpenUtau.Core/SignalChain/MetronomeScheduler.cs
+++ b/OpenUtau.Core/SignalChain/MetronomeScheduler.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using OpenUtau.Core.Util;
+
+namespace OpenUtau.Core.SignalChain {
+    class MetronomeScheduler {
+        public int NextTick { get; private set; } = -1;
+        public int NextBar { get; private set; }
+        public int NextBeat { get; private set; }
+        public double NextMs { get; private set; } = double.NaN;
+
+        public bool IsScheduled => NextTick >= 0 && !double.IsNaN(NextMs);
+
+        public void Reset(TimeAxis timeAxis, int tick) {
+            ArgumentNullException.ThrowIfNull(timeAxis);
+            if (tick < 0) {
+                Clear();
+                return;
+            }
+            timeAxis.TickPosToBarBeat(tick, out var bar, out var beat, out var remainingTicks);
+            if (remainingTicks > 0) {
+                timeAxis.NextBarBeat(bar, beat, out bar, out beat);
+            }
+            NextBar = bar;
+            NextBeat = beat;
+            NextTick = timeAxis.BarBeatToTickPos(bar, beat);
+            NextMs = timeAxis.TickPosToMsPos(NextTick);
+        }
+
+        public void Advance(TimeAxis timeAxis) {
+            ArgumentNullException.ThrowIfNull(timeAxis);
+            if (NextTick < 0) {
+                return;
+            }
+            timeAxis.NextBarBeat(NextBar, NextBeat, out var nextBar, out var nextBeat);
+            NextBar = nextBar;
+            NextBeat = nextBeat;
+            NextTick = timeAxis.BarBeatToTickPos(NextBar, NextBeat);
+            NextMs = timeAxis.TickPosToMsPos(NextTick);
+        }
+
+        public void SkipPast(TimeAxis timeAxis, double currentMs) {
+            ArgumentNullException.ThrowIfNull(timeAxis);
+            while (IsScheduled && NextMs <= currentMs) {
+                Advance(timeAxis);
+            }
+        }
+
+        public void Clear() {
+            NextTick = -1;
+            NextBar = 0;
+            NextBeat = 0;
+            NextMs = double.NaN;
+        }
+    }
+}

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -186,6 +186,7 @@ namespace OpenUtau.Core.Util {
             public bool DiffSingerVarianceLocalPitchPatch = false;
             public bool DiffSingerLangCodeHide = false;
             public bool DiffSingerLocalRetaking = false;
+            public bool Metronome = false;
             public bool SkipRenderingMutedTracks = false;
             public string Language = string.Empty;
             public string? SortingOrder = null;
@@ -203,6 +204,9 @@ namespace OpenUtau.Core.Util {
             public uint AudioBackEnd = 0; // 0 = Automatic, 1 = MiniAudio, 2 = SDL
             public bool UseSystemDefaultAudioDevice = true;
             public double PlayPosMarkerMargin = 0.9;
+            public int MetronomeVolume = 60;
+            public int MetronomeHighFrequency = 2200;
+            public int MetronomeLowFrequency = 1320;
             public int LockStartTime = 0;
             public int PlaybackAutoScroll = 2;
             public bool ReverseLogOrder = true;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -635,6 +635,10 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.playback.lockstarttime.off">Do nothing</system:String>
   <system:String x:Key="prefs.playback.lockstarttime.on">Move cursor and view position back to where you started playing</system:String>
   <system:String x:Key="prefs.playback.lockstarttime.onlycursor">Move only cursor back to where you started playing</system:String>
+  <system:String x:Key="prefs.playback.metronome">Metronome</system:String>
+  <system:String x:Key="prefs.playback.metronome.volume">Metronome Volume</system:String>
+  <system:String x:Key="prefs.playback.metronome.highfrequency">Metronome High Frequency</system:String>
+  <system:String x:Key="prefs.playback.metronome.lowfrequency">Metronome Low Frequency</system:String>
   <system:String x:Key="prefs.playback.systemdefault">Use system default device</system:String>
   <system:String x:Key="prefs.playback.test">Test</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>

--- a/OpenUtau/ViewModels/PlaybackViewModel.cs
+++ b/OpenUtau/ViewModels/PlaybackViewModel.cs
@@ -16,6 +16,15 @@ namespace OpenUtau.App.ViewModels {
         public int Resolution => Project.resolution;
         public int PlayPosTick => DocManager.Inst.playPosTick;
         public TimeSpan PlayPosTime => TimeSpan.FromMilliseconds((int)Project.timeAxis.TickPosToMsPos(DocManager.Inst.playPosTick));
+        public bool Metronome {
+            get => PlaybackManager.Inst.Metronome;
+            set {
+                if (PlaybackManager.Inst.Metronome != value) {
+                    PlaybackManager.Inst.Metronome = value;
+                    this.RaisePropertyChanged(nameof(Metronome));
+                }
+            }
+        }
         public bool HasRangeSelection => DocManager.Inst.rangeEndTick > DocManager.Inst.rangeStartTick;
         public bool IsPlaying => PlaybackManager.Inst.PlayingMaster;
         public bool ShowPlayPosHighlight => !IsPlaying || HasRangeSelection;

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -63,6 +63,9 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public partial int LockStartTime { get; set; }
         [Reactive] public partial int PlaybackAutoScroll { get; set; }
         [Reactive] public partial double PlayPosMarkerMargin { get; set; }
+        [Reactive] public partial int MetronomeVolume { get; set; }
+        [Reactive] public partial int MetronomeHighFrequency { get; set; }
+        [Reactive] public partial int MetronomeLowFrequency { get; set; }
 
         // Paths
         public string SingerPath => PathManager.Inst.SingersPath;
@@ -157,6 +160,9 @@ namespace OpenUtau.App.ViewModels {
             AudioBackEnd = Preferences.Default.AudioBackEnd;
             PlaybackAutoScroll = Preferences.Default.PlaybackAutoScroll;
             PlayPosMarkerMargin = Preferences.Default.PlayPosMarkerMargin;
+            MetronomeVolume = Preferences.Default.MetronomeVolume;
+            MetronomeHighFrequency = Preferences.Default.MetronomeHighFrequency;
+            MetronomeLowFrequency = Preferences.Default.MetronomeLowFrequency;
             LockStartTime = Preferences.Default.LockStartTime;
             InstallToAdditionalSingersPath = Preferences.Default.InstallToAdditionalSingersPath;
             LoadDeepFolders = Preferences.Default.LoadDeepFolderSinger;
@@ -260,6 +266,21 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.PlayPosMarkerMargin)
                 .Subscribe(playPosMarkerMargin => {
                     Preferences.Default.PlayPosMarkerMargin = playPosMarkerMargin;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.MetronomeVolume)
+                .Subscribe(metronomeVolume => {
+                    Preferences.Default.MetronomeVolume = metronomeVolume;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.MetronomeHighFrequency)
+                .Subscribe(metronomeHighFrequency => {
+                    Preferences.Default.MetronomeHighFrequency = metronomeHighFrequency;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.MetronomeLowFrequency)
+                .Subscribe(metronomeLowFrequency => {
+                    Preferences.Default.MetronomeLowFrequency = metronomeLowFrequency;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.LockStartTime)
@@ -490,6 +511,26 @@ namespace OpenUtau.App.ViewModels {
                 Log.Error(e, "Failed to play test sound.");
                 DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("Failed to play test sound.", e));
             }
+        }
+        public void TestMetronome() {
+            try {
+                PlaybackManager.Inst.PlayMetronomeClick();
+            } catch (Exception e) {
+                Log.Error(e, "Failed to play metronome preview.");
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("Failed to play metronome preview.", e));
+            }
+        }
+
+        public void ResetMetronomeVolume() {
+            MetronomeVolume = new Preferences.SerializablePreferences().MetronomeVolume;
+        }
+
+        public void ResetMetronomeHighFrequency() {
+            MetronomeHighFrequency = new Preferences.SerializablePreferences().MetronomeHighFrequency;
+        }
+
+        public void ResetMetronomeLowFrequency() {
+            MetronomeLowFrequency = new Preferences.SerializablePreferences().MetronomeLowFrequency;
         }
 
         public void OpenResamplerLocation() {

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -1,4 +1,4 @@
-<Window xmlns="https://github.com/avaloniaui"
+﻿<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -241,7 +241,7 @@
                 </TextBlock>
               </Grid>
             </Border>
-            <Border Classes="playback" Width="109" HorizontalAlignment="Center">
+            <Border Classes="playback" Width="127" HorizontalAlignment="Center">
               <StackPanel Orientation="Horizontal">
                 <Button Command="{Binding PlaybackViewModel.SeekStart}" Height="18">
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
@@ -263,6 +263,11 @@
                               ToolTip.Tip="{DynamicResource tip.playback.loop}" Height="18">
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
                         Data="M 0.86 1.21 H 6.58 v -2 l 2.45 3 -2.45 3 v -2 H 1.68 v 2 H 0.04 v -2 c 0 -1.1 0.33 -2 0.82 -2 z m 7.36 8 h -5.73 v 2 l -2.45 -3 2.45 -3 v 2 h 4.91 v -2 H 9.04 v 2 c 0 1.1 -0.33 2 -0.82 2 z"/>
+                </ToggleButton>
+                <ToggleButton IsChecked="{Binding PlaybackViewModel.Metronome}"
+                              ToolTip.Tip="{DynamicResource prefs.playback.metronome}">
+                  <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
+                        Data="M 5 1 C 6 1 7 1 8 1 L 11 5 L 11 13 L 2 13 L 2 5 Z Z M 6.5 4 A 1.5 1.5 0 1 1 6.5 7 A 1.5 1.5 0 1 1 6.5 4 Z M 6.5 5 L 12.5 0 L 12.5 1 L 6.5 6 Z"/>
                 </ToggleButton>
               </StackPanel>
             </Border>

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -132,6 +132,47 @@
             <Slider Grid.Column="4" Classes="fader" Value="{Binding PlayPosMarkerMargin}" Minimum="0" Maximum="1"
                     TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"/>
           </Grid>
+          <TextBlock Text="{DynamicResource prefs.playback.metronome}" Margin="0,10,0,0"/>
+          <Grid ColumnDefinitions="Auto,8,30,8,*" Margin="0,10,0,0">
+            <TextBlock Grid.Column="0" Text="{DynamicResource prefs.playback.metronome.volume}"/>
+            <TextBlock Grid.Column="2">
+              <TextBlock.Text>
+                <MultiBinding StringFormat="{}{0:#0}">
+                  <Binding Path="MetronomeVolume"/>
+                </MultiBinding>
+              </TextBlock.Text>
+            </TextBlock>
+            <Slider Grid.Column="4" Classes="fader" Value="{Binding MetronomeVolume}" Minimum="0" Maximum="100" Tag="MetronomeVolume"
+                    PointerPressed="OnMetronomeSliderPointerPressed"
+                    TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
+          </Grid>
+          <Grid ColumnDefinitions="Auto,8,40,8,*" Margin="0,10,0,0">
+            <TextBlock Grid.Column="0" Text="{DynamicResource prefs.playback.metronome.highfrequency}"/>
+            <TextBlock Grid.Column="2">
+              <TextBlock.Text>
+                <MultiBinding StringFormat="{}{0:#0}">
+                  <Binding Path="MetronomeHighFrequency"/>
+                </MultiBinding>
+              </TextBlock.Text>
+            </TextBlock>
+            <Slider Grid.Column="4" Classes="fader" Value="{Binding MetronomeHighFrequency}" Minimum="20" Maximum="5000" Tag="MetronomeHighFrequency"
+                    PointerPressed="OnMetronomeSliderPointerPressed"
+                    TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
+          </Grid>
+          <Grid ColumnDefinitions="Auto,8,40,8,*" Margin="0,10,0,0">
+            <TextBlock Grid.Column="0" Text="{DynamicResource prefs.playback.metronome.lowfrequency}"/>
+            <TextBlock Grid.Column="2">
+              <TextBlock.Text>
+                <MultiBinding StringFormat="{}{0:#0}">
+                  <Binding Path="MetronomeLowFrequency"/>
+                </MultiBinding>
+              </TextBlock.Text>
+            </TextBlock>
+            <Slider Grid.Column="4" Classes="fader" Value="{Binding MetronomeLowFrequency}" Minimum="20" Maximum="3000" Tag="MetronomeLowFrequency"
+                    PointerPressed="OnMetronomeSliderPointerPressed"
+                    TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
+          </Grid>
+          <Button Content="{DynamicResource prefs.playback.test}" HorizontalAlignment="Stretch" Command="{Binding TestMetronome}"/>
         </StackPanel>
 
         <!-- Paths -->

--- a/OpenUtau/Views/PreferencesDialog.axaml.cs
+++ b/OpenUtau/Views/PreferencesDialog.axaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using OpenUtau.App.ViewModels;
@@ -15,6 +16,28 @@ namespace OpenUtau.App.Views {
 
         public PreferencesDialog() {
             InitializeComponent();
+        }
+
+        void OnMetronomeSliderPointerPressed(object? sender, PointerPressedEventArgs e) {
+            if (sender is not Slider slider || viewModel == null) {
+                return;
+            }
+            var point = e.GetCurrentPoint(slider);
+            if (!point.Properties.IsRightButtonPressed) {
+                return;
+            }
+            switch (slider.Tag as string) {
+                case "MetronomeVolume":
+                    viewModel.ResetMetronomeVolume();
+                    break;
+                case "MetronomeHighFrequency":
+                    viewModel.ResetMetronomeHighFrequency();
+                    break;
+                case "MetronomeLowFrequency":
+                    viewModel.ResetMetronomeLowFrequency();
+                    break;
+            }
+            e.Handled = true;
         }
 
         void OpenSingersFolder(object sender, RoutedEventArgs e) {


### PR DESCRIPTION
## Summary

Adds a metronome to playback. While the transport is running, a click is generated on every beat, with an accented click on the first beat of each bar. The click follows tempo and time signature changes, including changes made while playing.

This is a modified version of the pull request at https://github.com/openutau/OpenUtau/pull/2067

## Features

- **Toolbar toggle** next to the loop button turns the metronome on and off. The state is persisted in `prefs.json` (`MetronomeEnabled`) and restored on startup.
- **Preferences → Playback** gains a Metronome section:
  - `MetronomeVolume` (0–100, default 60)
  - `MetronomeHighFrequency` (20–5000 Hz, default 2200) — bar accent
  - `MetronomeLowFrequency` (20–3000 Hz, default 1320) — beat
  - A **Test** button previews the two clicks without starting playback.
  - Right-clicking any of the three sliders resets it to its default.
- Toggling during playback takes effect immediately and stays aligned to the grid — the schedule is rebuilt from the current play position rather than restarted from zero.

## Implementation

- **`MetronomeEngine`** (`OpenUtau.Core/SignalChain/`) is an `ISignalSource` that owns a private `ToneGenerator`. It is mixed into the playback chain by the new **`PlaybackMix`**, which sums the rendered master mix with the metronome overlay.
- **`MetronomeScheduler`** walks bar/beat positions through `TimeAxis`, so tempo maps and time signature changes are handled without any assumption of a constant BPM. `BpmCommand`, `TimeSignatureCommand` and the tempo/time-signature add/remove commands rebuild the schedule mid-playback.
- Clicks are placed at a **sample offset inside the buffer** rather than at buffer boundaries, so timing does not quantize to the audio buffer size. Each click is a short two-tone burst (base + accent partial) with a 5 ms attack and a 10 ms release.
- The engine is **thread-safe**: the scheduler and the playback `TimeAxis` are guarded by a lock, since the schedule is written from the UI thread (toggle, tempo edits, start/stop) and read from the audio thread. Gain is only pushed to the tone generator when the preference actually changes, keeping the audio callback allocation- and lock-free in the common case.
- `PlaybackManager.MetronomeEnabled` is the single source of truth. It reads `MetronomeEngine.Enabled`, writes the preference on change, and is initialized from `Preferences` in the `PlaybackManager` constructor, so the metronome no longer depends on view model construction order to be in the right state. `PlaybackViewModel.MetronomeEnabled` is a pass-through property, matching the existing `LoopPlayback` pattern.

## Playback end detection

The overlay required a change to how the end of playback is detected.

Previously, playback ended implicitly: once the rendered audio ran out, `WaveMix.Mix()` stopped advancing, `MasterAdapter.Read()` returned 0, and NAudio reported end-of-stream. The metronome can produce sound at any position, so with the overlay in the mix that signal never arrives and playback would run past the end of the project forever.

Playback now stops on the play position instead:

- `Play()` records `playbackEndTick` (the explicit end tick, or `UProject.EndTick`).
- `PlaybackMix` exposes `MasterExhausted`, set when the master source stops advancing. This is what preserves release tails — playback continues while the rendered audio is still producing sound past the last part.
- `UpdatePlayPos()` ends playback when the play position reaches `playbackEndTick` **and** the master source is exhausted.
- When the project is empty (`EndTick == 0`) no bound applies, so the metronome can be used on its own.

As a side effect, whole-project loop playback (`loopProjectOnPlaybackEnd`) now works; it depended on the end-of-stream signal that was never reached.

## Fixes

- **Race condition at playback start.** `StartingToPlay` was cleared on the render thread before `AudioOutput.Play()` was called. In that window the 15 ms UI timer could observe `Stopped && PlayingMaster && !StartingToPlay`, treat it as the end of playback, and call `StopPlayback()`. Playback then started anyway but with `PlayingMaster == false`, so audio played while the position marker never moved. `StartingToPlay` is now cleared after playback has actually started, and `UpdatePlayPos()` null-checks `masterMix`.

## Files changed

| File | Change |
|---|---|
| `OpenUtau.Core/SignalChain/MetronomeEngine.cs` | New — click generation and scheduling |
| `OpenUtau.Core/SignalChain/MetronomeScheduler.cs` | New — bar/beat walking over `TimeAxis` |
| `OpenUtau.Core/PlaybackManager.cs` | `PlaybackMix`, `MetronomeEnabled`, click preview, end-of-playback detection, start race fix |
| `OpenUtau.Core/Util/Preferences.cs` | 4 new preferences |
| `OpenUtau/ViewModels/PlaybackViewModel.cs` | Toolbar toggle binding |
| `OpenUtau/ViewModels/PreferencesViewModel.cs` | Volume / frequency settings, test, reset |
| `OpenUtau/Views/MainWindow.axaml` | Metronome toggle button |
| `OpenUtau/Views/PreferencesDialog.axaml(.cs)` | Metronome settings UI |
| `OpenUtau/Strings/Strings.axaml` | 4 new strings (English only — other locales not translated yet) |

## Testing

Verified manually on Windows:

- Playback stops at the end of the project; loops back to the start when loop playback is enabled.
- Range playback and range loop stop at the range end.
- One-shot previews with an explicit end tick (e.g. Alt+Space) stop at the expected position.
- Release tails past the last part are not cut off.
- The metronome alone plays on an empty project.
- The position marker no longer freezes while audio keeps playing right after starting playback.