### PR TITLE
Minor UI Fixes and Tweaks

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -416,9 +416,7 @@
           </Border>
           <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                         Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Focusable="False" Cursor="SizeNorthSouth" IsVisible="{Binding ShowPianoRoll}"/>
-          <Canvas Grid.Row="4" Grid.ColumnSpan="3" IsVisible="{Binding ShowPianoRoll}">
-            <ContentControl Name="PianoRollContainer" Width="{Binding $parent[Canvas].Bounds.Width}" Height="{Binding $parent[Canvas].Bounds.Height}"/>
-          </Canvas>
+          <ContentControl Grid.Row="4" Grid.ColumnSpan="3" Name="PianoRollContainer"/>
           <TextBlock Grid.Row="5" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" Height="20" Margin="4,4,4,0" Text="{Binding ProgressText}"/>
           <ProgressBar Grid.Row="6" Grid.ColumnSpan="3" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Value="{Binding Progress}"/>
         </Grid>

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -243,26 +243,26 @@
             </Border>
             <Border Classes="playback" Width="109" HorizontalAlignment="Center">
               <StackPanel Orientation="Horizontal">
-                <Button Command="{Binding PlaybackViewModel.SeekStart}">
+                <Button Command="{Binding PlaybackViewModel.SeekStart}" Height="18">
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
                         Data="M 0 0 L 2 0 L 2 9 L 0 9 Z M 2 4.5 L 7 0 L 7 9 Z"/>
                 </Button>
-                <Button Click="OnPlayOrPause">
+                <Button Click="OnPlayOrPause" Height="18">
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
-                        Data="M 0 0 L 7 6.5 L 0 13 Z"/>
+                        Data="M 0 0.5 7 4.62 0 8.73 Z"/>
                 </Button>
-                <Button Command="{Binding PlaybackViewModel.Pause}">
+                <Button Command="{Binding PlaybackViewModel.Pause}" Height="18">
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
                         Data="M 0 0 L 2 0 L 2 9 L 0 9 Z M 4 0 L 6 0 L 6 9 L 4 9 Z"/>
                 </Button>
-                <Button Command="{Binding PlaybackViewModel.SeekEnd}">
+                <Button Command="{Binding PlaybackViewModel.SeekEnd}" Height="18">
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
                         Data="M 0 0 L 5 4.5 L 0 9 Z M 5 0 L 7 0 L 7 9 L 5 9 Z"/>
                 </Button>
                 <ToggleButton IsChecked="{Binding PlaybackViewModel.LoopPlayback}"
-                              ToolTip.Tip="{DynamicResource tip.playback.loop}">
+                              ToolTip.Tip="{DynamicResource tip.playback.loop}" Height="18">
                   <Path Fill="{Binding $parent.Foreground}" VerticalAlignment="Center" HorizontalAlignment="Center"
-                        Data="M 1 2 L 8 2 L 8 0 L 11 3 L 8 6 L 8 4 L 2 4 L 2 6 L 0 6 L 0 4 C 0 2.9 0.4 2 1 2 Z M 10 10 L 3 10 L 3 12 L 0 9 L 3 6 L 3 8 L 9 8 L 9 6 L 11 6 L 11 8 C 11 9.1 10.6 10 10 10 Z"/>
+                        Data="M 0.86 1.21 H 6.58 v -2 l 2.45 3 -2.45 3 v -2 H 1.68 v 2 H 0.04 v -2 c 0 -1.1 0.33 -2 0.82 -2 z m 7.36 8 h -5.73 v 2 l -2.45 -3 2.45 -3 v 2 h 4.91 v -2 H 9.04 v 2 c 0 1.1 -0.33 2 -0.82 2 z"/>
                 </ToggleButton>
               </StackPanel>
             </Border>

--- a/OpenUtau/Views/SplashWindow.axaml.cs
+++ b/OpenUtau/Views/SplashWindow.axaml.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
-using OpenUtau.App;
 using OpenUtau.Classic;
 using OpenUtau.Core;
 using ReactiveUI;
@@ -21,7 +21,8 @@ namespace OpenUtau.App.Views {
                 .Subscribe(_ => UpdateLogo())
                 .DisposeWith(disposable);
             this.Cursor = new Cursor(StandardCursorType.AppStarting);
-            this.Activated += SplashWindow_Opened;
+            this.GetObservable(Window.IsActiveProperty)
+                .Subscribe(_ => SplashWindow_Opened());
         }
 
         private readonly MultipleDisposable disposable = new();
@@ -35,7 +36,7 @@ namespace OpenUtau.App.Views {
             disposable.Dispose();
         }
 
-        private void SplashWindow_Opened(object? sender, EventArgs e) {
+        private void SplashWindow_Opened() {
             if (Screens.Primary == null && Screens.ScreenCount == 0) {
                 return;
             }


### PR DESCRIPTION
- Fix splash screen in X11
- Remove old workaround for attached pianoroll resize bug (no longer needed)
- Adjust playback control icons
  <img width="308" height="30" alt="image" src="https://github.com/user-attachments/assets/e7ba3c43-26a2-4649-a406-500f3600b6b8" />