### PR TITLE
Fix Minor UI Issues

### DIFF
--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -38,19 +38,19 @@
     </Style>
     <Style Selector="Slider.fader">
       <Setter Property="Foreground" Value="{Binding TrackColor.AccentColor}"/>
-      
+
       <Style Selector="^:pointerover">
-        <!--<Style Selector="^ /template/ Thumb">
-          <Setter Property="Background" Value="{Binding TrackColor.AccentColorLight}" />
-        </Style>-->
-        <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
-          <Setter Property="Background" Value="{Binding TrackColor.AccentColorLight}" />
-        </Style>
+      <Style Selector="^ /template/ Thumb">
+        <Setter Property="Background" Value="{Binding DataContext.TrackColor.AccentColorLight, RelativeSource={RelativeSource AncestorType=Slider}}"/>
       </Style>
+      <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
+        <Setter Property="Background" Value="{Binding TrackColor.AccentColorLight}" />
+      </Style>
+    </Style>
       <Style Selector="^:pressed">
-        <!--<Style Selector="^ /template/ Thumb">
-          <Setter Property="Background" Value="{Binding TrackColor.AccentColorDark}" />
-        </Style>-->
+        <Style Selector="^ /template/ Thumb">
+          <Setter Property="Background" Value="{Binding DataContext.TrackColor.AccentColorDark, RelativeSource={RelativeSource AncestorType=Slider}}"/>
+        </Style>
         <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
           <Setter Property="Background" Value="{Binding TrackColor.AccentColorDark}" />
         </Style>

--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -40,13 +40,13 @@
       <Setter Property="Foreground" Value="{Binding TrackColor.AccentColor}"/>
 
       <Style Selector="^:pointerover">
-      <Style Selector="^ /template/ Thumb">
-        <Setter Property="Background" Value="{Binding DataContext.TrackColor.AccentColorLight, RelativeSource={RelativeSource AncestorType=Slider}}"/>
+        <Style Selector="^ /template/ Thumb">
+          <Setter Property="Background" Value="{Binding DataContext.TrackColor.AccentColorLight, RelativeSource={RelativeSource AncestorType=Slider}}"/>
+        </Style>
+        <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
+          <Setter Property="Background" Value="{Binding TrackColor.AccentColorLight}" />
+        </Style>
       </Style>
-      <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
-        <Setter Property="Background" Value="{Binding TrackColor.AccentColorLight}" />
-      </Style>
-    </Style>
       <Style Selector="^:pressed">
         <Style Selector="^ /template/ Thumb">
           <Setter Property="Background" Value="{Binding DataContext.TrackColor.AccentColorDark, RelativeSource={RelativeSource AncestorType=Slider}}"/>

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -318,7 +318,8 @@
                               TrackHeight="{Binding TrackHeight}"
                               TrackOffset="{Binding TrackOffset}"
                               Items="{Binding Tracks}"
-                              PointerWheelChanged="MainPagePointerWheelChanged"/>
+                              PointerWheelChanged="MainPagePointerWheelChanged"
+                              Cursor="Arrow"/>
           <c:TrackBackground Grid.Row="2" Grid.Column="1" Margin="0" IsHitTestVisible="False"
                             Foreground="{DynamicResource TrackBackgroundAltBrush}"
                             DataContext="{Binding TracksViewModel}"


### PR DESCRIPTION
- Fixed the Volume Slider color
  - Previously, to avoid the issue where the thumb would turn white due to the binding error, I had commented out the code, so the thumb always appeared light blue when hovering over or clicking the slider. However, since I found a fundamental solution, it now binds correctly to the track color.
    <img width="302" height="140" alt="image" src="https://github.com/user-attachments/assets/fe4d809d-be6d-4fac-bd9b-08bbe7f942bb" />
- Fixed an issue where, when moving the mouse cursor quickly to a track header from the part edge, the cursor would remain resized.
  - Added cursor specification to `TrackHeaderCanvas`.

  https://github.com/user-attachments/assets/ae864005-7413-411b-9ba6-323dca6cc640

