### PR TITLE
Guard TimeAxis against non-finite tempo values

### DIFF
--- a/OpenUtau.Core/Util/TimeAxis.cs
+++ b/OpenUtau.Core/Util/TimeAxis.cs
@@ -35,10 +35,23 @@ namespace OpenUtau.Core {
             public int Ticks => tickEnd - tickPos;
         }
 
+        const double DefaultBpm = 120.0;
+        const int DefaultBeatPerBar = 4;
+        const int DefaultBeatUnit = 4;
+
         readonly List<TimeSigSegment> timeSigSegments = new List<TimeSigSegment>();
         readonly List<TempoSegment> tempoSegments = new List<TempoSegment>();
 
         public long Timestamp { get; private set; }
+
+        /// <summary>
+        /// A bpm is only usable if it can be divided by. Zero, NaN or infinity turns
+        /// msPerTick into infinity or NaN, which then poisons msPos of every following
+        /// segment and every ms value derived from them.
+        /// </summary>
+        static bool IsValidBpm(double bpm) {
+            return double.IsFinite(bpm) && bpm > 0;
+        }
 
         public void BuildSegments(UProject project) {
             Timestamp = DateTime.Now.ToFileTimeUtc();
@@ -55,13 +68,29 @@ namespace OpenUtau.Core {
                         throw new Exception("First time signature must be at bar 0.");
                     }
                 }
+                // A non-positive beat unit divides by zero here, and a non-positive
+                // beat per bar makes ticksPerBar zero, which divides by zero later.
+                var beatPerBar = timesig.beatPerBar > 0 ? timesig.beatPerBar : DefaultBeatPerBar;
+                var beatUnit = timesig.beatUnit > 0 ? timesig.beatUnit : DefaultBeatUnit;
                 timeSigSegments.Add(new TimeSigSegment {
                     barPos = timesig.barPosition,
                     tickPos = posTick,
-                    beatPerBar = timesig.beatPerBar,
-                    beatUnit = timesig.beatUnit,
-                    ticksPerBar = project.resolution * 4 * timesig.beatPerBar / timesig.beatUnit,
-                    ticksPerBeat = project.resolution * 4 / timesig.beatUnit,
+                    beatPerBar = beatPerBar,
+                    beatUnit = beatUnit,
+                    ticksPerBar = project.resolution * 4 * beatPerBar / beatUnit,
+                    ticksPerBeat = project.resolution * 4 / beatUnit,
+                });
+            }
+            if (timeSigSegments.Count == 0) {
+                // Without this a project with no time signature leaves every bar/beat
+                // lookup with nothing to return, and leaves tempoSegments empty too.
+                timeSigSegments.Add(new TimeSigSegment {
+                    barPos = 0,
+                    tickPos = 0,
+                    beatPerBar = DefaultBeatPerBar,
+                    beatUnit = DefaultBeatUnit,
+                    ticksPerBar = project.resolution * 4 * DefaultBeatPerBar / DefaultBeatUnit,
+                    ticksPerBeat = project.resolution * 4 / DefaultBeatUnit,
                 });
             }
             for (var i = 0; i < timeSigSegments.Count - 1; ++i) {
@@ -101,8 +130,13 @@ namespace OpenUtau.Core {
                     });
                 }
             }
