### PR TITLE
Toast Notification

### DIFF
--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -37,6 +37,40 @@ namespace OpenUtau.Core {
             }
         }
     }
+    public class ToastNotification : UNotification {
+        public readonly string windowType;
+        public readonly string message;
+        public readonly string translationKey;
+
+        /// <summary>
+        /// Not currently in use
+        /// </summary>
+        public string? title;
+        /// <summary>
+        /// Not currently in use (The color of the toast might change in the future).
+        /// </summary>
+        public string type = "Warning";
+        /// <summary>
+        /// Toast display time. If 0 is specified, it will not close automatically.
+        /// </summary>
+        public long durationSec = 4;
+        public Exception? e;
+
+        /// <summary>
+        /// Displays a toast message in the window that does not interfere with the user's operations.
+        /// </summary>
+        /// <param name="windowType">"MainWindow" or "Pianoroll" (If the specified window is not on top, a toast will always appear in the main window).</param>
+        /// <param name="message">This is not displayed in the UI. The actual text is specified by translationKey.</param>
+        /// <param name="translationKey">The key for the text that actually appears on the toast.</param>
+        /// <param name="e">If there are any associated exceptions, clicking the toast notification will display a standard error dialog.</param>
+        public ToastNotification(string windowType, string message, string translationKey, Exception? e = null) {
+            this.windowType = windowType;
+            this.message = message;
+            this.translationKey = translationKey;
+            this.e = e;
+        }
+        public override string ToString() => $"Toast notification: {message}";
+    }
 
     public class LoadingNotification : UNotification {
         public readonly Type window;

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -207,6 +207,7 @@ namespace OpenUtau.Core.Render {
                 } catch (Exception e) {
                     if (!newCancellation.IsCancellationRequested) {
                         Log.Error(e, "Failed to pre-render.");
+                        DocManager.Inst.ExecuteCmd(new ToastNotification("Pianoroll", "Failed to pre-render.", "errors.failed.prerender", e));
                     }
                 }
             });

--- a/OpenUtau/Controls/ToastControl.cs
+++ b/OpenUtau/Controls/ToastControl.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
+using OpenUtau.App.Views;
+using OpenUtau.Core;
+
+namespace OpenUtau.App.Controls {
+    public static class ToastControl {
+        public static Notification GetNotification(ToastNotification notif, Window window) {
+            var message = ThemeManager.GetString(notif.translationKey);
+            var type = NotificationType.Warning;
+            switch (notif.type) {
+                case "Information":
+                    type = NotificationType.Information;
+                    break;
+                case "Error":
+                    type = NotificationType.Error;
+                    break;
+                case "Success":
+                    type = NotificationType.Success;
+                    break;
+                default:
+                    break;
+            };
+            Action? action = null;
+            if (notif.e != null) {
+                message += $"\n{ThemeManager.GetString("errors.toast.details")}";
+                action = new Action(() => {
+                    MessageBox.ShowError(window, notif.e);
+                });
+            }
+            return new Notification(
+                        notif.title,
+                        message,
+                        type,
+                        notif.durationSec == 0 ? TimeSpan.Zero : TimeSpan.FromSeconds(notif.durationSec),
+                        action);
+        }
+    }
+}

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -186,6 +186,7 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="errors.failed.openfile">Failed to open</system:String>
   <system:String x:Key="errors.failed.openlocation">Failed to open location</system:String>
   <system:String x:Key="errors.failed.opennewerproject">Project file is newer than software! Upgrade OpenUtau!</system:String>
+  <system:String x:Key="errors.failed.prerender">Failed to render in the background.</system:String>
   <system:String x:Key="errors.failed.render">Failed to render.</system:String>
   <system:String x:Key="errors.failed.runeditingmacro">Failed to run editing macro</system:String>
   <system:String x:Key="errors.failed.save">Failed to save</system:String>
@@ -199,6 +200,7 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>
   <system:String x:Key="errors.resampler.failed.message">Resampler failed to create output file(s). Resampler errors like this are often caused by oto.ini configuration issues. Consider generating a singer error report to check for such issues.</system:String>
+  <system:String x:Key="errors.toast.details">(Click here for details)</system:String>
 
   <system:String x:Key="exesetup.installing">Installing "{0}"...</system:String>
   <system:String x:Key="exesetup.linux">To use exe resamplers or wavtools on Linux:

--- a/OpenUtau/Styles/Styles.axaml
+++ b/OpenUtau/Styles/Styles.axaml
@@ -492,4 +492,43 @@
     <Setter Property="Margin" Value="0"/>
   </Style>
 
