### PR TITLE
Fix DiffSinger crash when rendering races singer memory release

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -357,9 +357,8 @@ namespace OpenUtau.Core.DiffSinger {
                     throw new Exception(
                         "This singer has no variance predictor but its acoustic model requires one.");
                 }
-                var variancePredictor = singer.getVariancePredictor();
                 VarianceResult varianceResult;
-                lock(variancePredictor){
+                lock(singer.SessionLock){
                     if(cancellation.IsCancellationRequested) {
                         return null;
                     }
@@ -456,7 +455,7 @@ namespace OpenUtau.Core.DiffSinger {
                 : null;
             var acousticOutputs = acousticCache?.Load();
             if (acousticOutputs is null) {
-                lock(acousticModel){
+                lock(singer.SessionLock){
                     if(cancellation.IsCancellationRequested) {
                         return null;
                     }
@@ -496,7 +495,7 @@ namespace OpenUtau.Core.DiffSinger {
                 : null;
             var vocoderOutputs = vocoderCache?.Load();
             if (vocoderOutputs is null) {
-                lock(vocoder){
+                lock(singer.SessionLock){
                     if(cancellation.IsCancellationRequested) {
                         return null;
                     }
@@ -526,7 +525,7 @@ namespace OpenUtau.Core.DiffSinger {
                 throw new Exception("This singer has no pitch predictor.");
             }
             var pitchPredictor = singer.getPitchPredictor()!;
-            lock (pitchPredictor) {
+            lock (singer.SessionLock) {
                 return pitchPredictor.Process(phrase);
             }
         }
@@ -547,7 +546,7 @@ namespace OpenUtau.Core.DiffSinger {
             var retakeNoteIndexes = DiffSingerRetake.MapSelectedPositionsToNoteIndexes(
                 phrase.position, noteRelativePositions, selectedNotePositions);
             if (retakeNoteIndexes.Count == 0 || retakeNoteIndexes.Count == phrase.notes.Length) {
-                lock (pitchPredictor) {
+                lock (singer.SessionLock) {
                     return pitchPredictor.Process(phrase);
                 }
             }
@@ -558,7 +557,7 @@ namespace OpenUtau.Core.DiffSinger {
             int totalFrames = ph_dur.Sum();
             var existingPitch = DiffSingerUtils.SampleCurve(phrase, phrase.pitches, 0, frameMs, totalFrames, headFrames, tailFrames,
                 x => x * 0.01).Select(f => (float)f).ToArray();
-            lock (pitchPredictor) {
+            lock (singer.SessionLock) {
                 return pitchPredictor.Process(phrase, retakeNoteIndexes, existingPitch);
             }
         }
@@ -576,7 +575,7 @@ namespace OpenUtau.Core.DiffSinger {
                 return new List<RenderRealCurveResult>(0);
             }
             var variancePredictor = singer.getVariancePredictor()!;
-            lock (variancePredictor) {
+            lock (singer.SessionLock) {
                 var result = variancePredictor.Process(phrase);
                 return BuildRenderedRealCurves(phrase, result);
             }

--- a/OpenUtau.Core/DiffSinger/DiffSingerScript.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerScript.cs
@@ -136,7 +136,7 @@ namespace OpenUtau.Core.DiffSinger {
                 if (options.exportVariance && singer.HasVariancePredictor) {
                     var variancePredictor = singer.getVariancePredictor();
                     VarianceResult varianceResult;
-                    lock (variancePredictor) {
+                    lock (singer.SessionLock) {
                         varianceResult = variancePredictor.Process(phrase);
                     }
                     if (varianceResult.energy != null) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -52,6 +52,15 @@ namespace OpenUtau.Core.DiffSinger {
         public DsPitch pitchPredictor = null;
         public DiffSingerSpeakerEmbedManager speakerEmbedManager = null;
         public DsVariance variancePredictor = null;
+        /// <summary>
+        /// Guards the lazily created native models above: building one, using one and freeing one
+        /// are mutually exclusive per singer. Locking the model instances themselves cannot do
+        /// that, because the instance to lock does not exist until it has been built and is set to
+        /// null when it is freed — so two threads could build the same model at once, or one could
+        /// go on using a model a concurrent <see cref="FreeMemory"/> had already disposed. The
+        /// result was an access violation inside onnxruntime rather than a managed exception.
+        /// </summary>
+        public object SessionLock { get; } = new object();
         public bool HasPitchPredictor => File.Exists(Path.Join(Location, "dspitch", "dsconfig.yaml"));
         public bool HasVariancePredictor => File.Exists(Path.Join(Location,"dsvariance", "dsconfig.yaml"));
 
@@ -173,49 +182,59 @@ namespace OpenUtau.Core.DiffSinger {
         }
 
         public InferenceSession getAcousticSession() {
-            if (acousticSession is null) {
-                var acousticPath = Path.Combine(Location, dsConfig.acoustic);
-                var acousticBytes = File.ReadAllBytes(acousticPath);
-                acousticHash = XXH64.DigestOf(acousticBytes);
-                acousticSession = Onnx.getInferenceSession(acousticBytes, OnnxRunnerChoice.Default);
+            lock (SessionLock) {
+                if (acousticSession is null) {
+                    var acousticPath = Path.Combine(Location, dsConfig.acoustic);
+                    var acousticBytes = File.ReadAllBytes(acousticPath);
+                    acousticHash = XXH64.DigestOf(acousticBytes);
+                    acousticSession = Onnx.getInferenceSession(acousticBytes, OnnxRunnerChoice.Default);
+                }
+                return acousticSession;
             }
-            return acousticSession;
         }
 
         public DsVocoder getVocoder() {
-            if(vocoder is null) {
-                if(File.Exists(Path.Join(Location, "dsvocoder", "vocoder.yaml"))) {
-                    vocoder = new DsVocoder(Path.Join(Location, "dsvocoder"));
-                    return vocoder;
+            lock (SessionLock) {
+                if(vocoder is null) {
+                    if(File.Exists(Path.Join(Location, "dsvocoder", "vocoder.yaml"))) {
+                        vocoder = new DsVocoder(Path.Join(Location, "dsvocoder"));
+                        return vocoder;
+                    }
+                    vocoder = new DsVocoder(Path.Combine(PathManager.Inst.DependencyPath, dsConfig.vocoder));
                 }
-                vocoder = new DsVocoder(Path.Combine(PathManager.Inst.DependencyPath, dsConfig.vocoder));
+                return vocoder;
             }
-            return vocoder;
         }
 
         public DsPitch? getPitchPredictor(){
-            if(pitchPredictor is null) {
-                if(HasPitchPredictor){
-                    pitchPredictor = new DsPitch(Path.Join(Location, "dspitch"));
+            lock (SessionLock) {
+                if(pitchPredictor is null) {
+                    if(HasPitchPredictor){
+                        pitchPredictor = new DsPitch(Path.Join(Location, "dspitch"));
+                    }
                 }
+                return pitchPredictor;
             }
-            return pitchPredictor;
         }
-       
+
         public DiffSingerSpeakerEmbedManager getSpeakerEmbedManager(){
-            if(speakerEmbedManager is null) {
-                speakerEmbedManager = new DiffSingerSpeakerEmbedManager(dsConfig, Location);
+            lock (SessionLock) {
+                if(speakerEmbedManager is null) {
+                    speakerEmbedManager = new DiffSingerSpeakerEmbedManager(dsConfig, Location);
+                }
+                return speakerEmbedManager;
             }
-            return speakerEmbedManager;
         }
 
         public DsVariance? getVariancePredictor(){
-            if(variancePredictor is null) {
-                if(HasVariancePredictor){
-                    variancePredictor = new DsVariance(Path.Join(Location, "dsvariance"));
+            lock (SessionLock) {
+                if(variancePredictor is null) {
+                    if(HasVariancePredictor){
+                        variancePredictor = new DsVariance(Path.Join(Location, "dsvariance"));
+                    }
                 }
+                return variancePredictor;
             }
-            return variancePredictor;
         }
 
         public int PhonemeTokenize(string phoneme){
@@ -233,28 +252,16 @@ namespace OpenUtau.Core.DiffSinger {
 
         public override void FreeMemory(){
             Log.Information($"Freeing memory for singer {Id}");
-            if(acousticSession != null) {
-                lock(acousticSession) {
-                    acousticSession?.Dispose();
-                }
+            // The same lock the getters take, so a render already inside one of these models
+            // finishes before it is disposed instead of being left holding a freed handle.
+            lock (SessionLock) {
+                acousticSession?.Dispose();
                 acousticSession = null;
-            }
-            if(vocoder != null) {
-                lock(vocoder) {
-                    vocoder?.Dispose();
-                }
+                vocoder?.Dispose();
                 vocoder = null;
-            }
-            if(pitchPredictor != null) {
-                lock(pitchPredictor) {
-                    pitchPredictor?.Dispose();
-                }
+                pitchPredictor?.Dispose();
                 pitchPredictor = null;
-            }
-            if(variancePredictor != null){
-                lock(variancePredictor) {
-                    variancePredictor?.Dispose();
-                }
+                variancePredictor?.Dispose();
                 variancePredictor = null;
             }
         }


### PR DESCRIPTION
## The crash

A user reported OpenUtau exiting with no dialog in two situations: starting playback before rendering had finished, and switching singer then pressing render straight after. Windows recorded an access violation (`0xC0000005`) in `coreclr.dll`, with this managed stack:

```
Microsoft.ML.OnnxRuntime.InferenceSession.Init
OpenUtau.Core.Onnx.getInferenceSession
OpenUtau.Core.DiffSinger.DsVariance..ctor
OpenUtau.Core.DiffSinger.DiffSingerSinger.getVariancePredictor
OpenUtau.Core.DiffSinger.DiffSingerRenderer.LoadRenderedRealCurves
OpenUtau.Core.Render.RealCurveUpdater.LoadPhraseUpdates
OpenUtau.Core.Render.RenderEngine.PublishRealCurveUpdates
OpenUtau.Core.Render.RenderEngine.RenderRequests        (thread pool)
```

Because it ends in native memory, `AppDomain.UnhandledException` never fires and the Serilog log simply stops mid-line — which is why this only ever looked like a silent quit.

## Cause

The five lazy getters on `DiffSingerSinger` (`getAcousticSession`, `getVocoder`, `getPitchPredictor`, `getSpeakerEmbedManager`, `getVariancePredictor`) were unsynchronized check-then-create, and `FreeMemory` locked each model instance while disposing it:

```csharp
if (variancePredictor != null) {
    lock (variancePredictor) { variancePredictor?.Dispose(); }
    variancePredictor = null;
}
```

That instance is the one object which cannot serve as the lock here: it does not exist until it has been built, and it is set to `null` when it is freed. So two threads could build the same model at once, and a thread that had already obtained a reference could go on using a model a concurrent `FreeMemory` had disposed.

`RenderEngine.PrepareRequests` calls `SingerManager.ReleaseSingersNotInUse` on every render preparation, which is why both reported triggers are the same race: pressing play starts a second preparation while the first render is still in flight, and switching singer makes the old singer unused while a render still holds its models.

## Fix

Each singer gets one lock covering building, using and freeing its models. `FreeMemory` and the call sites in `DiffSingerRenderer`/`DiffSingerScript` take the same lock, so a reference cannot be disposed while a render is inside it.

The models of a single singer no longer run concurrently with one another. On the render path that costs close to nothing — `RenderRequests` already renders phrase by phrase with `task.Wait()` — and the caller it does serialize is `DiffSingerRealCurveScheduler`'s background refresh, which is exactly the one that has to wait. Single lock, no nesting, so no deadlock.

## Not a regression in #2175

The unsafe getters predate that PR; #2175 was simply the first caller to reach `getVariancePredictor` from a render thread, which made a long-standing race reachable. I checked branches that lack it — they are unexposed, not safe. The crash additionally needs the model to be unbuilt at that moment, which is why it appears right after a project load or a singer switch and rarely again afterwards.

## Testing

- `dotnet build OpenUtau.Core` clean, `dotnet test OpenUtau.Test` → **255 passed, 0 failed**.
- No unit test is included: `DiffSingerSinger` needs a real voicebank with ONNX models on disk, which the test project has none of, and a bare concurrency assertion would be flaky. The reproduction is manual — with a singer that has a `dsvariance` model and `DiffSingerTensorCache` enabled, load a project or switch singer, press play, and trigger a second render while the first is still running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
