### PR TITLE
Fix NaN envelope when oto preutter is zero

### DIFF
--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -135,7 +135,7 @@ namespace OpenUtau.Core.Ustx {
                     maxPreutter = gapMs;
                 }
                 if (autoPreutter > maxPreutter) {
-                    double ratio = maxPreutter / autoPreutter;
+                    double ratio = autoPreutter > 0 ? maxPreutter / autoPreutter : 0d;
                     autoPreutter = maxPreutter;
                     autoOverlap *= ratio;
                 }


### PR DESCRIPTION
Singers with dummy otos (VOICEVOX, ENUNU, DiffSinger, Vogen) and UTAU otos with a blank preutter leave autoPreutter at 0. When the previous phoneme is shorter than 5ms, maxPreutter goes negative and ValidateOverlap computes maxPreutter / autoPreutter = -Infinity, so autoOverlap becomes NaN. That NaN reaches the previous phoneme's envelope p3/p4 via tailIntrude/tailOverlap, and PhonemeCanvas.Render crashes feeding it to TimeAxis.MsPosToTickPos.

Scale autoOverlap only when there is a preutter to scale against.