+  <Style Selector="NotificationCard">
+    <Setter Property="CornerRadius" Value="6"/>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <LayoutTransformControl Name="PART_LayoutTransformControl">
+          <Border Name="PART_ShadowBorder"
+                  CornerRadius="{TemplateBinding CornerRadius}"
+                  BoxShadow="0 4 12 0 #20000000"
+                  Margin="0,0,0,8">
+            <Border Name="PART_Border"
+                    Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                    CornerRadius="{TemplateBinding CornerRadius}"
+                    ClipToBounds="True">
+              <Grid ColumnDefinitions="6, *, Auto">
+                <Rectangle Name="PART_AccentBar"
+                           Grid.Column="0"
+                           Width="6"
+                           VerticalAlignment="Stretch"
+                           Fill="{DynamicResource AccentBrush1}"/>
+                <ContentPresenter Name="PART_ContentPresenter"
+                                  Grid.Column="1"
+                                  Content="{TemplateBinding Content}"
+                                  Margin="14,10"
+                                  VerticalAlignment="Center">
+                  <ContentPresenter.ContentTemplate>
+                    <DataTemplate>
+                      <TextBlock Text="{Binding Message}"
+                                 TextWrapping="Wrap"
+                                 VerticalAlignment="Center"/>
+                    </DataTemplate>
+                  </ContentPresenter.ContentTemplate>
+                </ContentPresenter>
+              </Grid>
+            </Border>
+          </Border>
+        </LayoutTransformControl>
+      </ControlTemplate>
+    </Setter>
+  </Style>
 </Styles>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -8,13 +8,12 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Notifications;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Platform.Storage;
-using Avalonia.VisualTree;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using OpenUtau.App.Controls;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Classic;
@@ -40,6 +39,7 @@ namespace OpenUtau.App.Views {
 
         private PianoRollDetachedWindow? pianoRollWindow;
         private PianoRoll? pianoRoll;
+        private WindowNotificationManager notificationManager;
 
         private PartEditState? partEditState;
 
@@ -92,6 +92,11 @@ namespace OpenUtau.App.Views {
                 DispatcherPriority.Normal,
                 (sender, args) => DocManager.Inst.AutoSave());
             autosaveTimer.Start();
+
+            notificationManager = new WindowNotificationManager(this) {
+                Position = NotificationPosition.BottomCenter,
+                MaxItems = 3
+            };
 
             PartRenameCommand = ReactiveCommand.Create<UPart>(part => RenamePart(part));
             PartGotoFileCommand = ReactiveCommand.Create<UPart>(part => GotoFile(part));
@@ -1939,6 +1944,11 @@ namespace OpenUtau.App.Views {
                         MessageBox.ShowError(this, notif.e, notif.message, true);
                         break;
                 }
+            } else if (cmd is ToastNotification toast) {
+                if (toast.windowType == "Pianoroll" && pianoRollWindow != null) {
+                    if (pianoRollWindow.Toast(toast)) return;
+                }
+                notificationManager.Show(ToastControl.GetNotification(toast, this));
             } else if (cmd is VoiceColorRemappingNotification voicecolorNotif) {
                 if (voicecolorNotif.TrackNo < 0 || DocManager.Inst.Project.tracks.Count <= voicecolorNotif.TrackNo) {
                     // Verify whether remapping is required when the voice color lineup changes

--- a/OpenUtau/Views/PianoRollDetachedWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollDetachedWindow.axaml.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
 using Avalonia.Input;
 using OpenUtau.App.Controls;
+using OpenUtau.Core;
 using OpenUtau.Core.Util;
 
 namespace OpenUtau.App.Views {
     public partial class PianoRollDetachedWindow : Window {
         private readonly PianoRoll pianoRoll;
         private bool forceClose;
+        private WindowNotificationManager notificationManager;
 
         public PianoRollDetachedWindow(PianoRoll pianoRoll) {
             InitializeComponent();
@@ -21,6 +24,11 @@ namespace OpenUtau.App.Views {
                 Position = new PixelPoint(x, y);
             }
             WindowState = (WindowState)Preferences.Default.PianorollWindowSize.State;
+
+            notificationManager = new WindowNotificationManager(this) {
+                Position = NotificationPosition.BottomCenter,
+                MaxItems = 3
+            };
         }
 
         public void WindowGotFocus(object sender, FocusChangedEventArgs e) {
@@ -46,5 +54,12 @@ namespace OpenUtau.App.Views {
             Close();
         }
 
+        public bool Toast(ToastNotification toast) {
+            if (this.IsActive) {
+                notificationManager.Show(ToastControl.GetNotification(toast, this));
+                return true;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Overview
- Toasts display information in the UI without interrupting the user’s current actions.
- If the information is accompanied by an exception, clicking the toast will also display a standard error dialog.
- Toasts are displayed for 4 seconds by default and can be dismissed by clicking them. Up to three toasts can be displayed simultaneously.
<img width="748" height="414" alt="image" src="https://github.com/user-attachments/assets/1430c829-b9bb-4023-b5c8-e0f10614a26e" />

## Advantages
- Notifications can be displayed without pausing playback.
- This provides additional options for notifying users about minor errors or information that do not warrant a full dialog in future development.

## Note
- To make it as compact as possible, I've omitted the title from the toast card by style.
- Previously, when background pre-rendering failed, the error was not displayed until playback began; this PR introduces a toast notification instead. However, if this proves to be annoying, I will consider removing it from this PR (as the main focus of this PR is the toast mechanism itself).