+            if (!IsValidBpm(tempoSegments[0].bpm)) {
+                // No tempo at tick 0, or one that cannot be divided by. Everything
+                // after inherits from here, so this segment must be valid.
+                tempoSegments[0].bpm = DefaultBpm;
+            }
             for (var i = 0; i < tempoSegments.Count - 1; ++i) {
-                if (tempoSegments[i + 1].bpm == 0) {
+                if (!IsValidBpm(tempoSegments[i + 1].bpm)) {
                     tempoSegments[i + 1].bpm = tempoSegments[i].bpm;
                 }
                 tempoSegments[i].tickEnd = tempoSegments[i + 1].tickPos;
@@ -117,26 +151,83 @@ namespace OpenUtau.Core {
             }
         }
 
+        /// <summary>
+        /// Finds the tempo segment containing a tick. Never throws: a tick past the
+        /// last segment, or a NaN one, is clamped instead. These lookups run on the
+        /// render thread, where an exception takes the whole app down.
+        /// </summary>
+        TempoSegment TempoSegmentAtTick(double tick) {
+            if (!double.IsNaN(tick)) {
+                for (var i = 0; i < tempoSegments.Count; ++i) { // TODO: optimize
+                    var segment = tempoSegments[i];
+                    if (segment.tickPos == tick || segment.tickEnd > tick) {
+                        return segment;
+                    }
+                }
+            }
+            return tempoSegments[tempoSegments.Count - 1];
+        }
+
+        /// <summary>
+        /// Ms counterpart of <see cref="TempoSegmentAtTick"/>. Also never throws.
+        /// </summary>
+        TempoSegment TempoSegmentAtMsPos(double ms) {
+            if (!double.IsNaN(ms)) {
+                for (var i = 0; i < tempoSegments.Count; ++i) { // TODO: optimize
+                    var segment = tempoSegments[i];
+                    if (segment.msPos == ms || segment.msEnd > ms) {
+                        return segment;
+                    }
+                }
+            }
+            return tempoSegments[tempoSegments.Count - 1];
+        }
+
+        TimeSigSegment TimeSigSegmentAtTick(int tick) {
+            for (var i = 0; i < timeSigSegments.Count; ++i) { // TODO: optimize
+                var segment = timeSigSegments[i];
+                if (segment.tickPos == tick || segment.tickEnd > tick) {
+                    return segment;
+                }
+            }
+            return timeSigSegments[timeSigSegments.Count - 1];
+        }
+
+        TimeSigSegment TimeSigSegmentAtBar(int bar) {
+            for (var i = 0; i < timeSigSegments.Count; ++i) { // TODO: optimize
+                var segment = timeSigSegments[i];
+                if (segment.barPos == bar || segment.barEnd > bar) {
+                    return segment;
+                }
+            }
+            return timeSigSegments[timeSigSegments.Count - 1];
+        }
+
         public double GetBpmAtTick(int tick) {
-            var segment = tempoSegments.First(seg => seg.tickPos == tick || seg.tickEnd > tick); // TODO: optimize
+            var segment = TempoSegmentAtTick(tick);
             return segment.bpm;
         }
 
         public double TickPosToMsPos(double tick) {
-            var segment = tempoSegments.First(seg => seg.tickPos == tick || seg.tickEnd > tick); // TODO: optimize
+            var segment = TempoSegmentAtTick(tick);
             return segment.msPos + segment.msPerTick * (tick - segment.tickPos);
         }
 
         public double MsPosToNonExactTickPos(double ms) {
-            var segment = tempoSegments.First(seg => seg.msPos == ms || seg.msEnd > ms); // TODO: optimize
+            var segment = TempoSegmentAtMsPos(ms);
             double tickPos = segment.tickPos + (ms - segment.msPos) * segment.ticksPerMs;
             return tickPos;
         }
 
         public int MsPosToTickPos(double ms) {
-            var segment = tempoSegments.First(seg => seg.msPos == ms || seg.msEnd > ms); // TODO: optimize
+            var segment = TempoSegmentAtMsPos(ms);
             double tickPos = segment.tickPos + (ms - segment.msPos) * segment.ticksPerMs;
-            return (int)Math.Round(tickPos);
+            if (!double.IsFinite(tickPos)) {
+                // Casting NaN or infinity saturates silently, which hides the bad
+                // value. Fall back to the segment start instead.
+                return segment.tickPos;
+            }
+            return (int)Math.Round(Math.Clamp(tickPos, int.MinValue, int.MaxValue));
         }
 
         public int TicksBetweenMsPos(double msPos, double msEnd) {
@@ -160,7 +251,7 @@ namespace OpenUtau.Core {
         }
 
         public void TickPosToBarBeat(int tick, out int bar, out int beat, out int remainingTicks) {
-            var segment = timeSigSegments.First(seg => seg.tickPos == tick || seg.tickEnd > tick); // TODO: optimize
+            var segment = TimeSigSegmentAtTick(tick);
             bar = segment.barPos + (tick - segment.tickPos) / segment.ticksPerBar;
             int tickInBar = tick - segment.tickPos - segment.ticksPerBar * (bar - segment.barPos);
             beat = tickInBar / segment.ticksPerBeat;
@@ -168,14 +259,14 @@ namespace OpenUtau.Core {
         }
 
         public int BarBeatToTickPos(int bar, int beat) {
-            var segment = timeSigSegments.First(seg => seg.barPos == bar || seg.barEnd > bar); // TODO: optimize
+            var segment = TimeSigSegmentAtBar(bar);
             return segment.tickPos + segment.ticksPerBar * (bar - segment.barPos) + segment.ticksPerBeat * beat;
         }
 
         public void NextBarBeat(int bar, int beat, out int nextBar, out int nextBeat) {
             nextBar = bar;
             nextBeat = beat + 1;
-            var segment = timeSigSegments.First(seg => seg.barPos == bar || seg.barEnd > bar); // TODO: optimize
+            var segment = TimeSigSegmentAtBar(bar);
             if (nextBeat >= segment.beatPerBar) {
                 nextBar++;
                 nextBeat = 0;
@@ -191,7 +282,7 @@ namespace OpenUtau.Core {
         }
 
         public UTimeSignature TimeSignatureAtTick(int tick) {
-            var segment = timeSigSegments.First(seg => seg.tickPos == tick || seg.tickEnd > tick); // TODO: optimize
+            var segment = TimeSigSegmentAtTick(tick);
             return new UTimeSignature {
                 barPosition = segment.barPos,
                 beatPerBar = segment.beatPerBar,
@@ -200,7 +291,7 @@ namespace OpenUtau.Core {
         }
 
         public UTimeSignature TimeSignatureAtBar(int bar) {
-            var segment = timeSigSegments.First(seg => seg.barPos == bar || seg.barEnd > bar); // TODO: optimize
+            var segment = TimeSigSegmentAtBar(bar);
             return new UTimeSignature {
                 barPosition = segment.barPos,
                 beatPerBar = segment.beatPerBar,

--- a/OpenUtau.Test/Core/Util/TimeAxisTest.cs
+++ b/OpenUtau.Test/Core/Util/TimeAxisTest.cs
@@ -99,5 +99,97 @@ namespace OpenUtau.Core {
             Assert.Equal(0, beat);
             Assert.Equal(440, remainingTicks);
         }
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(-120.0)]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        public void InvalidFirstTempoTest(double bpm) {
+            var timeAxis = new TimeAxis();
+            var project = new UProject();
+            project.tempos[0].bpm = bpm;
+            timeAxis.BuildSegments(project);
+
+            // Falls back to the default tempo instead of producing NaN or infinity.
+            Assert.Equal(120, timeAxis.GetBpmAtTick(0));
+            Assert.Equal(500, timeAxis.TickPosToMsPos(480), 6);
+            Assert.Equal(480, timeAxis.MsPosToTickPos(500));
+        }
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        public void InvalidLaterTempoTest(double bpm) {
+            var timeAxis = new TimeAxis();
+            var project = new UProject();
+            project.tempos.Add(new UTempo(4800, bpm));
+            timeAxis.BuildSegments(project);
+
+            // An unusable tempo inherits the previous one. Without this, msPos of
+            // every following segment becomes NaN or infinity, and any ms value
+            // derived from it kills the render thread on lookup.
+            Assert.Equal(120, timeAxis.GetBpmAtTick(4800));
+            Assert.Equal(10000, timeAxis.TickPosToMsPos(9600), 6);
+            Assert.Equal(9600, timeAxis.MsPosToTickPos(10000));
+        }
+
+        [Fact]
+        public void NoTemposTest() {
+            var timeAxis = new TimeAxis();
+            var project = new UProject();
+            project.tempos.Clear();
+            timeAxis.BuildSegments(project);
+
+            Assert.Equal(120, timeAxis.GetBpmAtTick(0));
+            Assert.Equal(500, timeAxis.TickPosToMsPos(480), 6);
+        }
+
+        [Fact]
+        public void NoTimeSignaturesTest() {
+            var timeAxis = new TimeAxis();
+            var project = new UProject();
+            project.timeSignatures.Clear();
+            timeAxis.BuildSegments(project);
+
+            Assert.Equal(120, timeAxis.GetBpmAtTick(0));
+            Assert.Equal(1920, timeAxis.BarBeatToTickPos(1, 0));
+            timeAxis.TickPosToBarBeat(1920, out int bar, out int beat, out int remainingTicks);
+            Assert.Equal(1, bar);
+            Assert.Equal(0, beat);
+            Assert.Equal(0, remainingTicks);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(4)]
+        [InlineData(-1)]
+        public void InvalidBeatUnitTest(int beatUnit) {
+            var timeAxis = new TimeAxis();
+            var project = new UProject();
+            project.timeSignatures[0].beatUnit = beatUnit;
+            timeAxis.BuildSegments(project);
+
+            // A non-positive beat unit used to divide by zero while building.
+            Assert.Equal(1920, timeAxis.BarBeatToTickPos(1, 0));
+        }
+
+        [Theory]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        public void NonFiniteLookupTest(double value) {
+            var timeAxis = new TimeAxis();
+            var project = new UProject();
+            timeAxis.BuildSegments(project);
+
+            // Callers on the render thread pass values derived from phoneme
+            // envelopes, which can go non-finite. These must not throw.
+            var tickPos = timeAxis.MsPosToTickPos(value);
+            Assert.InRange(tickPos, int.MinValue, int.MaxValue);
+            timeAxis.MsPosToNonExactTickPos(value);
+            timeAxis.TickPosToMsPos(value);
+        }
     }
 }


### PR DESCRIPTION
While testing the synthesis process of another PR, NaN (Not a Number) was passed to PhonemeCanvas during envelope rendering in a project set to 300 BPM, triggering an InvalidOperationException. The cause was that the lookup process in TimeAxis used `First(predicate)` with a condition that could not match NaN or infinity inputs. Consequently, if even a single inappropriate value was included, the "Sequence contains no matching element" exception was thrown, causing the rendering thread to stop.

The cause of the NaN is currently under investigation (the BPM was saved correctly in the project file itself). If NaN (or infinity) is passed to `BuildSegments`, `msPerTick` becomes infinite or NaN, contaminating the `msPos` of all subsequent segments. The previous fallback process only checked for `bpm == 0`, allowing NaN to slip through this condition. As a result, phonemes whose start position (`PositionMs`) was in a normal segment and end position (`EndMs`) overlapped with a contaminated segment ended up with a non-finite `DurationMs` (length), causing `PhonemeCanvas.Render` to throw an exception during envelope rendering.

Fixes included in this PR:
- Updated the logic to reject all BPM values that cannot be used in division, not just zero, falling back to 120 if the first segment lacks a valid BPM.
- Set the default time signature to 4/4 if the project lacks one, and set positive default values for both the denominator and numerator of the time signature, as they were also causing division by zero.
- Replaced all `First(predicate)` lookups with a helper process that clamps to the last segment's value instead of throwing an exception.
- Stopped relying on NaN-to-int casts (which silently returned 0 due to saturating casts) and directly clamped the result of `MsPosToTickPos`.