### PR TITLE
Add in-process HiFiUTAU renderer and Custom Server renderer

### DIFF
--- a/OpenUtau.Core/CustomRender/CustomF0Utils.cs
+++ b/OpenUtau.Core/CustomRender/CustomF0Utils.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+
+namespace OpenUtau.Core.CustomRender {
+    public static class CustomF0Utils {
+        private const int Interval = 5;
+
+        /// <summary>
+        /// OpenUtau 标准曲线的默认值映射表（abbr -> defaultValue）。
+        /// 对应 Format.Ustx.AddDefaultExpressions 中的配置。
+        /// 注意：dyn（动态曲线）和 shfc（音高偏移曲线）不作为公共字段暴露，
+        /// 需要通过 RenderPhrase.curves 或修改 RenderPhrase 访问。
+        /// </summary>
+        private static readonly Dictionary<string, double> CurveDefaults = new Dictionary<string, double> {
+            { "genc", 0 },
+            { "brec", 0 },
+            { "tenc", 0 },
+            { "voic", 100 },
+            { "lowc", 0 },
+            { "hcmp", 0 },
+            { "brel", 0 },
+            { "breh", 0 },
+        };
+
+        /// <summary>
+        /// 自动发现 RenderPhrase 中所有曲线并采样到目标帧率。
+        /// 返回字典（abbr -> double[]），包含所有标准曲线和自定义曲线。
+        /// </summary>
+        public static Dictionary<string, double[]> SampleAllCurves(
+            RenderPhrase phrase,
+            double frameMs,
+            int totalFrames) {
+            var result = new Dictionary<string, double[]>();
+
+            // 定义标准曲线映射：abbr -> (hasData函数, 采样函数)
+            // 注意：dyn（动态曲线）和 shfc（音高偏移曲线）存储在 RenderPhrase 内部，
+            // 不作为公共字段暴露，因此无法在此采样。
+            // 若需要它们，可在 RenderPhrase 中添加公共访问器。
+            var standardCurves = new (string abbr, Func<bool> hasData, Func<int, double> sample)[] {
+                ("pitd",
+                    () => phrase.pitches != null && phrase.pitches.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        int idx = ClampIndex(ticks, phrase.pitches!.Length);
+                        return MusicMath.ToneToFreq(phrase.pitches[idx] * 0.01);
+                    }),
+                ("genc",
+                    () => phrase.gender != null && phrase.gender.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.gender![ClampIndex(ticks, phrase.gender.Length)];
+                    }),
+                ("brec",
+                    () => phrase.breathiness != null && phrase.breathiness.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.breathiness![ClampIndex(ticks, phrase.breathiness.Length)];
+                    }),
+                ("tenc",
+                    () => phrase.tension != null && phrase.tension.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.tension![ClampIndex(ticks, phrase.tension.Length)];
+                    }),
+                ("voic",
+                    () => phrase.voicing != null && phrase.voicing.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.voicing![ClampIndex(ticks, phrase.voicing.Length)];
+                    }),
+                ("lowc",
+                    () => phrase.lowcut != null && phrase.lowcut.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.lowcut![ClampIndex(ticks, phrase.lowcut.Length)];
+                    }),
+                ("warm",
+                    () => phrase.warmth != null && phrase.warmth.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.warmth![ClampIndex(ticks, phrase.warmth.Length)];
+                    }),
+                ("hcmp",
+                    () => phrase.hcmp != null && phrase.hcmp.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.hcmp![ClampIndex(ticks, phrase.hcmp.Length)];
+                    }),
+                ("brel",
+                    () => phrase.breathLow != null && phrase.breathLow.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.breathLow![ClampIndex(ticks, phrase.breathLow.Length)];
+                    }),
+                ("breh",
+                    () => phrase.breathHigh != null && phrase.breathHigh.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.breathHigh![ClampIndex(ticks, phrase.breathHigh.Length)];
+                    }),
+            };
+
+            // 采样所有标准曲线
+            foreach (var (abbr, hasData, sample) in standardCurves) {
+                if (!hasData()) {
+                    continue;
+                }
+                var curve = new double[totalFrames];
+                for (int i = 0; i < totalFrames; i++) {
+                    curve[i] = sample(i);
+                }
+                result[abbr] = curve;
+            }
+
+            // 采样自定义曲线（由 renderer 自定义的额外曲线）
+            if (phrase.curves != null) {
+                foreach (var tuple in phrase.curves) {
+                    if (tuple.Item2 == null || tuple.Item2.Length == 0) {
+                        continue;
+                    }
+                    var curve = new double[totalFrames];
+                    for (int i = 0; i < totalFrames; i++) {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        curve[i] = tuple.Item2[ClampIndex(ticks, tuple.Item2.Length)];
+                    }
+                    result[tuple.Item1] = curve;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 为指定音素范围内的曲线采样。
+        /// 返回字典（abbr -> double[]），长度为该音素内的帧数。
+        /// </summary>
+        public static Dictionary<string, double[]> SampleCurvesForPhoneme(
+            RenderPhrase phrase,
+            RenderPhone phone,
+            int phoneIndex,
+            double frameMs,
+            int totalFrames) {
+            var result = new Dictionary<string, double[]>();
+
+            // 计算该音素在全局帧范围内的起始和结束帧索引
+            // phrase 的第 0 帧对应绝对时间 (phrase.positionMs - phrase.leadingMs)
+            double phraseBaseMs = phrase.positionMs - phrase.leadingMs;
+            double phoneStartMs = phone.positionMs - phone.leadingMs;
+            double phoneEndMs = phone.endMs;
+
+            int startFrame = Math.Max(0, (int)((phoneStartMs - phraseBaseMs) / frameMs));
+            int endFrame = Math.Min(totalFrames, (int)Math.Ceiling((phoneEndMs - phraseBaseMs) / frameMs));
+            int phoneFrames = Math.Max(1, endFrame - startFrame);
+
+            // 标准曲线（逐音素只保留 genc，其他曲线在全局层面传递）
+            var standardCurves = new (string abbr, Func<bool> hasData, Func<int, double> sample)[] {
+                ("genc",
+                    () => phrase.gender != null && phrase.gender.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.gender![ClampIndex(ticks, phrase.gender.Length)];
+                    }),
+            };
+
+            foreach (var (abbr, hasData, sample) in standardCurves) {
+                if (!hasData()) {
+                    continue;
+                }
+                var curve = new double[phoneFrames];
+                for (int i = 0; i < phoneFrames; i++) {
+                    int globalIdx = startFrame + i;
+                    if (globalIdx < totalFrames) {
+                        curve[i] = sample(globalIdx);
+                    } else {
+                        curve[i] = sample(totalFrames - 1);
+                    }
+                }
+                result[abbr] = curve;
+            }
+
+            // 自定义曲线
+            if (phrase.curves != null) {
+                foreach (var tuple in phrase.curves) {
+                    if (tuple.Item2 == null || tuple.Item2.Length == 0) {
+                        continue;
+                    }
+                    var curve = new double[phoneFrames];
+                    for (int i = 0; i < phoneFrames; i++) {
+                        int globalIdx = startFrame + i;
+                        if (globalIdx < totalFrames) {
+                            int ticks = GetTicks(phrase, globalIdx, frameMs);
+                            curve[i] = tuple.Item2[ClampIndex(ticks, tuple.Item2.Length)];
+                        } else {
+                            int ticks = GetTicks(phrase, totalFrames - 1, frameMs);
+                            curve[i] = tuple.Item2[ClampIndex(ticks, tuple.Item2.Length)];
+                        }
+                    }
+                    result[tuple.Item1] = curve;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 判断单条曲线是否全部为默认值。
+        /// pitd（音高偏差）永远视为有用，始终返回 false。
+        /// 未知曲线回退默认值 0。
+        /// </summary>
+        public static bool IsCurveDefault(string abbr, double[] curve) {
+            if (abbr == "pitd") {
+                return false; // pitd 永远有用
+            }
+            if (curve == null || curve.Length == 0) {
+                return true;
+            }
+            double defaultValue = CurveDefaults.TryGetValue(abbr, out var def) ? def : 0.0;
+            foreach (var v in curve) {
+                if (v != defaultValue) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// 检查所有曲线是否均为默认值。
+        /// </summary>
+        public static bool AllCurvesDefault(Dictionary<string, double[]> curves) {
+            if (curves == null || curves.Count == 0) {
+                return true;
+            }
+            foreach (var kvp in curves) {
+                if (!IsCurveDefault(kvp.Key, kvp.Value)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetTicks(RenderPhrase phrase, int frameIndex, double frameMs) {
+            double posMs = GetFramePositionMs(phrase, frameIndex, frameMs);
+            double positionOffset = phrase.position - phrase.leading;
+            return (int)(phrase.timeAxis.MsPosToTickPos(posMs) - positionOffset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ClampIndex(int ticks, int length) {
+            return Math.Max(0, Math.Min(length - 1, ticks / Interval));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static double GetFramePositionMs(RenderPhrase phrase, int frameIndex, double frameMs) {
+            double positionMs = phrase.positionMs + frameIndex * frameMs;
+
+            if (phrase.phones.Length == 0) {
+                return positionMs;
+            }
+
+            var firstPhone = phrase.phones[0];
+            if (firstPhone.envelope.Length >= 2) {
+                double preutter = -firstPhone.envelope[0].X;
+                if (preutter > 0) {
+                    return positionMs - preutter;
+                }
+            }
+
+            return positionMs;
+        }
+    }
+}

--- a/OpenUtau.Core/CustomRender/CustomPhraseJson.cs
+++ b/OpenUtau.Core/CustomRender/CustomPhraseJson.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+
+namespace OpenUtau.Core.CustomRender {
+    /// <summary>
+    /// 将 RenderPhrase 转换为 Custom Server HTTP 端点所需的音素 JSON。
+    /// 独立于 HiFiUTAU，可单独维护。
+    /// </summary>
+    public static class CustomPhraseJson {
+        /// <summary>
+        /// 构建完整音素 JSON（hop_size/frame_ms/phoneme_list/Dynamic_parameter）。
+        /// </summary>
+        public static JObject Build(RenderPhrase phrase) {
+            const int hopSize = 256;
+            const int sampleRate = 44100;
+            double frameMs = 1000.0 * hopSize / sampleRate;
+
+            int totalFrames = (int)Math.Ceiling((phrase.durationMs + phrase.leadingMs) / frameMs);
+
+            var curves = CustomF0Utils.SampleAllCurves(phrase, frameMs, totalFrames);
+
+            var dynamicParam = new Dictionary<string, object?>();
+
+            var knownCurves = new[] { "pitd", "genc", "brec", "tenc", "voic", "lowc", "brel", "breh" };
+            foreach (var abbr in knownCurves) {
+                if (curves.TryGetValue(abbr, out var data)) {
+                    dynamicParam[abbr] = data;
+                }
+            }
+
+            foreach (var kvp in curves) {
+                if (Array.IndexOf(knownCurves, kvp.Key) >= 0) {
+                    continue;
+                }
+                dynamicParam[kvp.Key] = kvp.Value;
+            }
+
+            var perPhonemeCurves = new Dictionary<string, Dictionary<string, double[]>>();
+            for (int i = 0; i < phrase.phones.Length; i++) {
+                var phone = phrase.phones[i];
+                var curvesForPhone = CustomF0Utils.SampleCurvesForPhoneme(
+                    phrase, phone, i, frameMs, totalFrames);
+                perPhonemeCurves[(i + 1).ToString()] = curvesForPhone;
+            }
+
+            var phonemeList = BuildPhonemeList(phrase, perPhonemeCurves);
+
+            var jsonData = new {
+                hop_size = hopSize,
+                sample_rate = sampleRate,
+                frame_ms = frameMs,
+                out_wav = Path.Join(PathManager.Inst.CachePath, $"custom-{phrase.hash:x16}.wav"),
+                wav_dur = phrase.durationMs,
+                phoneme_list = phonemeList,
+                Dynamic_parameter = dynamicParam,
+            };
+
+            return JObject.FromObject(jsonData);
+        }
+
+        private static Dictionary<string, object> BuildPhonemeList(
+            RenderPhrase phrase,
+            Dictionary<string, Dictionary<string, double[]>> perPhonemeCurves) {
+            var phonemeList = new Dictionary<string, object>();
+
+            for (int i = 0; i < phrase.phones.Length; i++) {
+                var phone = phrase.phones[i];
+                var envelope = phone.envelope;
+                var key = (i + 1).ToString();
+
+                var noteFlags = new Dictionary<string, object> {
+                    { "vel", phone.velocity * 100.0 },
+                    { "vol", phone.volume * 100.0 },
+                    { "mod", phone.modulation * 100.0 },
+                    { "shft", phone.toneShift },
+                    { "phtp", phone.phonemeType },
+                    { "strt", phone.stretchMode },
+                    { "splc", phone.spliceMode },
+                    { "stms", phone.stretchMs },
+                    { "S", phone.stretchMs }
+                };
+                foreach (var flag in phone.flags) {
+                    noteFlags[flag.Item1] = flag.Item2 ?? 0;
+                }
+
+                float p3X, p3Y, p4X, p4Y;
+
+                if (i < phrase.phones.Length - 1) {
+                    var nextPhone = phrase.phones[i + 1];
+                    var nextEnvelope = nextPhone.envelope;
+
+                    var nextPreutter = -nextEnvelope[0].X;
+                    var nextOverlap = nextEnvelope[1].X - nextEnvelope[0].X;
+                    var tailIntrude = Math.Max(nextPreutter, nextPreutter - nextOverlap);
+                    var tailOverlap = Math.Max(nextOverlap, 0);
+
+                    p3X = (float)(phone.durationMs - tailIntrude);
+                    p4X = (float)(p3X + tailOverlap);
+                    p3Y = envelope[3].Y;
+                    p4Y = envelope[4].Y;
+                } else {
+                    p3X = envelope[3].X;
+                    p3Y = envelope[3].Y;
+                    p4X = envelope[4].X;
+                    p4Y = envelope[4].Y;
+                }
+
+                Dictionary<string, double[]>? phonemeDynamicParams = null;
+                if (perPhonemeCurves.TryGetValue(key, out var curves) && curves != null && curves.Count > 0) {
+                    phonemeDynamicParams = curves;
+                }
+
+                var phonemeData = new {
+                    phoneme_name = phone.phoneme,
+                    note_pitch = MusicMath.GetToneName(phone.tone),
+                    dur = envelope[4].X,
+                    Note_flags = noteFlags,
+                    phoneme_oto = new {
+                        audio_file_path = phone.oto?.File ?? "",
+                        Offset = phone.oto?.Offset ?? 0.0,
+                        Consonant = phone.oto?.Consonant ?? 0.0,
+                        Cutoff = phone.oto?.Cutoff ?? 0.0,
+                        Preutter = phone.oto?.Preutter ?? 0.0,
+                        Overlap = phone.oto?.Overlap ?? 0.0,
+                    },
+                    envelope = new {
+                        p0 = new { x = envelope[0].X, y = envelope[0].Y },
+                        p1 = new { x = envelope[1].X, y = envelope[1].Y },
+                        p2 = new { x = envelope[2].X, y = envelope[2].Y },
+                        p3 = new { x = p3X, y = p3Y },
+                        p4 = new { x = p4X, y = p4Y }
+                    },
+                    Dynamic_parameter = phonemeDynamicParams
+                };
+                phonemeList[key] = phonemeData;
+            }
+
+            return phonemeList;
+        }
+    }
+}

--- a/OpenUtau.Core/CustomRender/CustomServerRenderer.cs
+++ b/OpenUtau.Core/CustomRender/CustomServerRenderer.cs
@@ -1,0 +1,294 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NAudio.Wave;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OpenUtau.Core.Format;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+using Serilog;
+
+namespace OpenUtau.Core.CustomRender {
+    public class CustomServerRenderer : IRenderer {
+        public string ServerUrl { get; set; } = "http://localhost:8000";
+        public string Endpoint { get; set; } = "/synthesize";
+        // HttpClient 设计为单例复用，避免为每个请求创建新的连接池
+        private static readonly HttpClient sharedHttpClient = new HttpClient {
+            Timeout = TimeSpan.FromMinutes(5)
+        };
+
+        // 基于 hash 的互斥锁，防止相同内容并发进入临界区
+        private static readonly ConcurrentDictionary<ulong, SemaphoreSlim> _hashLocks =
+            new ConcurrentDictionary<ulong, SemaphoreSlim>();
+
+        // 追踪进行中的 HTTP 任务（key: phrase.hash, value: 正在执行的 HTTP 任务）
+        // 即使播放被取消，HTTP 任务也会继续完成并将结果写入缓存文件，
+        // 后续相同 hash 的渲染请求可以直接等待已有任务，避免重复提交。
+        private static readonly ConcurrentDictionary<ulong, Task<byte[]?>> _inFlightHttpTasks =
+            new ConcurrentDictionary<ulong, Task<byte[]?>>();
+
+        public CustomServerRenderer() {
+        }
+
+        public CustomServerRenderer(string fullUrl) {
+            ParseFullUrl(fullUrl);
+        }
+
+        private void ParseFullUrl(string fullUrl) {
+            if (string.IsNullOrEmpty(fullUrl)) {
+                return;
+            }
+            try {
+                var uri = new Uri(fullUrl);
+                ServerUrl = uri.Scheme + "://" + uri.Authority;
+                Endpoint = uri.PathAndQuery;
+            } catch {
+                ServerUrl = fullUrl;
+                Endpoint = "/synthesize";
+            }
+        }
+
+        private string GetFullUrl() {
+            return ServerUrl.TrimEnd('/') + '/' + Endpoint.TrimStart('/');
+        }
+
+        public USingerType SingerType => USingerType.Classic;
+
+        public bool SupportsRenderPitch => false;
+
+        public bool SupportsExpression(UExpressionDescriptor descriptor) {
+            return true;
+        }
+
+        public RenderResult Layout(RenderPhrase phrase) {
+            return new RenderResult() {
+                leadingMs = phrase.leadingMs,
+                positionMs = phrase.positionMs,
+                estimatedLengthMs = phrase.durationMs + phrase.leadingMs,
+            };
+        }
+
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo,
+            CancellationTokenSource cancellation, bool isPreRender = false, RenderPhraseEvents? renderEvents = null) {
+            return RenderImpl(phrase, progress, trackNo, cancellation, isPreRender, null);
+        }
+
+        internal async Task<RenderResult> RenderImpl(RenderPhrase phrase, Progress progress, int trackNo,
+            CancellationTokenSource cancellation, bool isPreRender, string? preGeneratedJson) {
+            try {
+                string progressInfo =
+                    $"Track {trackNo + 1}: CustomServerRenderer \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
+
+                var wavPath = Path.Join(PathManager.Inst.CachePath, $"custom-{phrase.hash:x16}.wav");
+                phrase.AddCacheFile(wavPath);
+
+                var result = Layout(phrase);
+
+                // ===== 第一层检查：快速路径（无锁） =====
+                if (File.Exists(wavPath)) {
+                    using (var waveStream = new WaveFileReader(wavPath)) {
+                        result.samples = Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
+                    }
+
+                    if (result.samples != null) {
+                        Renderers.ApplyDynamics(phrase, result);
+                    }
+
+                    progress.Complete(phrase.phones.Length, progressInfo);
+                    return result;
+                }
+
+                // ===== 基于 hash 的互斥锁，防止并发重复提交相同内容 =====
+                var hashLock = GetOrCreateHashLock(phrase.hash);
+                await hashLock.WaitAsync(cancellation.Token).ConfigureAwait(false);
+                try {
+                    // ===== 第二层检查：获取锁后再次检查缓存（double-check） =====
+                    if (File.Exists(wavPath)) {
+                        using (var waveStream = new WaveFileReader(wavPath)) {
+                            result.samples = Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
+                        }
+                        if (result.samples != null) {
+                            Renderers.ApplyDynamics(phrase, result);
+                        }
+                        progress.Complete(phrase.phones.Length, progressInfo);
+                        return result;
+                    }
+
+                    // ===== 获取或创建进行中的 HTTP 任务 =====
+                    // 如果已有相同 hash 的 HTTP 任务在执行（例如上一次播放取消后仍在跑），
+                    // 直接等待该任务，不重复提交。
+                    Task<byte[]?> httpTask;
+                    if (_inFlightHttpTasks.TryGetValue(phrase.hash, out var existingTask)) {
+                        httpTask = existingTask;
+                        Log.Debug($"CustomServerRenderer reusing in-flight HTTP task for hash {phrase.hash:x16}");
+                    } else {
+                        var jsonData = preGeneratedJson ?? ConvertPhraseToJson(phrase);
+                        // 可选：将 JSON 写入文件
+                        SaveJsonToFile(jsonData, phrase);
+                        // 使用 CancellationToken.None：即使播放被取消，HTTP 请求也继续完成，
+                        // 确保后端结果被缓存，避免下次播放重复提交。
+                        httpTask = SendToServerAsync(jsonData, CancellationToken.None);
+                        if (!_inFlightHttpTasks.TryAdd(phrase.hash, httpTask)) {
+                            // 竞态：另一个线程刚好也添加了，使用已有的
+                            httpTask = _inFlightHttpTasks[phrase.hash];
+                        }
+                    }
+
+                    // 等待 HTTP 任务完成（可能被用户取消播放，但 HTTP 任务不受影响继续跑）
+                    byte[]? wavData;
+                    try {
+                        wavData = await httpTask.ConfigureAwait(false);
+                    } finally {
+                        _inFlightHttpTasks.TryRemove(phrase.hash, out _);
+                    }
+
+                    if (wavData != null && wavData.Length > 0) {
+                        File.WriteAllBytes(wavPath, wavData);
+                        using (var waveStream = new WaveFileReader(wavPath)) {
+                            result.samples = Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
+                        }
+                        if (result.samples != null) {
+                            Renderers.ApplyDynamics(phrase, result);
+                        }
+                    } else {
+                        Log.Warning("Server returned empty response, using fallback rendering");
+                        result = FallbackRender(phrase);
+                    }
+                } finally {
+                    hashLock.Release();
+                }
+
+                progress.Complete(phrase.phones.Length, progressInfo);
+                return result;
+            } catch (Exception e) {
+                Log.Error(e, "CustomServerRenderer failed");
+                return FallbackRender(phrase);
+            }
+        }
+
+        public static async Task<RenderResult[]> RenderBatch(
+            RenderPhrase[] phrases,
+            Progress progress,
+            int trackNo,
+            CancellationTokenSource cancellation,
+            string serverUrl = "http://localhost:8000/synthesize",
+            int maxConcurrency = 2) {
+            if (phrases == null || phrases.Length == 0) {
+                return Array.Empty<RenderResult>();
+            }
+
+            var results = new RenderResult[phrases.Length];
+            var semaphore = new SemaphoreSlim(maxConcurrency);
+            var tasks = new List<Task<(int index, RenderResult result)>>(phrases.Length);
+
+            for (int i = 0; i < phrases.Length; i++) {
+                int index = i;
+                var phrase = phrases[index];
+                
+                var task = Task.Run(async () => {
+                    await semaphore.WaitAsync(cancellation.Token).ConfigureAwait(false);
+                    try {
+                        var renderer = new CustomServerRenderer(serverUrl);
+                        var result = await renderer.Render(phrase, progress, trackNo, cancellation, false).ConfigureAwait(false);
+                        return (index, result);
+                    } finally {
+                        semaphore.Release();
+                    }
+                }, cancellation.Token);
+                tasks.Add(task);
+            }
+
+            var completedTasks = await Task.WhenAll(tasks).ConfigureAwait(false);
+            foreach (var (index, result) in completedTasks) {
+                results[index] = result;
+            }
+
+            return results;
+        }
+
+        internal static JObject ConvertPhraseToJObject(RenderPhrase phrase) {
+            return CustomPhraseJson.Build(phrase);
+        }
+
+        internal static string ConvertPhraseToJson(RenderPhrase phrase) {
+            return JsonConvert.SerializeObject(ConvertPhraseToJObject(phrase), Formatting.None);
+        }
+
+        private async Task<byte[]?> SendToServerAsync(string jsonData, CancellationToken cancellation) {
+            try {
+                var content = new StringContent(jsonData, Encoding.UTF8, "application/json");
+
+                var fullUrl = GetFullUrl();
+                var response = await sharedHttpClient.PostAsync(fullUrl, content, cancellation).ConfigureAwait(false);
+
+                if (response.IsSuccessStatusCode) {
+                    Log.Debug($"CustomServerRenderer received {response.Content.Headers.ContentLength ?? 0} bytes");
+                    return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                } else {
+                    var errorContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Log.Error($"Server returned error: {response.StatusCode}, Content: {errorContent}");
+                    return null;
+                }
+            } catch (Exception e) {
+                Log.Error(e, "Failed to send data to server");
+                return null;
+            }
+        }
+
+        private RenderResult FallbackRender(RenderPhrase phrase) {
+            var result = Layout(phrase);
+            // new float[] 自动初始化为0，无需手动填充
+            double totalDurationMs = phrase.durationMs + phrase.leadingMs;
+            result.samples = new float[(int)(totalDurationMs * 44.1)];
+            return result;
+        }
+
+        /// <summary>
+        /// 将 JSON 写入缓存目录，便于调试。
+        /// </summary>
+        private static void SaveJsonToFile(string json, RenderPhrase phrase) {
+            try {
+                var jsonPath = Path.Join(PathManager.Inst.CachePath, $"custom-{phrase.hash:x16}.json");
+                File.WriteAllText(jsonPath, json, Encoding.UTF8);
+                Log.Debug($"CustomServerRenderer saved JSON to {jsonPath}");
+            } catch (Exception e) {
+                Log.Error(e, "Failed to save CustomServer JSON file");
+            }
+        }
+
+        /// <summary>
+        /// 获取或创建基于 phrase.hash 的互斥锁，防止相同内容的并发重复提交。
+        /// </summary>
+        private static SemaphoreSlim GetOrCreateHashLock(ulong hash) {
+            var newLock = new SemaphoreSlim(1, 1);
+            var hashLock = _hashLocks.GetOrAdd(hash, newLock);
+            // 如果 GetOrAdd 返回了已存在的值，释放我们创建的 newLock
+            if (hashLock != newLock) {
+                newLock.Dispose();
+            }
+            return hashLock;
+        }
+
+        public RenderPitchResult LoadRenderedPitch(RenderPhrase phrase) {
+            return null!;
+        }
+
+        public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
+            return new List<RenderRealCurveResult>(0);
+        }
+
+        public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {
+            return new UExpressionDescriptor[] { };
+        }
+
+        public override string ToString() => Renderers.CUSTOM_SERVER;
+    }
+}

--- a/OpenUtau.Core/Format/USTx.cs
+++ b/OpenUtau.Core/Format/USTx.cs
@@ -36,6 +36,17 @@ namespace OpenUtau.Core.Format {
         public const string VOIC = "voic";
         public const string CLRY = "clry";
         public const string XSY = "xsy";
+        public const string GWL = "gwl";
+        public const string LOWC = "lowc";
+        public const string BREL = "brel";
+        public const string BREH = "breh";
+        public const string PHTP = "phtp";
+        public const string PHTD = "phtd";
+        public const string STRT = "strt";
+        public const string SPLC = "splc";
+        public const string STMS = "stms";
+        public const string WARM = "warm";
+        public const string HCMP = "hcmp";
 
         public static readonly string[] required = { DYN, PITD, CLR, ENG, VEL, VOL, ATK, DEC };
 
@@ -64,6 +75,16 @@ namespace OpenUtau.Core.Format {
             project.RegisterExpression(new UExpressionDescriptor("voicing (curve)", VOIC, 0, 100, 100) { type = UExpressionType.Curve });
             project.RegisterExpression(new UExpressionDescriptor("voice color y", CLRY, false, new string[0]));
             project.RegisterExpression(new UExpressionDescriptor("cross synthesis (curve)", XSY, 0, 100, 0) { type = UExpressionType.Curve });
+            project.RegisterExpression(new UExpressionDescriptor("growl (curve)", GWL, 0, 100, 0) { type = UExpressionType.Curve });
+            project.RegisterExpression(new UExpressionDescriptor("lowcut (curve)", LOWC, 0, 100, 0) { type = UExpressionType.Curve });
+            project.RegisterExpression(new UExpressionDescriptor("brightness (curve)", WARM, -100, 100, 0) { type = UExpressionType.Curve });
+            project.RegisterExpression(new UExpressionDescriptor("hard compression (curve)", HCMP, 0, 100, 0) { type = UExpressionType.Curve });
+            project.RegisterExpression(new UExpressionDescriptor("breath low (curve)", BREL, -100, 100, 0) { type = UExpressionType.Curve });
+            project.RegisterExpression(new UExpressionDescriptor("breath high (curve)", BREH, -100, 100, 0) { type = UExpressionType.Curve });
+            project.RegisterExpression(new UExpressionDescriptor("volume normalize", PHTP, false, new string[] { "none", "backward", "forward" }));
+            project.RegisterExpression(new UExpressionDescriptor("stretch mode", STRT, false, new string[] { "normal", "loop" }));
+            project.RegisterExpression(new UExpressionDescriptor("splice mode", SPLC, false, new string[] { "model", "mel" }));
+            project.RegisterExpression(new UExpressionDescriptor("stretch ms", STMS, -50, 50, 0));
 
             string message = string.Empty;
             if (ValidateExpression(project, "g", GEN)) {

--- a/OpenUtau.Core/HiFiUtau/Engine/Dsp/Interpolation.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Dsp/Interpolation.cs
@@ -1,0 +1,94 @@
+using System;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Dsp {
+    /// <summary>
+    /// numpy/scipy 语义的一维插值工具：
+    ///   - NpInterp: np.interp（端点截断）
+    ///   - LinearExtrap: interp1d(kind='linear', fill_value='extrapolate')
+    ///   - InterpToLen / ResampleArray: 引擎内帧级参数重采样
+    /// </summary>
+    public static class Interpolation {
+        /// <summary>np.interp：xp 升序，x 越界取端点值。</summary>
+        public static double[] NpInterp(double[] xs, double[] xp, double[] fp) {
+            var result = new double[xs.Length];
+            int j = 0;
+            for (int i = 0; i < xs.Length; i++) {
+                double x = xs[i];
+                if (x <= xp[0]) { result[i] = fp[0]; continue; }
+                if (x >= xp[xp.Length - 1]) { result[i] = fp[fp.Length - 1]; continue; }
+                while (j < xp.Length - 2 && xp[j + 1] < x) j++;
+                while (j > 0 && xp[j] > x) j--;
+                double t = (x - xp[j]) / (xp[j + 1] - xp[j]);
+                result[i] = fp[j] + t * (fp[j + 1] - fp[j]);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// interp1d(np.arange(n), y, kind='linear', fill_value='extrapolate') 在点 xs 处求值。
+        /// xs 越界时线性外推。
+        /// </summary>
+        public static double LinearExtrap(double[] y, double x) {
+            int n = y.Length;
+            if (n == 1) return y[0];
+            if (x <= 0) {
+                double t = x;
+                return y[0] + t * (y[1] - y[0]);
+            }
+            if (x >= n - 1) {
+                double t = x - (n - 1);
+                return y[n - 1] + t * (y[n - 1] - y[n - 2]);
+            }
+            int i = (int)Math.Floor(x);
+            double frac = x - i;
+            return y[i] + frac * (y[i + 1] - y[i]);
+        }
+
+        /// <summary>Python round()（银行家舍入）。</summary>
+        public static double PyRound(double x) => Math.Round(x, MidpointRounding.ToEven);
+
+        /// <summary>np.linspace(0, n-1, m)。</summary>
+        public static double[] LinSpace01(int n, int m) {
+            var xs = new double[m];
+            if (m == 1) { if (n > 0) xs[0] = 0; return xs; }
+            if (n == 1) {
+                for (int i = 0; i < m; i++) xs[i] = 0;
+                return xs;
+            }
+            double step = (n - 1) / (double)(m - 1);
+            for (int i = 0; i < m; i++) xs[i] = step * i;
+            return xs;
+        }
+
+        /// <summary>
+        /// synthesis_pipeline.utils.interp_to_len：将一维数组线性插值到目标长度。
+        /// 空/退化为常数的分支与 Python 版一致。
+        /// </summary>
+        public static double[] InterpToLen(double[] arr, int targetLen) {
+            int n = arr.Length;
+            if (n == targetLen) return (double[])arr.Clone();
+            if (n == 0 || targetLen <= 0) {
+                var constant = new double[Math.Max(targetLen, 0)];
+                double fill = n > 0 ? arr[0] : 0;
+                for (int i = 0; i < constant.Length; i++) constant[i] = fill;
+                return constant;
+            }
+            var xs = LinSpace01(n, targetLen);
+            var result = new double[targetLen];
+            for (int i = 0; i < targetLen; i++) {
+                result[i] = LinearExtrap(arr, xs[i]);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// synthesis_pipeline.utils.resample_array：按 hop 比例重采样帧级参数。
+        /// target_len = max(1, round(len * origHop/targetHop))（银行家舍入）。
+        /// </summary>
+        public static double[] ResampleArray(double[] arr, int origHop, int targetHop) {
+            double ratio = (double)origHop / targetHop;
+            int targetLen = Math.Max(1, (int)PyRound(arr.Length * ratio));
+            return InterpToLen(arr, targetLen);
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Dsp/MelFilterbank.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Dsp/MelFilterbank.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Dsp {
+    /// <summary>
+    /// librosa.filters.mel(htk=false, norm='slaney') 的精确移植。
+    /// Slaney mel 刻度（200/3 线性段 + log(6.4)/27 对数段）与面积归一化，
+    /// 基矩阵先以 double 计算再 round 到 float32——与 librosa 的 float32 基矩阵
+    /// 在 float64 域做 dot 的实际行为完全一致。
+    /// </summary>
+    public static class MelFilterbank {
+        public const double SlaneyLinearStep = 200.0 / 3.0;   // Hz per mel below 1kHz
+        public static readonly double SlaneyLogStep = Math.Log(6.4) / 27.0;
+        public const double SlaneyBreakHz = 1000.0;
+
+        public static double HzToMel(double hz) {
+            return hz < SlaneyBreakHz
+                ? hz / SlaneyLinearStep
+                : 15.0 + Math.Log(hz / SlaneyBreakHz) / SlaneyLogStep;
+        }
+
+        public static double MelToHz(double mel) {
+            return mel < 15.0
+                ? mel * SlaneyLinearStep
+                : SlaneyBreakHz * Math.Exp(SlaneyLogStep * (mel - 15.0));
+        }
+
+        public static double[] MelFrequencies(int n, double fmin, double fmax) {
+            double melMin = HzToMel(fmin), melMax = HzToMel(fmax);
+            var result = new double[n];
+            for (int i = 0; i < n; i++) {
+                double mel = n == 1 ? melMin : melMin + (melMax - melMin) * i / (n - 1);
+                result[i] = MelToHz(mel);
+            }
+            return result;
+        }
+
+        /// <summary>返回平铺 (nMels, bins) 的基矩阵，bins = nFft/2+1，band-major。</summary>
+        public static double[] Basis(int sr, int nFft, int nMels, double fmin, double fmax) {
+            int bins = nFft / 2 + 1;
+            var fftFreqs = new double[bins];
+            for (int i = 0; i < bins; i++) {
+                fftFreqs[i] = sr / 2.0 * i / (bins - 1);
+            }
+            var melF = MelFrequencies(nMels + 2, fmin, fmax);
+            var w = new double[nMels * bins];
+            for (int m = 0; m < nMels; m++) {
+                double left = melF[m], center = melF[m + 1], right = melF[m + 2];
+                double enorm = 2.0 / (melF[m + 2] - melF[m]);
+                for (int b = 0; b < bins; b++) {
+                    double lower = center > left ? (fftFreqs[b] - left) / (center - left) : 0.0;
+                    double upper = right > center ? (right - fftFreqs[b]) / (right - center) : 0.0;
+                    double v = Math.Max(0.0, Math.Min(lower, upper));
+                    w[m * bins + b] = v * enorm;
+                }
+            }
+            // round 到 float32 再回 double，与 librosa float32 基矩阵一致
+            for (int i = 0; i < w.Length; i++) {
+                w[i] = (double)(float)w[i];
+            }
+            return w;
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Dsp/Simd.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Dsp/Simd.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Numerics;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Dsp {
+    /// <summary>
+    /// mel 投影用的 SIMD 点积（替代 librosa/numpy 的 BLAS matmul）。
+    /// 输入两侧均须为连续 float32 段；与标量 double 版差异 ~1e-5，远小于金标准阈值。
+    /// </summary>
+    internal static class Simd {
+        public static float Dot(float[] a, int aOff, float[] b, int bOff, int n) {
+            int vecEnd = n - n % Vector<float>.Count;
+            var acc = Vector<float>.Zero;
+            for (int i = 0; i < vecEnd; i += Vector<float>.Count) {
+                acc += new Vector<float>(a, aOff + i) * new Vector<float>(b, bOff + i);
+            }
+            float sum = 0;
+            for (int i = 0; i < Vector<float>.Count; i++) {
+                sum += acc[i];
+            }
+            for (int i = vecEnd; i < n; i++) {
+                sum += a[aOff + i] * b[bOff + i];
+            }
+            return sum;
+        }
+
+        public static float[] ToFloat32(double[] x) {
+            var r = new float[x.Length];
+            for (int i = 0; i < x.Length; i++) r[i] = (float)x[i];
+            return r;
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Dsp/Stft.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Dsp/Stft.cs
@@ -1,0 +1,164 @@
+using System;
+using NWaves.Transforms;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Dsp {
+    /// <summary>
+    /// librosa 语义的 STFT/ISTFT 薄胶水层。
+    ///
+    /// 与 librosa.stft/istft(center=True, window='hann') 逐点对齐：
+    ///   - 周期性 hann 窗（scipy get_window fftbins=True）
+    ///   - librosa 0.11 起默认 pad_mode='constant'（零填充）；0.10 为 'reflect'。
+    ///     引擎管线中的 mel/tension/lowcut/warmth 均未显式传 pad_mode，
+    ///     随 librosa 版本变化——本实现提供两种模式，默认 constant（与当前
+    ///     已发布 PyInstaller 引擎一致）；hnsep/wav2mel 在 Python 中显式用 reflect。
+    ///   - ISTFT 为 window² 重叠相加归一化，center 裁剪后输出 hop*(T-1) 个采样
+    /// FFT 内核使用 NWaves.Fft（float32 内部精度，与 numpy float64 相差 ~1e-6 量级，
+    /// 经金标准测试验证对合成结果无可闻影响）。
+    /// 频谱布局与 numpy 一致：bin-major 平铺，索引 [bin * frames + t]，bins = nFft/2+1。
+    /// </summary>
+    public static class Stft {
+        public enum PadMode { Constant, Reflect }
+
+        /// <summary>周期性 hann（scipy get_window('hann', N, fftbins=True)）。</summary>
+        public static float[] HannPeriodic(int n) {
+            var w = new float[n];
+            for (int i = 0; i < n; i++) {
+                w[i] = (float)(0.5 * (1.0 - Math.Cos(2.0 * Math.PI * i / n)));
+            }
+            return w;
+        }
+
+        /// <summary>对称 hann（np.hanning / NWaves Window.Hann）。</summary>
+        public static float[] HannSymmetric(int n) {
+            return NWaves.Windows.Window.Hann(n);
+        }
+
+        /// <summary>np.pad(x, (left, right), mode='reflect')。</summary>
+        public static float[] PadReflect(float[] x, int left, int right) {
+            int n = x.Length;
+            var outArr = new float[left + n + right];
+            for (int i = 0; i < left; i++) {
+                int src = ReflectIndex(i, left, n);
+                outArr[i] = x[src];
+            }
+            Array.Copy(x, 0, outArr, left, n);
+            for (int i = 0; i < right; i++) {
+                int src = ReflectIndex(left + n + i, left, n);
+                outArr[left + n + i] = x[src];
+            }
+            return outArr;
+        }
+
+        private static int ReflectIndex(int idx, int left, int n) {
+            // np.pad reflect: 关于边界元素镜像，不含边界本身
+            int span = 2 * (n - 1);
+            int v = (idx - left) % span;
+            if (v < 0) v += span;
+            return v < n - 1 ? v : span - v;
+        }
+
+        /// <summary>np.pad(x, (left, right), mode='constant')（零填充）。</summary>
+        public static float[] PadConstant(float[] x, int left, int right) {
+            var outArr = new float[left + x.Length + right];
+            Array.Copy(x, 0, outArr, left, x.Length);
+            return outArr;
+        }
+
+        public static (float[] re, float[] im, int bins, int frames) Forward(
+                float[] x, int nFft, int hop, float[] win, bool center,
+                PadMode padMode = PadMode.Constant) {
+            int bins = nFft / 2 + 1;
+            float[] buf = x;
+            if (center) {
+                int pad = nFft / 2;
+                buf = padMode == PadMode.Reflect ? PadReflect(x, pad, pad) : PadConstant(x, pad, pad);
+            }
+            int frames = buf.Length < nFft ? 1 : (buf.Length - nFft) / hop + 1;
+            // librosa: 短于 n_fft 的信号也至少产生 1 帧（窗口右侧补零语义），
+            // 这里与 librosa 保持一致：不足部分补零凑满一帧。
+            var re = new float[bins * frames];
+            var im = new float[bins * frames];
+
+            int winLen = win.Length;
+            var winPadded = new float[nFft];
+            int padLeft = (nFft - winLen) / 2;
+            Array.Copy(win, 0, winPadded, padLeft, winLen);
+
+            var fft = new Fft(nFft);
+            var frameRe = new float[nFft];
+            var frameIm = new float[nFft];
+            var outRe = new float[nFft];
+            var outIm = new float[nFft];
+
+            for (int t = 0; t < frames; t++) {
+                int off = t * hop;
+                for (int i = 0; i < nFft; i++) {
+                    int j = off + i;
+                    frameRe[i] = j < buf.Length ? buf[j] * winPadded[i] : 0f;
+                    frameIm[i] = 0f;
+                }
+                fft.Direct(frameRe, frameIm, outRe, outIm);
+                for (int b = 0; b < bins; b++) {
+                    re[b * frames + t] = outRe[b];
+                    im[b * frames + t] = outIm[b];
+                }
+            }
+            return (re, im, bins, frames);
+        }
+
+        /// <summary>
+        /// librosa.istft(center=True, length=None) 等价：输出长度 = hop*(frames-1)。
+        /// re/im 为 bin-major 平铺的半谱。
+        /// </summary>
+        public static float[] Inverse(float[] re, float[] im, int nFft, int hop, float[] win, bool center) {
+            int bins = nFft / 2 + 1;
+            int frames = re.Length / bins;
+
+            int winLen = win.Length;
+            var winPadded = new float[nFft];
+            int padLeft = (nFft - winLen) / 2;
+            Array.Copy(win, 0, winPadded, padLeft, winLen);
+
+            int nOut = nFft + hop * (frames - 1);
+            var acc = new double[nOut];
+            var norm = new double[nOut];
+
+            var fft = new Fft(nFft);
+            var fullRe = new float[nFft];
+            var fullIm = new float[nFft];
+            var timeRe = new float[nFft];
+            var timeIm = new float[nFft];
+
+            for (int t = 0; t < frames; t++) {
+                // 半谱 → 共轭对称全谱（librosa: concatenate([S, conj(S[-2:0:-1])])）
+                for (int b = 0; b < bins; b++) {
+                    fullRe[b] = re[b * frames + t];
+                    fullIm[b] = im[b * frames + t];
+                }
+                for (int b = 1; b < nFft - bins + 1; b++) {
+                    fullRe[nFft - b] = fullRe[b];
+                    fullIm[nFft - b] = -fullIm[b];
+                }
+                fft.InverseNorm(fullRe, fullIm, timeRe, timeIm);
+                int off = t * hop;
+                for (int i = 0; i < nFft; i++) {
+                    acc[off + i] += (double)timeRe[i] * winPadded[i];
+                    norm[off + i] += (double)winPadded[i] * winPadded[i];
+                }
+            }
+
+            var y = new double[nOut];
+            for (int i = 0; i < nOut; i++) {
+                y[i] = norm[i] > 1e-12 ? acc[i] / norm[i] : 0.0;
+            }
+
+            int start = center ? nFft / 2 : 0;
+            int len = center ? nOut - nFft : nOut;
+            var result = new float[len];
+            for (int i = 0; i < len; i++) {
+                result[i] = (float)y[start + i];
+            }
+            return result;
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/AudioReader.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/AudioReader.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// synthesis_pipeline.utils.read_audio 的移植：读取音频为 float32 单声道，
+    /// 必要时重采样到目标采样率。
+    ///
+    /// 归一化语义与 soundfile.read(dtype='float32') 对齐：PCM16/24/32 整型除以满量程，
+    /// 浮点 WAV 原样。NAudio 的 ToSampleProvider 行为与此一致。
+    /// 多声道取均值（soundfile x.mean(axis=1) 语义）。
+    /// </summary>
+    public static class AudioReader {
+        // 同一音源文件会被多个音素重复读取，缓存解码结果
+        private static readonly ConcurrentDictionary<string, float[]> Cache = new();
+
+        public static void ClearCache() => Cache.Clear();
+
+        public static float[] Read(string path, int targetSr = 44100) {
+            if (!File.Exists(path)) {
+                throw new FileNotFoundException($"音频文件不存在: {path}");
+            }
+            var audio = Cache.GetOrAdd(path, p => Decode(p));
+            if (audio.Length == 0) return Array.Empty<float>();
+            // 采样率不匹配时重采样（librosa.resample 语义；用 WdlResampler 实现）
+            if (targetSr > 0 &&audioSampleRates.TryGetValue(path, out int fs) && fs != targetSr) {
+                return Resample(audio, fs, targetSr);
+            }
+            return audio;
+        }
+
+        private static readonly ConcurrentDictionary<string, int> audioSampleRates = new();
+
+        private static float[] Decode(string path) {
+            using var reader = new WaveFileReader(path);
+            audioSampleRates[path] = reader.WaveFormat.SampleRate;
+            var provider = reader.ToSampleProvider().ToMono(1, 0);
+            var list = new List<float>(4096);
+            var buffer = new float[8192];
+            int read;
+            while ((read = provider.Read(buffer, 0, buffer.Length)) > 0) {
+                for (int i = 0; i < read; i++) list.Add(buffer[i]);
+            }
+            return list.ToArray();
+        }
+
+        public static float[] Resample(float[] input, int fromSr, int toSr) {
+            if (fromSr == toSr || input.Length == 0) return input;
+            // WDL 重采样（NAudio 内置，纯托管），质量优于线性插值
+            var src = new FloatArraySampleProvider(input, fromSr);
+            var resampler = new WdlResamplingSampleProvider(src, toSr);
+            int outLen = (int)Math.Floor(input.Length * (double)toSr / fromSr);
+            var outArr = new float[Math.Max(outLen, 1)];
+            int total = 0, read;
+            var buffer = new float[8192];
+            while (total < outArr.Length && (read = resampler.Read(buffer, 0, Math.Min(buffer.Length, outArr.Length - total))) > 0) {
+                Array.Copy(buffer, 0, outArr, total, read);
+                total += read;
+            }
+            if (total < outArr.Length) Array.Resize(ref outArr, total);
+            return outArr;
+        }
+
+        private sealed class FloatArraySampleProvider : ISampleProvider {
+            private readonly float[] data;
+            public WaveFormat WaveFormat { get; }
+            public FloatArraySampleProvider(float[] data, int sr) {
+                this.data = data;
+                WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sr, 1);
+            }
+            public int Read(float[] buffer, int offset, int count) {
+                int n = Math.Min(count, data.Length);
+                Array.Copy(data, 0, buffer, offset, n);
+                return n;
+            }
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/Fragment.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/Fragment.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Threading.Tasks;
+using OpenUtau.Core.HiFiUtau.Engine.Dsp;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// synthesis_pipeline/fragment.py 的移植（SPLC=0 feat 管线）。
+    /// hop=64 提取 mel，含上下文填充、时间拉伸、strt 循环、左侧裁剪/补空白、P 归一化、
+    /// phtp 音量匹配、genc/shft 频域偏移。数值语义逐行对照 Python 版。
+    /// </summary>
+    public static class Fragment {
+        public const int SampleRate = 44100;
+        public const int HopLength = 64;
+        public const int Nfft = 2048;
+        public const int WinLength = 2048;
+        public const int NMels = 128;
+        public const double MsPerFrame = (double)HopLength / SampleRate * 1000;
+
+        private static readonly double[] melBasis = MelFilterbank.Basis(SampleRate, Nfft, NMels, 40, 16000);
+        private static readonly float[] melBasisF32 = Simd.ToFloat32(melBasis);
+        private static readonly float[] hannPeriodic = Stft.HannPeriodic(WinLength);
+
+        /// <summary>fragment.py _audio_to_mel：log(clip(melspectrogram(power=1), 1e-5))。</summary>
+        public static (double[] mel, int frames) AudioToMel(float[] audio) {
+            if (audio.Length == 0) return (Array.Empty<double>(), 0);
+            var (re, im, bins, frames) = Stft.Forward(audio, Nfft, HopLength, hannPeriodic, center: true);
+            // 幅度谱转置为帧主序 [t*bins+b]，mel 投影两侧均连续（SIMD 点积 + 按频带并行）
+            var magT = new float[bins * frames];
+            for (int t = 0; t < frames; t++) {
+                int src = t, dst = t * bins;
+                for (int b = 0; b < bins; b++) {
+                    float r = re[src], m = im[src];
+                    magT[dst + b] = MathF.Sqrt(r * r + m * m);
+                    src += frames;
+                }
+            }
+            var mel = new double[NMels * frames];
+            Parallel.For(0, NMels, m => {
+                int bOff = m * bins, oOff = m * frames;
+                for (int t = 0; t < frames; t++) {
+                    float sum = Simd.Dot(melBasisF32, bOff, magT, t * bins, bins);
+                    mel[oOff + t] = Math.Log(Math.Max(sum, 1e-5));
+                }
+            });
+            return (mel, frames);
+        }
+
+        /// <summary>fragment.py cut_audio（串行版）。</summary>
+        public static void CutAudio(PhraseData phrase) {
+            foreach (var info in phrase.Phones) {
+                ProcessSinglePhoneme(phrase, info);
+            }
+        }
+
+        /// <summary>fragment.py _process_single_phoneme。</summary>
+        public static void ProcessSinglePhoneme(PhraseData phrase, PhoneInfo info) {
+            string wavPath = info.Oto.AudioFilePath;
+            var audio = AudioReader.Read(wavPath, SampleRate);
+            double totalLenMs = audio.Length / (double)SampleRate * 1000;
+
+            double offsetMs = info.Oto.Offset;
+            double consonantMs = info.Oto.Consonant;
+            double cutoffMs = info.Oto.Cutoff;
+            double preutterMs = info.Oto.Preutter;
+
+            double p0X = info.P0.X;
+            double vel = info.RequireFlag("vel");
+            double stretchFactor = Math.Pow(2.0, (100 - vel) / 100.0);
+            double stretchedPreutter = preutterMs * stretchFactor;
+            double preToLeftMs = stretchedPreutter + p0X;
+
+            int startSample = (int)Math.Round(offsetMs / 1000 * SampleRate);
+            int consonantSample = (int)Math.Round((offsetMs + consonantMs) / 1000 * SampleRate);
+            int endSample = cutoffMs > 0
+                ? (int)Math.Round((totalLenMs - cutoffMs) / 1000 * SampleRate)
+                : (int)Math.Round((offsetMs + Math.Abs(cutoffMs)) / 1000 * SampleRate);
+
+            startSample = Math.Max(0, Math.Min(startSample, audio.Length));
+            consonantSample = Math.Max(startSample, Math.Min(consonantSample, audio.Length));
+            endSample = Math.Max(consonantSample, Math.Min(endSample, audio.Length));
+
+            int segLen = endSample - startSample;
+            var audioSeg = new float[segLen];
+            Array.Copy(audio, startSample, audioSeg, 0, segLen);
+            int conSamples = consonantSample - startSample;
+
+            // mel 提取：读更长音频留 STFT 上下文，再裁掉边缘帧
+            int padContext = (int)Interpolation.PyRound((double)(Nfft / 2) / HopLength) * HopLength;
+            int padFront = Math.Min(padContext, startSample);
+            int padTail = Math.Min(padContext, audio.Length - endSample);
+
+            int extLen = segLen + padFront + padTail;
+            var audioExt = new float[extLen];
+            Array.Copy(audio, startSample - padFront, audioExt, 0, extLen);
+            var (melExt, melExtFrames) = AudioToMel(audioExt);
+
+            int cropFront = padFront / HopLength;
+            int cropTail = padTail / HopLength;
+            int nFrames;
+            double[] melFull;
+            if (cropTail > 0) {
+                nFrames = melExtFrames - cropFront - cropTail;
+                melFull = SliceFrames(melExt, NMels, melExtFrames, cropFront, nFrames);
+            } else {
+                nFrames = melExtFrames - cropFront;
+                melFull = SliceFrames(melExt, NMels, melExtFrames, cropFront, nFrames);
+            }
+
+            if (nFrames <= 0) {
+                info.Mel = Array.Empty<double>();
+                info.MelFrames = 0;
+                info.AudioSeg = audioSeg;
+                info.ConsonantFrames = 0;
+                info.StretchFactor = 1.0;
+                return;
+            }
+
+            // 辅音/元音帧数
+            int conFramesOrig = conSamples > 0
+                ? Math.Max(1, (int)((conSamples - HopLength) / (double)HopLength) + 1)
+                : 0;
+            conFramesOrig = Math.Min(conFramesOrig, nFrames);
+            int vowFramesOrig = nFrames - conFramesOrig;
+
+            double p4X = info.P4.X;
+            double totalBudgetMs = p4X + stretchedPreutter;
+            int totalBudgetFrames = Math.Max((int)(totalBudgetMs / MsPerFrame), 1);
+
+            int targetConFrames = Math.Max(1, (int)(conFramesOrig * stretchFactor));
+            targetConFrames = Math.Min(targetConFrames, totalBudgetFrames - 1);
+            int targetVowFrames = totalBudgetFrames - targetConFrames;
+            int totalFrames = totalBudgetFrames;
+
+            // strt=1: reflect padding 正反循环
+            int strt = (int)info.Flag("strt", 0);
+            if (strt == 1 && vowFramesOrig > 1 && targetVowFrames > vowFramesOrig * 1.5) {
+                int conFrames = conFramesOrig;
+                int padExtra = Math.Min(4, vowFramesOrig / 2);
+                int padFrames = targetVowFrames - vowFramesOrig + padExtra;
+                // np.pad(mel_vowel, ((0,0),(0,pad)), 'reflect') 逐行反射
+                var extended = new double[NMels * (conFrames + vowFramesOrig + padFrames)];
+                for (int m = 0; m < NMels; m++) {
+                    int srcOff = m * nFrames;
+                    int dstOff = m * (conFrames + vowFramesOrig + padFrames);
+                    Array.Copy(melFull, srcOff, extended, dstOff, conFrames + vowFramesOrig);
+                    for (int k = 0; k < padFrames; k++) {
+                        int srcIdx = ReflectFrameIndex(vowFramesOrig - 2 - k, vowFramesOrig);
+                        extended[dstOff + conFrames + vowFramesOrig + k] = melFull[srcOff + conFrames + srcIdx];
+                    }
+                }
+                melFull = extended;
+                nFrames = conFrames + vowFramesOrig + padFrames;
+                vowFramesOrig = nFrames - conFrames;
+            }
+
+            // 帧索引映射
+            var mapped = new double[totalFrames];
+            for (int t = 0; t < totalFrames; t++) {
+                if (t < targetConFrames) {
+                    mapped[t] = (double)t / stretchFactor;
+                } else if (vowFramesOrig > 0) {
+                    mapped[t] = conFramesOrig + (double)(t - targetConFrames) * (vowFramesOrig / (double)Math.Max(1, targetVowFrames));
+                } else {
+                    mapped[t] = conFramesOrig;
+                }
+                mapped[t] = Math.Clamp(mapped[t], 0, nFrames - 1);
+            }
+
+            // 线性拉伸插值（逐 band 沿帧轴）
+            double[] melOut = InterpRows(melFull, NMels, nFrames, mapped);
+            int outFrames = totalFrames;
+
+            // strt=1: 抹平循环段能量起伏
+            if (strt == 1 && targetVowFrames > 1 && outFrames >= targetConFrames + 2) {
+                int vowStart = targetConFrames;
+                int vowLen = outFrames - vowStart;
+                var frameEnergy = new double[vowLen];
+                for (int t = 0; t < vowLen; t++) {
+                    double sum = 0;
+                    for (int m = 0; m < NMels; m++) {
+                        sum += Math.Exp(melOut[m * outFrames + vowStart + t]);
+                    }
+                    frameEnergy[t] = Math.Max(sum / NMels, 1e-12);
+                }
+                double e0 = frameEnergy[0], e1 = frameEnergy[vowLen - 1];
+                for (int t = 0; t < vowLen; t++) {
+                    double target = e0 + (e1 - e0) * t / (vowLen - 1);
+                    double logT = Math.Log(target);
+                    for (int m = 0; m < NMels; m++) {
+                        melOut[m * outFrames + vowStart + t] += -Math.Log(frameEnergy[t]) + logT;
+                    }
+                }
+            }
+
+            int leftPadFrames = 0;
+            // 左侧裁剪/补空白
+            if (preToLeftMs > 0) {
+                int leftCutFrames = (int)(preToLeftMs / MsPerFrame);
+                if (leftCutFrames < outFrames) {
+                    melOut = SliceFrames(melOut, NMels, outFrames, leftCutFrames, outFrames - leftCutFrames);
+                    outFrames -= leftCutFrames;
+                    targetConFrames = Math.Max(0, targetConFrames - leftCutFrames);
+                } else {
+                    melOut = Array.Empty<double>();
+                    outFrames = 0;
+                    targetConFrames = 0;
+                }
+            } else if (preToLeftMs < 0) {
+                leftPadFrames = (int)(-preToLeftMs / MsPerFrame);
+                var blank = new double[NMels * leftPadFrames];
+                for (int i = 0; i < blank.Length; i++) blank[i] = Math.Log(1e-5);
+                if (outFrames > 0) {
+                    int fadeIn = Math.Min(12, leftPadFrames);
+                    // 逐频带独立淡入，保留频谱形状
+                    for (int t = 0; t < fadeIn; t++) {
+                        double alpha = (t + 1) / (double)(fadeIn + 1);
+                        for (int m = 0; m < NMels; m++) {
+                            double first = Math.Exp(melOut[m * outFrames]);
+                            blank[m * leftPadFrames + leftPadFrames - fadeIn + t] =
+                                Math.Log(first * alpha + 1e-10);
+                        }
+                    }
+                }
+                var combined = new double[NMels * (leftPadFrames + outFrames)];
+                Array.Copy(blank, combined, NMels * leftPadFrames);
+                if (outFrames > 0) Array.Copy(melOut, 0, combined, NMels * leftPadFrames, NMels * outFrames);
+                melOut = combined;
+                outFrames += leftPadFrames;
+                targetConFrames += leftPadFrames;
+            }
+
+            // P 参数：音量均衡
+            double pFlag = info.Flag("P", 0);
+            if (pFlag > 0 && outFrames > 0) {
+                double targetRms = 0.5;
+                int audioStart = preToLeftMs < 0 ? leftPadFrames : 0;
+                if (outFrames > audioStart) {
+                    int audioFrames = outFrames - audioStart;
+                    double sumSq = 0;
+                    for (int m = 0; m < NMels; m++) {
+                        for (int t = 0; t < audioFrames; t++) {
+                            double v = Math.Exp(melOut[m * outFrames + audioStart + t]);
+                            sumSq += v * v;
+                        }
+                    }
+                    double curRms = Math.Sqrt(sumSq / (NMels * audioFrames));
+                    if (curRms > 1e-12) {
+                        double blend = pFlag / 100.0;
+                        double targetRmsActual = curRms * (1 - blend) + targetRms * blend;
+                        double scale = targetRmsActual / curRms;
+                        double logScale = Math.Log(scale);
+                        for (int i = 0; i < melOut.Length; i++) melOut[i] += logScale;
+                    }
+                }
+            }
+
+            info.Mel = melOut;
+            info.MelFrames = outFrames;
+            info.AudioSeg = audioSeg;
+            info.ConsonantFrames = targetConFrames;
+            info.StretchFactor = stretchFactor;
+        }
+
+        private static int ReflectFrameIndex(int idx, int n) {
+            if (n == 1) return 0;
+            int span = 2 * (n - 1);
+            int v = idx % span;
+            if (v < 0) v += span;
+            return v < n - 1 ? v : span - v;
+        }
+
+        /// <summary>band-major (rows, srcFrames) 的帧切片。</summary>
+        public static double[] SliceFrames(double[] src, int rows, int srcFrames, int startFrame, int count) {
+            if (count <= 0) return Array.Empty<double>();
+            var dst = new double[rows * count];
+            for (int r = 0; r < rows; r++) {
+                Array.Copy(src, r * srcFrames + startFrame, dst, r * count, count);
+            }
+            return dst;
+        }
+
+        /// <summary>interp1d(axis=1) 等价：逐 band 沿帧轴对 newX 求值（含外推）。</summary>
+        public static double[] InterpRows(double[] src, int rows, int srcFrames, double[] newX) {
+            var dst = new double[rows * newX.Length];
+            for (int r = 0; r < rows; r++) {
+                int off = r * srcFrames;
+                var row = new double[srcFrames];
+                Array.Copy(src, off, row, 0, srcFrames);
+                int dstOff = r * newX.Length;
+                for (int i = 0; i < newX.Length; i++) {
+                    dst[dstOff + i] = Interpolation.LinearExtrap(row, newX[i]);
+                }
+            }
+            return dst;
+        }
+
+        /// <summary>fragment.py adjust_volume_by_phtp。msPerFrame 由管线决定（hop64/hop512）。</summary>
+        public static void AdjustVolumeByPhtp(PhraseData phrase, double msPerFrame) {
+            var phones = phrase.Phones;
+            for (int i = 0; i < phones.Count; i++) {
+                var info = phones[i];
+                double phtp = info.Flag("phtp", 0);
+                if (phtp == 0) continue;
+                var melCur = info.Mel;
+                if (melCur == null || info.MelFrames == 0) continue;
+
+                if (phtp == 1 && i < phones.Count - 1) {
+                    var nextInfo = phones[i + 1];
+                    var melNext = nextInfo.Mel;
+                    if (melNext == null || nextInfo.MelFrames == 0) continue;
+                    double p0X = nextInfo.P0.X, p1X = nextInfo.P1.X;
+                    double overlapMs = p1X < 0 ? Math.Abs(p0X) - Math.Abs(p1X) : Math.Abs(p1X) + Math.Abs(p0X);
+                    if (overlapMs <= 0) continue;
+                    int overlapFrames = (int)Interpolation.PyRound(overlapMs / msPerFrame);
+                    int curTail = Math.Min(overlapFrames, info.MelFrames);
+                    int nextHead = Math.Min(overlapFrames, nextInfo.MelFrames);
+                    if (curTail <= 0 || nextHead <= 0) continue;
+                    double rmsCur = MelRms(melCur, info.MelFrames, info.MelFrames - curTail, curTail);
+                    double rmsNext = MelRms(melNext, nextInfo.MelFrames, 0, nextHead);
+                    if (rmsCur < 1e-12 || rmsNext < 1e-12) continue;
+                    double scale = rmsNext / rmsCur;
+                    double logScale = Math.Log(scale);
+                    for (int k = 0; k < melCur.Length; k++) melCur[k] += logScale;
+                } else if (phtp == 2 && i > 0) {
+                    var prevInfo = phones[i - 1];
+                    var melPrev = prevInfo.Mel;
+                    if (melPrev == null || prevInfo.MelFrames == 0) continue;
+                    double p0X = info.P0.X, p1X = info.P1.X;
+                    double overlapMs = p1X < 0 ? Math.Abs(p0X) - Math.Abs(p1X) : Math.Abs(p1X) + Math.Abs(p0X);
+                    if (overlapMs <= 0) continue;
+                    int overlapFrames = (int)Interpolation.PyRound(overlapMs / msPerFrame);
+                    int prevTail = Math.Min(overlapFrames, prevInfo.MelFrames);
+                    int curHead = Math.Min(overlapFrames, info.MelFrames);
+                    if (prevTail <= 0 || curHead <= 0) continue;
+                    double rmsPrev = MelRms(melPrev, prevInfo.MelFrames, prevInfo.MelFrames - prevTail, prevTail);
+                    double rmsCur = MelRms(melCur, info.MelFrames, 0, curHead);
+                    if (rmsPrev < 1e-12 || rmsCur < 1e-12) continue;
+                    double scale = rmsPrev / rmsCur;
+                    double logScale = Math.Log(scale);
+                    for (int k = 0; k < melCur.Length; k++) melCur[k] += logScale;
+                }
+            }
+        }
+
+        private static double MelRms(double[] mel, int frames, int startFrame, int count) {
+            double sumSq = 0;
+            int n = NMels * count;
+            for (int m = 0; m < NMels; m++) {
+                for (int t = 0; t < count; t++) {
+                    double v = Math.Exp(mel[m * frames + startFrame + t]);
+                    sumSq += v * v;
+                }
+            }
+            return Math.Sqrt(sumSq / n);
+        }
+
+        /// <summary>fragment.py apply_dynamic_gen_to_mels：音素级 genc/shft 频域偏移。</summary>
+        public static void ApplyDynamicGenToMels(PhraseData phrase) {
+            foreach (var info in phrase.Phones) {
+                var mel = info.Mel;
+                if (mel == null || info.MelFrames == 0) continue;
+                int nMels = NMels;
+                int T = info.MelFrames;
+
+                var phGenc = info.GetPhoneDP("genc");
+                bool useGenc = phGenc.Length > 0;
+
+                if (useGenc) {
+                    var gencInterp = Interpolation.InterpToLen(phGenc, T);
+                    var melOut = new double[mel.Length];
+                    var oldIdx = new double[nMels];
+                    for (int m = 0; m < nMels; m++) oldIdx[m] = m;
+                    for (int t = 0; t < T; t++) {
+                        double factor = Math.Pow(2.0, (gencInterp[t] / 100.0) / 12.0);
+                        if (Math.Abs(factor - 1.0) < 0.001) {
+                            for (int m = 0; m < nMels; m++) melOut[m * T + t] = mel[m * T + t];
+                        } else {
+                            for (int m = 0; m < nMels; m++) {
+                                double idx = Math.Clamp(oldIdx[m] / factor, 0, nMels - 1);
+                                melOut[m * T + t] = NpInterpColumn(mel, nMels, T, t, idx);
+                            }
+                        }
+                    }
+                    info.Mel = melOut;
+                    continue;
+                }
+
+                double shftVal = info.Flag("shft", 0);
+                if (shftVal == 0) continue;
+                shftVal = Math.Clamp(shftVal, -200, 200);
+                double factorConst = Math.Pow(2.0, (shftVal / 100.0) / 12.0);
+                if (Math.Abs(factorConst - 1.0) < 0.001) continue;
+                var warped = new double[mel.Length];
+                for (int t = 0; t < T; t++) {
+                    for (int m = 0; m < nMels; m++) {
+                        double idx = Math.Clamp(m / factorConst, 0, nMels - 1);
+                        warped[m * T + t] = NpInterpColumn(mel, nMels, T, t, idx);
+                    }
+                }
+                info.Mel = warped;
+            }
+        }
+
+        /// <summary>np.interp(idx, arange(nMels), mel[:, t])：跨频带插值（端点截断）。</summary>
+        private static double NpInterpColumn(double[] mel, int nMels, int T, int t, double idx) {
+            if (idx <= 0) return mel[0 * T + t];
+            if (idx >= nMels - 1) return mel[(nMels - 1) * T + t];
+            int i = (int)idx;
+            double frac = idx - i;
+            return mel[i * T + t] + frac * (mel[(i + 1) * T + t] - mel[i * T + t]);
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/FragmentMel.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/FragmentMel.cs
@@ -1,0 +1,172 @@
+using System;
+using OpenUtau.Core.HiFiUtau.Engine.Dsp;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// synthesis_pipeline/fragment_mel.py 的移植（SPLC=1 mel 管线）。
+    /// hop=512 直接工作，用 MelExtractor 做自定义帧定位 mel 提取。
+    /// </summary>
+    public static class FragmentMel {
+        public const int HopLength = 512;
+        public const double MsPerFrame = (double)HopLength / 44100 * 1000;
+
+        public static void CutAudio(PhraseData phrase, MelExtractor melExc) {
+            var phones = phrase.Phones;
+            int n = phones.Count;
+            var (starts, preutters, consonants, offsets, vfs, ends) = CalcPositionsAndRatiosMs(phones);
+            for (int i = 0; i < n; i++) {
+                ProcessSinglePhoneme(phrase, phones[i], melExc, starts[i], preutters[i], consonants[i], offsets[i], vfs[i], ends[i]);
+            }
+        }
+
+        /// <summary>fragment_mel.py calc_positions_and_ratios_ms（单位：ms / 采样）。</summary>
+        public static (double[] starts, double[] preutters, double[] consonants, double[] offsets,
+                       double[] vfs, double[] ends) CalcPositionsAndRatiosMs(System.Collections.Generic.List<PhoneInfo> phones) {
+            double spm = 44100 / 1000.0;
+            int n = phones.Count;
+            var startsMs = new double[n];
+            var starts = new double[n];
+            var preutters = new double[n];
+            var consonants = new double[n];
+            var offsets = new double[n];
+            var vfs = new double[n];
+            var ends = new double[n];
+
+            for (int i = 0; i < n; i++) {
+                var info = phones[i];
+                double p0 = info.P0.X, p1 = info.P1.X, p4 = info.P4.X;
+                double ov = p1 - p0;
+                double s;
+                if (i == 0) {
+                    s = 0.0;
+                } else {
+                    var prev = phones[i - 1];
+                    double prevLen = prev.P4.X - prev.P0.X;
+                    s = startsMs[i - 1] + prevLen - ov;
+                }
+                double preutter = s - p0;
+                double consonantMs = info.Oto.Consonant;
+                double preutterMs = info.Oto.Preutter;
+                double vel = info.RequireFlag("vel");
+                double vf = Math.Pow(2.0, (100.0 - vel) / 100.0);
+                double consonant = preutter + (consonantMs - preutterMs) * vf;
+                double offset = consonant - consonantMs * vf;
+                double endPos = s + (p4 - p0);
+
+                startsMs[i] = s;
+                starts[i] = s * spm;
+                preutters[i] = preutter * spm;
+                consonants[i] = consonant * spm;
+                offsets[i] = offset * spm;
+                vfs[i] = vf;
+                ends[i] = endPos * spm;
+            }
+            return (starts, preutters, consonants, offsets, vfs, ends);
+        }
+
+        /// <summary>fragment_mel.py _process_single_phoneme。</summary>
+        public static void ProcessSinglePhoneme(PhraseData phrase, PhoneInfo info, MelExtractor melExc,
+                double starts, double preutter, double consonant, double offset, double vf, double end) {
+            double spm = 44100 / 1000.0;
+            var audio = AudioReader.Read(info.Oto.AudioFilePath, 44100);
+            double totalLen = audio.Length;
+
+            double otoOffset = info.Oto.Offset * spm;
+            double otoConsonant = (info.Oto.Consonant + info.Oto.Offset) * spm;
+            double otoEnd = info.Oto.Cutoff > 0
+                ? totalLen - info.Oto.Cutoff * spm
+                : otoOffset + Math.Abs(info.Oto.Cutoff * spm);
+            double otoPreutter = (info.Oto.Preutter + info.Oto.Offset) * spm;
+
+            int strt = (int)info.Flag("strt", 0);
+            double sf = otoEnd - otoConsonant > 0 ? (end - consonant) / (otoEnd - otoConsonant) : 1.0;
+
+            int melOffset = (int)Math.Floor((offset - HopLength / 2.0) / HopLength);
+            int melConsonant = (int)Math.Floor((consonant - HopLength / 2.0) / HopLength);
+            int melEnd = (int)Math.Floor((end - HopLength / 2.0) / HopLength + 1);
+            int frame = melEnd - melOffset + 1;
+            int conFrames = melEnd - melConsonant + 1;
+
+            // Python 浮点取模: 结果恒为非负（C# % 对负数返回负值，需修正）
+            double pyMod = (offset - HopLength / 2.0) % HopLength;
+            if (pyMod < 0) pyMod += HopLength;
+            double hStart = offset - pyMod;
+            var hPoints = new double[frame];
+            for (int i = 0; i < frame; i++) hPoints[i] = i * (double)HopLength + hStart;
+
+            // fn(x): 辅音段速度拉伸，元音段按 strt 线性或三角循环
+            var otoHPoints = new double[frame];
+            for (int i = 0; i < frame; i++) {
+                double x = hPoints[i];
+                if (x < consonant) {
+                    otoHPoints[i] = otoConsonant - (consonant - x) / vf;
+                } else if (strt == 1) {
+                    double period = 2 * (otoEnd - otoConsonant);
+                    otoHPoints[i] = otoEnd - Math.Abs((x - consonant) % period - (otoEnd - otoConsonant));
+                } else {
+                    otoHPoints[i] = otoConsonant + (x - consonant) / sf;
+                }
+            }
+
+            var mel = melExc.Extract(audio, otoHPoints);
+            int T = frame;
+            // dynamic_range_compression
+            for (int i = 0; i < mel.Length; i++) mel[i] = Math.Log(Math.Max(mel[i], 1e-5));
+
+            // strt=1: 抹平循环段能量起伏（前 T-conFrames 帧为元音）
+            if (strt == 1 && conFrames < T) {
+                int vowelLen = T - conFrames;
+                var frameEnergy = new double[vowelLen];
+                for (int t = 0; t < vowelLen; t++) {
+                    double sum = 0;
+                    for (int m = 0; m < 128; m++) sum += Math.Exp(mel[m * T + t]);
+                    frameEnergy[t] = Math.Max(sum / 128, 1e-12);
+                }
+                double e0 = frameEnergy[0], e1 = frameEnergy[vowelLen - 1];
+                for (int t = 0; t < vowelLen; t++) {
+                    double target = vowelLen > 1 ? e0 + (e1 - e0) * t / (vowelLen - 1) : e0;
+                    double logT = Math.Log(target);
+                    for (int m = 0; m < 128; m++) {
+                        mel[m * T + t] += -Math.Log(frameEnergy[t]) + logT;
+                    }
+                }
+            }
+
+            // P 参数：音量均衡
+            double pFlag = info.Flag("P", 0);
+            if (pFlag > 0 && T > 0) {
+                double targetRms = 0.5;
+                double sumSq = 0;
+                for (int i = 0; i < mel.Length; i++) {
+                    double v = Math.Exp(mel[i]);
+                    sumSq += v * v;
+                }
+                double curRms = Math.Sqrt(sumSq / mel.Length);
+                if (curRms > 1e-12) {
+                    double blend = pFlag / 100.0;
+                    double targetRmsActual = curRms * (1 - blend) + targetRms * blend;
+                    double logScale = Math.Log(targetRmsActual / curRms);
+                    for (int i = 0; i < mel.Length; i++) mel[i] += logScale;
+                }
+            }
+
+            info.Mel = mel;
+            info.MelFrames = T;
+            info.AudioSeg = audio;
+            info.MelOffset = melOffset;
+            info.MelEnd = melEnd;
+            info.Preutter = preutter;
+            info.HPoints = hPoints;
+        }
+
+        /// <summary>fragment_mel.py adjust_volume_by_phtp（与 Fragment 相同逻辑，但 ms_per_frame=hop512）。</summary>
+        public static void AdjustVolumeByPhtp(PhraseData phrase) {
+            Fragment.AdjustVolumeByPhtp(phrase, MsPerFrame);
+        }
+
+        /// <summary>fragment_mel.py apply_dynamic_gen_to_mels（与 Fragment 相同逻辑）。</summary>
+        public static void ApplyDynamicGenToMels(PhraseData phrase) {
+            Fragment.ApplyDynamicGenToMels(phrase);
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/HiddenSplicer.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/HiddenSplicer.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// Mel 域拼接 + OpenUtau vocoder oudep（PC-NSF-HiFiGAN 整图 ONNX：mel+f0 → wav）。
+    /// 不使用 part1/part2 拆分图，也不加载 PyTorch ckpt。
+    /// </summary>
+    public sealed class HiddenSplicer : IDisposable {
+        public int ModelHop { get; }
+        public int SampleRate { get; }
+        public int NumMels { get; }
+        public int FrontPadFrames { get; } = 6;
+        public int TailPadFrames { get; } = 4;
+
+        readonly InferenceSession fused;
+
+        public HiddenSplicer(InferenceSession fusedSession, int hopSize, int sampleRate, int numMels) {
+            fused = fusedSession;
+            ModelHop = hopSize > 0 ? hopSize : 512;
+            SampleRate = sampleRate > 0 ? sampleRate : 44100;
+            NumMels = numMels > 0 ? numMels : 128;
+        }
+
+        /// <summary>mel 域能量叠加后，用 vocoder oudep 整图合成。</summary>
+        public float[] SpliceAndSynthesizeMel(List<PhoneInfo> phonemeList, double[] f0Np) {
+            int n = phonemeList.Count;
+            var last = phonemeList[^1];
+            int maxMelLen = last.MelEnd + 1;
+            int melDim = NumMels;
+            var totalMelEnergy = new double[melDim * maxMelLen];
+
+            for (int i = 0; i < n; i++) {
+                var phoneme = phonemeList[i];
+                double p0Y = phoneme.P0.Y, p4Y = phoneme.P4.Y;
+                if (i == 0) p0Y = 100;
+                if (i == n - 1) p4Y = 100;
+
+                double preutter = phoneme.Preutter;
+                double x0 = preutter + phoneme.P0.X * (SampleRate / 1000.0);
+                double x1 = preutter + phoneme.P1.X * (SampleRate / 1000.0);
+                double x2 = preutter + phoneme.P2.X * (SampleRate / 1000.0);
+                double x3 = preutter + phoneme.P3.X * (SampleRate / 1000.0);
+                double x4 = preutter + phoneme.P4.X * (SampleRate / 1000.0);
+
+                double y0 = p0Y / 100, y1 = phoneme.P1.Y / 100, y2 = phoneme.P2.Y / 100;
+                double y3 = phoneme.P3.Y / 100, y4 = p4Y / 100;
+
+                var xs = new[] { x0, x1, x2, x3, x4 };
+                var ys = new[] { y0, y1, y2, y3, y4 };
+                var gain = new double[phoneme.HPoints.Length];
+                for (int t = 0; t < gain.Length; t++) {
+                    gain[t] = NpInterpScalar(phoneme.HPoints[t], xs, ys);
+                }
+                var mel = phoneme.Mel;
+                int T = phoneme.MelFrames;
+                var energyMel = new double[mel.Length];
+                for (int k = 0; k < mel.Length; k++) energyMel[k] = Math.Exp(mel[k] * 2);
+                for (int m = 0; m < melDim; m++) {
+                    for (int t = 0; t < T; t++) energyMel[m * T + t] *= gain[t];
+                }
+
+                int start = phoneme.MelOffset;
+                int clipStart = Math.Max(start, 0);
+                int srcStart = clipStart - start;
+                for (int m = 0; m < melDim; m++) {
+                    for (int t = srcStart; t < T; t++) {
+                        int dst = start + t;
+                        if (dst < maxMelLen) totalMelEnergy[m * maxMelLen + dst] += energyMel[m * T + t];
+                    }
+                }
+            }
+
+            var totalMelLog = new double[melDim * maxMelLen];
+            for (int i = 0; i < totalMelLog.Length; i++) {
+                totalMelLog[i] = Math.Log(Math.Max(totalMelEnergy[i], 1e-12)) / 2;
+            }
+
+            var f0 = new double[maxMelLen];
+            Array.Copy(f0Np, f0, Math.Min(f0Np.Length, maxMelLen));
+            if (f0Np.Length < maxMelLen) {
+                double edge = f0Np.Length > 0 ? f0Np[^1] : 440;
+                for (int i = f0Np.Length; i < maxMelLen; i++) f0[i] = edge;
+            }
+            var f0Pad = new double[FrontPadFrames + maxMelLen + TailPadFrames];
+            for (int t = 0; t < FrontPadFrames; t++) f0Pad[t] = f0[0];
+            Array.Copy(f0, 0, f0Pad, FrontPadFrames, maxMelLen);
+            for (int t = 0; t < TailPadFrames; t++) f0Pad[FrontPadFrames + maxMelLen + t] = f0[^1];
+
+            var melPad = new double[melDim * (FrontPadFrames + maxMelLen + TailPadFrames)];
+            int paddedLen = FrontPadFrames + maxMelLen + TailPadFrames;
+            for (int m = 0; m < melDim; m++) {
+                for (int t = 0; t < FrontPadFrames; t++) melPad[m * paddedLen + t] = totalMelLog[m * maxMelLen];
+                Array.Copy(totalMelLog, m * maxMelLen, melPad, m * paddedLen + FrontPadFrames, maxMelLen);
+                for (int t = 0; t < TailPadFrames; t++) {
+                    melPad[m * paddedLen + FrontPadFrames + maxMelLen + t] = totalMelLog[m * maxMelLen + maxMelLen - 1];
+                }
+            }
+
+            return FusedSynthesize(melPad, paddedLen, f0Pad);
+        }
+
+        /// <summary>
+        /// vocoder oudep：mel [1, T, n_mels]，f0 [1, T]。
+        /// HiFi 内部 mel 是 band-major (n_mels, T)，转置后再喂。
+        /// </summary>
+        float[] FusedSynthesize(double[] bandMajorMel, int frames, double[] f0) {
+            var melNtc = new float[frames * NumMels];
+            for (int t = 0; t < frames; t++) {
+                for (int m = 0; m < NumMels; m++) {
+                    melNtc[t * NumMels + m] = (float)bandMajorMel[m * frames + t];
+                }
+            }
+            int f0Len = Math.Max(frames, f0.Length);
+            var f0In = new float[f0Len];
+            int n = Math.Min(f0.Length, f0Len);
+            for (int i = 0; i < n; i++) f0In[i] = (float)f0[i];
+            for (int i = n; i < f0Len; i++) f0In[i] = n > 0 ? f0In[n - 1] : 440f;
+
+            var melTensor = new DenseTensor<float>(melNtc, new[] { 1, frames, NumMels });
+            var f0Tensor = new DenseTensor<float>(f0In, new[] { 1, f0Len });
+            var inputs = new List<NamedOnnxValue> {
+                NamedOnnxValue.CreateFromTensor("mel", melTensor),
+                NamedOnnxValue.CreateFromTensor("f0", f0Tensor),
+            };
+            using var results = fused.Run(inputs);
+            var wav = results.First().AsTensor<float>();
+            int total = (int)wav.Length;
+            var samples = new float[total];
+            for (int i = 0; i < total; i++) samples[i] = wav.GetValue(i);
+            return samples;
+        }
+
+        static double NpInterpScalar(double x, double[] xp, double[] fp) {
+            if (x <= xp[0]) return fp[0];
+            if (x >= xp[^1]) return fp[^1];
+            int j = Array.BinarySearch(xp, x);
+            if (j >= 0) return fp[j];
+            j = ~j - 1;
+            double t = (x - xp[j]) / (xp[j + 1] - xp[j]);
+            return fp[j] + t * (fp[j + 1] - fp[j]);
+        }
+
+        public void Dispose() {
+            fused.Dispose();
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/Hnsep.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/Hnsep.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using OpenUtau.Core.HiFiUtau.Engine.Dsp;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// tools/hnsep_onnx.py 的移植：谐波/噪声分离。
+    /// pt2 新模型: 手写 STFT（对称 hann、reflect 填充）→ mask 推理 → 手写 ISTFT。
+    /// 旧模型: waveform → harmonic + noise。
+    /// </summary>
+    public sealed class Hnsep : IDisposable {
+        private const int Nfft = 2048;
+        private const int HopLength = 512;
+        private const int SegLength = 32 * HopLength;
+
+        private readonly InferenceSession session;
+        private readonly bool isPt2;
+
+        public Hnsep(string modelPath, Func<string, InferenceSession> sessionFactory) {
+            isPt2 = modelPath.Contains("pt2");
+            session = sessionFactory(modelPath);
+        }
+
+        public (double[] harmonic, double[] noise) Separate(float[] waveform) {
+            return isPt2 ? SeparatePt2(waveform) : SeparateLegacy(waveform);
+        }
+
+        private (double[] harmonic, double[] noise) SeparateLegacy(float[] waveform) {
+            var input = new float[waveform.Length];
+            Array.Copy(waveform, input, waveform.Length);
+            var tensor = new DenseTensor<float>(input, new[] { 1, waveform.Length });
+            var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor("waveform", tensor) };
+            using var results = session.Run(inputs);
+            var h = results.First(r => r.Name == "harmonic").AsTensor<float>();
+            var n = results.First(r => r.Name == "noise").AsTensor<float>();
+            var harmonic = new double[h.Length];
+            var noise = new double[n.Length];
+            for (int i = 0; i < h.Length; i++) harmonic[i] = h.GetValue(i);
+            for (int i = 0; i < n.Length; i++) noise[i] = n.GetValue(i);
+            return (harmonic, noise);
+        }
+
+        private (double[] harmonic, double[] noise) SeparatePt2(float[] waveform) {
+            int nSamples = waveform.Length;
+            var window = Stft.HannSymmetric(Nfft);  // np.hanning
+
+            int t1 = nSamples + HopLength;
+            int tPad = SegLength * ((t1 - 1) / SegLength + 1) - t1;
+            int nlPad = tPad / 2 / HopLength;
+            int tlPad = nlPad * HopLength;
+            var padded = new float[tlPad + nSamples + (tPad - tlPad)];
+            Array.Copy(waveform, 0, padded, tlPad, nSamples);
+
+            // reflect 填充 n_fft/2（Python 显式 reflect）
+            int padLen = Nfft / 2;
+            var buf = Stft.PadReflect(padded, padLen, padLen);
+            int nFrames = (buf.Length - Nfft) / HopLength + 1;
+            int bins = Nfft / 2 + 1;
+
+            // STFT（bin-major [1025, T]）
+            var specRe = new float[bins * nFrames];
+            var specIm = new float[bins * nFrames];
+            var frame = new float[Nfft];
+            var frameIm = new float[Nfft];
+            var reOut = new float[Nfft];
+            var imOut = new float[Nfft];
+            var fft = new NWaves.Transforms.Fft(Nfft);
+            for (int t = 0; t < nFrames; t++) {
+                int off = t * HopLength;
+                for (int i = 0; i < Nfft; i++) {
+                    frame[i] = buf[off + i] * window[i];
+                    frameIm[i] = 0f;
+                }
+                fft.Direct(frame, frameIm, reOut, imOut);
+                for (int b = 0; b < bins; b++) {
+                    specRe[b * nFrames + t] = reOut[b];
+                    specIm[b * nFrames + t] = imOut[b];
+                }
+            }
+
+            // mask 推理（模型 Concat 节点要求 spec_real/spec_imag 同时输入）
+            var maskRe = new float[bins * nFrames];
+            var maskIm = new float[bins * nFrames];
+            {
+                var reTensor = new DenseTensor<float>(specRe, new[] { 1, 1, bins, nFrames });
+                var imTensor = new DenseTensor<float>(specIm, new[] { 1, 1, bins, nFrames });
+                var inputs = new List<NamedOnnxValue> {
+                    NamedOnnxValue.CreateFromTensor("spec_real", reTensor),
+                    NamedOnnxValue.CreateFromTensor("spec_imag", imTensor),
+                };
+                using var results = session.Run(inputs);
+                var maskReTensor = results.First(r => r.Name == "mask_real").AsTensor<float>();
+                var maskImTensor = results.First(r => r.Name == "mask_imag").AsTensor<float>();
+                for (int i = 0; i < maskRe.Length; i++) {
+                    maskRe[i] = maskReTensor.GetValue(i);
+                    maskIm[i] = maskImTensor.GetValue(i);
+                }
+            }
+
+            // spec * (mask_r + j·mask_i) → ISTFT 重叠相加
+            var harmonic = new double[buf.Length];
+            var norm = new double[buf.Length];
+            for (int t = 0; t < nFrames; t++) {
+                // 构建共轭对称全谱
+                var fullRe = new float[Nfft];
+                var fullIm = new float[Nfft];
+                for (int b = 0; b < bins; b++) {
+                    double r = specRe[b * nFrames + t], im = specIm[b * nFrames + t];
+                    double mr = maskRe[b * nFrames + t], mi = maskIm[b * nFrames + t];
+                    fullRe[b] = (float)(r * mr - im * mi);
+                    fullIm[b] = (float)(r * mi + im * mr);
+                }
+                for (int b = 1; b < Nfft - bins + 1; b++) {
+                    fullRe[Nfft - b] = fullRe[b];
+                    fullIm[Nfft - b] = -fullIm[b];
+                }
+                var timeRe = new float[Nfft];
+                var timeIm = new float[Nfft];
+                fft.InverseNorm(fullRe, fullIm, timeRe, timeIm);
+                int off = t * HopLength;
+                for (int i = 0; i < Nfft; i++) {
+                    harmonic[off + i] += (double)timeRe[i] * window[i];
+                    norm[off + i] += (double)window[i] * window[i];
+                }
+            }
+            for (int i = 0; i < harmonic.Length; i++) {
+                harmonic[i] /= Math.Max(norm[i], 1e-10);
+            }
+
+            // 裁剪填充
+            int start = padLen + tlPad;
+            var hOut = new double[nSamples];
+            Array.Copy(harmonic, start, hOut, 0, nSamples);
+            var nOut = new double[nSamples];
+            for (int i = 0; i < nSamples; i++) nOut[i] = waveform[i] - hOut[i];
+            return (hOut, nOut);
+        }
+
+        public void Dispose() => session?.Dispose();
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/MelExtractor.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/MelExtractor.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+using OpenUtau.Core.HiFiUtau.Engine.Dsp;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// util/wav2mel.py 的 PitchAndTimeAdjustableMelSpectrogram 移植：
+    /// 支持自定义帧中心位置（用于时间拉伸）的 mel 提取。
+    /// STFT 用对称 hann（np.hanning）+ reflect 填充（Python 显式指定，与 librosa 版本无关）。
+    /// 输出 (128, T) band-major。
+    /// </summary>
+    public sealed class MelExtractor {
+        public const int Nfft = 2048;
+        public const int WinLength = 2048;
+        public const int NMels = 128;
+        public const double Fmin = 40, Fmax = 16000;
+        public const int SampleRate = 44100;
+
+        private readonly float[] melBasisF32; // float32 mel 基（librosa 同为 float32），SIMD 点积用
+        private readonly float[] hannSym;     // np.hanning
+
+        public MelExtractor() {
+            melBasisF32 = Simd.ToFloat32(MelFilterbank.Basis(SampleRate, Nfft, NMels, Fmin, Fmax));
+            hannSym = Stft.HannSymmetric(WinLength);
+        }
+
+        /// <summary>
+        /// wav2mel __call__（key_shift=0 路径，引擎中仅使用该路径）。
+        /// centers: 帧中心采样位置（float 截断取整）。
+        /// </summary>
+        public double[] Extract(float[] y, double[] centers) {
+            int T = centers.Length;
+            int bins = Nfft / 2 + 1;
+            var padded = Stft.PadReflect(y, Nfft / 2, Nfft / 2);
+            int padLen = padded.Length;
+
+            // 幅度谱存为帧主序 [t*bins+b]，mel 投影两侧均连续（SIMD 点积 + 按频带并行）
+            var magT = new float[bins * T];
+            var frame = new float[Nfft];
+            var frameIm = new float[Nfft];
+            var reOut = new float[Nfft];
+            var imOut = new float[Nfft];
+            var fft = new NWaves.Transforms.Fft(Nfft);
+
+            for (int t = 0; t < T; t++) {
+                int start = (int)centers[t];  // np: indices.astype(int) 截断
+                for (int i = 0; i < Nfft; i++) {
+                    int j = start + i;
+                    // Python: np.clip(indices, 0, len(padded)-1) 后取帧
+                    j = Math.Clamp(j, 0, padLen - 1);
+                    frame[i] = padded[j] * hannSym[i];
+                    frameIm[i] = 0f;
+                }
+                fft.Direct(frame, frameIm, reOut, imOut);
+                int dst = t * bins;
+                for (int b = 0; b < bins; b++) {
+                    float r = reOut[b], m = imOut[b];
+                    magT[dst + b] = MathF.Sqrt(r * r + m * m);
+                }
+            }
+
+            // mel = basis @ |spec|（basis 为 float32-round 后的 double，与 librosa 一致）
+            // 小输入并行开销大于收益，仅在帧数较多时按频带并行
+            var mel = new double[NMels * T];
+            if (T >= 512) {
+                Parallel.For(0, NMels, m => {
+                    int off = m * bins;
+                    int outOff = m * T;
+                    for (int t = 0; t < T; t++) {
+                        mel[outOff + t] = Simd.Dot(melBasisF32, off, magT, t * bins, bins);
+                    }
+                });
+            } else {
+                for (int m = 0; m < NMels; m++) {
+                    int off = m * bins;
+                    int outOff = m * T;
+                    for (int t = 0; t < T; t++) {
+                        mel[outOff + t] = Simd.Dot(melBasisF32, off, magT, t * bins, bins);
+                    }
+                }
+            }
+            return mel;
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/NumpyRandom.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/NumpyRandom.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// numpy legacy RandomState 的精确移植（MT19937 + rk_gauss），
+    /// 用于 growl 效果的噪声序列复现（Python: np.random.RandomState(42).standard_normal(n)）。
+    /// 参考 numpy/random/mtrand/randomkit.c。
+    /// </summary>
+    public sealed class NumpyRandom {
+        private const int N = 624;
+        private const int M = 397;
+        private const uint MatrixA = 0x9908b0dfu;
+        private const uint UpperMask = 0x80000000u;
+        private const uint LowerMask = 0x7fffffffu;
+
+        private readonly uint[] mt = new uint[N];
+        private int mti = N + 1;   // 表示需要重新生成
+        private bool hasGauss;
+        private double gaussCache;
+
+        public NumpyRandom(int seed) {
+            // init_genrand
+            mt[0] = (uint)(seed & 0xffffffffu);
+            for (int i = 1; i < N; i++) {
+                mt[i] = (uint)(1812433253u * (mt[i - 1] ^ (mt[i - 1] >> 30)) + (uint)i);
+            }
+            mti = N;
+        }
+
+        private uint NextUint32() {
+            uint y;
+            if (mti >= N) {
+                int kk;
+                for (kk = 0; kk < N - M; kk++) {
+                    y = (mt[kk] & UpperMask) | (mt[kk + 1] & LowerMask);
+                    mt[kk] = mt[kk + M] ^ (y >> 1) ^ ((y & 1) != 0 ? MatrixA : 0u);
+                }
+                for (; kk < N - 1; kk++) {
+                    y = (mt[kk] & UpperMask) | (mt[kk + 1] & LowerMask);
+                    mt[kk] = mt[kk + (M - N)] ^ (y >> 1) ^ ((y & 1) != 0 ? MatrixA : 0u);
+                }
+                y = (mt[N - 1] & UpperMask) | (mt[0] & LowerMask);
+                mt[N - 1] = mt[M - 1] ^ (y >> 1) ^ ((y & 1) != 0 ? MatrixA : 0u);
+                mti = 0;
+            }
+            y = mt[mti++];
+            y ^= y >> 11;
+            y ^= (y << 7) & 0x9d2c5680u;
+            y ^= (y << 15) & 0xefc60000u;
+            y ^= y >> 18;
+            return y;
+        }
+
+        /// <summary>rk_double：53 位精度均匀 [0,1)。</summary>
+        private double NextDouble() {
+            uint a = NextUint32() >> 5;
+            uint b = NextUint32() >> 6;
+            return (a * 67108864.0 + b) / 9007199254740992.0;
+        }
+
+        /// <summary>rk_gauss：极坐标法（带缓存），与 numpy standard_normal 逐值一致。</summary>
+        public double StandardNormal() {
+            if (hasGauss) {
+                hasGauss = false;
+                return gaussCache;
+            }
+            double x, y, r2;
+            do {
+                x = 2.0 * NextDouble() - 1.0;
+                y = 2.0 * NextDouble() - 1.0;
+                r2 = x * x + y * y;
+            } while (r2 >= 1.0 || r2 == 0.0);
+            double f = Math.Sqrt(-2.0 * Math.Log(r2) / r2);
+            gaussCache = x * f;
+            hasGauss = true;
+            return y * f;
+        }
+
+        /// <summary>standard_normal(n)。</summary>
+        public double[] StandardNormal(int n) {
+            var result = new double[n];
+            for (int i = 0; i < n; i++) result[i] = StandardNormal();
+            return result;
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/PhraseData.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/PhraseData.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// hifiutau-engine 合成请求 JSON 的强类型解析。
+    /// JSON 契约与 HifiUtauPhraseJson.Build() 的输出一致（即 Python 引擎的输入）。
+    /// </summary>
+    public sealed class PhraseData {
+        public int HopSize { get; init; }                 // json['hop_size']，Python: Dynamic_hop
+        public double WavDurMs { get; init; }             // json['wav_dur']
+        public int SampleRateConst => 44100;              // frag.sample_rate（Python 固定 44100）
+        public List<PhoneInfo> Phones { get; init; } = new();
+        public Dictionary<string, double[]> Dynamic { get; init; } = new();  // Dynamic_parameter
+
+        public static PhraseData Parse(JObject json) {
+            var data = new PhraseData {
+                HopSize = json.Value<int?>("hop_size") ?? 256,
+                WavDurMs = json.Value<double?>("wav_dur") ?? 0,
+            };
+            if (json["Dynamic_parameter"] is JObject dp) {
+                foreach (var kv in dp) {
+                    if (kv.Value is JArray arr) {
+                        var curve = new double[arr.Count];
+                        for (int i = 0; i < arr.Count; i++) curve[i] = arr[i].Value<double>();
+                        data.Dynamic[kv.Key] = curve;
+                    }
+                }
+            }
+            if (json["phoneme_list"] is JObject list) {
+                foreach (var kv in list) {
+                    if (kv.Value is JObject p) data.Phones.Add(PhoneInfo.Parse(p));
+                }
+            }
+            return data;
+        }
+
+        /// <summary>fragment.py _get_param：取第一个存在的键，否则空数组。</summary>
+        public double[] GetParam(params string[] keys) {
+            foreach (string k in keys) {
+                if (Dynamic.TryGetValue(k, out var v)) return v;
+            }
+            return Array.Empty<double>();
+        }
+    }
+
+    public sealed class PhoneInfo {
+        public string Name = "";
+        public Dictionary<string, double> Flags = new();   // Note_flags
+        public OtoEntry Oto = new();
+        public EnvPoint P0 = new(), P1 = new(), P2 = new(), P3 = new(), P4 = new();
+        public Dictionary<string, double[]> PerPhoneDP = new();  // 音素级 Dynamic_parameter
+
+        // ── 管线中间产物 ──
+        public double[] Mel = Array.Empty<double>();      // (128, T) band-major
+        public int MelFrames;                             // Mel 的帧数
+        public float[] AudioSeg = Array.Empty<float>();
+        public int ConsonantFrames;
+        public double StretchFactor = 1.0;
+        // FragmentMel 专用
+        public double[] HPoints = Array.Empty<double>();
+        public int MelOffset, MelEnd;
+        public double Preutter;
+        // BaseSplicer 专用
+        public int ModelStartFrame, ModelEndFrame, ModelFrames;
+
+        public double Flag(string key, double fallback) => Flags.TryGetValue(key, out var v) ? v : fallback;
+        public double RequireFlag(string key) => Flags.TryGetValue(key, out var v) ? v : throw new KeyNotFoundException($"Note_flags 缺少 {key}");
+
+        public double[] GetPhoneDP(string key)
+            => PerPhoneDP.TryGetValue(key, out var v) && v.Length > 0 ? v : Array.Empty<double>();
+
+        public static PhoneInfo Parse(JObject p) {
+            var info = new PhoneInfo { Name = p.Value<string>("phoneme_name") ?? "" };
+            if (p["Note_flags"] is JObject flags) {
+                foreach (var kv in flags) {
+                    info.Flags[kv.Key] = kv.Value?.Type == JTokenType.Array
+                        ? 0 : Convert.ToDouble(kv.Value?.Value<double?>() ?? kv.Value?.Value<long?>() ?? 0);
+                }
+            }
+            if (p["phoneme_oto"] is JObject oto) {
+                info.Oto = new OtoEntry {
+                    AudioFilePath = oto.Value<string>("audio_file_path") ?? "",
+                    Offset = oto.Value<double?>("Offset") ?? 0,
+                    Consonant = oto.Value<double?>("Consonant") ?? 0,
+                    Cutoff = oto.Value<double?>("Cutoff") ?? 0,
+                    Preutter = oto.Value<double?>("Preutter") ?? 0,
+                };
+            }
+            if (p["envelope"] is JObject env) {
+                info.P0 = ParsePoint(env["p0"]);
+                info.P1 = ParsePoint(env["p1"]);
+                info.P2 = ParsePoint(env["p2"]);
+                info.P3 = ParsePoint(env["p3"]);
+                info.P4 = ParsePoint(env["p4"]);
+            }
+            if (p["Dynamic_parameter"] is JObject dp) {
+                foreach (var kv in dp) {
+                    if (kv.Value is JArray arr) {
+                        var curve = new double[arr.Count];
+                        for (int i = 0; i < arr.Count; i++) curve[i] = arr[i].Value<double>();
+                        info.PerPhoneDP[kv.Key] = curve;
+                    }
+                }
+            }
+            return info;
+        }
+
+        private static EnvPoint ParsePoint(JToken? t) {
+            var p = t as JObject;
+            return new EnvPoint {
+                X = p?.Value<double?>("x") ?? 0,
+                Y = p?.Value<double?>("y") ?? 0,
+            };
+        }
+    }
+
+    public sealed class OtoEntry {
+        public string AudioFilePath = "";
+        public double Offset, Consonant, Cutoff, Preutter;
+    }
+
+    public sealed class EnvPoint {
+        public double X, Y;
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/PostProcessing.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/PostProcessing.cs
@@ -1,0 +1,794 @@
+using System;
+using OpenUtau.Core.HiFiUtau.Engine.Dsp;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// engine.py _postprocess + post_process.py + tension_filter.py + warmth.py
+    /// + growl.py + _numba_ops.py 的移植。数值语义逐行对照 Python 版。
+    /// </summary>
+    public static class PostProcessing {
+        private const int StftNfft = 2048;
+        private const int StftHop = 512;
+        private static readonly float[] hannPeriodic = Stft.HannPeriodic(StftNfft);
+
+        // scipy.signal.butter(4, 2000.0, fs=44100, output='sos') 的精确系数（常数）
+        private static readonly double[][] SosLow = {
+            new[] { 2.9136579221204529e-04, 5.8273158442409057e-04, 2.9136579221204529e-04, 1.0, -1.5236413003220306, 0.58766346876782993 },
+            new[] { 1.0, 2.0, 1.0, 1.0, -1.7329280106367695, 0.80574423646235072 },
+        };
+        private static readonly double[][] SosHigh = {
+            new[] { 0.6881179899153391, -1.3762359798306782, 0.6881179899153391, 1.0, -1.5236413003220306, 0.58766346876782993 },
+            new[] { 1.0, -2.0, 1.0, 1.0, -1.7329280106367695, 0.80574423646235072 },
+        };
+
+        // ══════════════════ 主入口（engine.py _postprocess） ══════════════════
+
+        public static byte[] Postprocess(SynthesisEngine engine, float[]? wav,
+                float[]? harmonicIn, float[]? noiseIn, PhraseData phrase) {
+            double[]? h = harmonicIn != null ? ToDouble(harmonicIn) : null;
+            double[]? n = noiseIn != null ? ToDouble(noiseIn) : null;
+            // engine.py: harmonic+noise 都有 → wav = harmonic + noise；否则基信号 = wav
+            double[] baseWav = (h != null && n != null) ? Add(h, n) : ToDouble(wav!);
+
+            int frontDh = (int)Interpolation.PyRound(engine.FrontPadFrames * (double)engine.ModelHop / phrase.HopSize);
+            int tailDh = (int)Interpolation.PyRound(engine.TailPadFrames * (double)engine.ModelHop / phrase.HopSize);
+
+            double[] pit = phrase.GetParam("pit", "pitd");
+            double[] breath = phrase.GetParam("brec", "breath");
+            double[] tension = phrase.GetParam("tenc", "tension");
+            double[] voicing = phrase.GetParam("voic", "voicing");
+            double[] brel = phrase.GetParam("brel", "bret_low");
+            double[] breh = phrase.GetParam("breh", "bret_high");
+            double[] warm = phrase.GetParam("warm", "warmth");
+            double[] hcmp = phrase.GetParam("hcmp", "hcmp");
+            double[] lowcut = phrase.GetParam("lowc", "lowcut");
+            double[] growl = phrase.GetParam("gwl", "growl");
+
+            bool needBreath = breath.Length > 0 && !AllClose(breath, 0, atol: 0.5);
+            bool needTension = tension.Length > 0 && !AllClose(tension, 0, atol: 0.5);
+            bool needVoicing = voicing.Length > 0 && !AllClose(voicing, 100, rtol: 0.05);
+            bool needBrel = brel.Length > 0 && !AllClose(brel, 0, atol: 0.5);
+            bool needBreh = breh.Length > 0 && !AllClose(breh, 0, atol: 0.5);
+            bool needHcmp = hcmp.Length > 0 && !AllClose(hcmp, 0, atol: 0.5);
+            bool needWarm = warm.Length > 0 && !AllClose(warm, 0, atol: 0.5);
+            bool needLegacy = needBreath || needTension || needVoicing || needBrel || needBreh;
+
+            if (needLegacy || needHcmp || needWarm) {
+                if (h == null || n == null) {
+                    var engineHnsep = engine.HnsepModel ?? throw new InvalidOperationException(
+                        "当前合成使用了依赖 HN-SEP 的参数，但 HN-SEP 模型未加载。");
+                    var (hh, nn) = engineHnsep.Separate(ToFloat(baseWav));
+                    h = hh; n = nn;
+                }
+
+                if (needLegacy) {
+                    var padB = PadEdge(breath, frontDh, tailDh);
+                    var padT = PadEdge(tension, frontDh, tailDh);
+                    var padV = PadEdge(voicing, frontDh, tailDh);
+                    var padF0 = PadEdge(pit, frontDh, tailDh);
+                    var padBrel = PadEdge(brel, frontDh, tailDh);
+                    var padBreh = PadEdge(breh, frontDh, tailDh);
+                    (h, n) = ApplyHnsepPostprocessComponents(h, n, padB, padT, padV, phrase.SampleRateConst,
+                        f0Curve: padF0, brelArray: padBrel, brehArray: padBreh);
+                }
+
+                if (needWarm) {
+                    double warmVal = Mean(warm);
+                    h = ApplyWarmthEq(h, warmVal, phrase.SampleRateConst);
+                }
+
+                if (needHcmp) {
+                    double hcmpVal = Mean(hcmp);
+                    h = ApplyHarmonicCompression(h, hcmpVal, phrase.SampleRateConst);
+                }
+
+                baseWav = Add(h!, n!);
+            }
+
+            // 低切（F0 跟随 Butterworth 高通）
+            if (lowcut.Length > 0 && !AllClose(lowcut, 0, atol: 0.5)) {
+                var paddedLowcut = InterpToLenWithPad(PadEdge(lowcut, frontDh, tailDh), baseWav.Length);
+                var padF0 = PadEdge(pit, frontDh, tailDh);
+                baseWav = ApplyDynamicLowcut(baseWav, paddedLowcut, phrase.SampleRateConst, f0Curve: padF0);
+            }
+
+            // 咆哮（最后一步）
+            if (growl.Length > 0) {
+                baseWav = ApplyGrowl(baseWav,
+                    PadEdge(growl, frontDh, tailDh),
+                    phrase.SampleRateConst,
+                    f0: PadEdge(pit, frontDh, tailDh),
+                    f0Hop: phrase.HopSize);
+            }
+
+            // 统一裁剪首尾补帧
+            int frontTrim = engine.FrontPadFrames * engine.ModelHop;
+            int tailTrim = engine.TailPadFrames * engine.ModelHop;
+            if (frontTrim > 0 && baseWav.Length > frontTrim) {
+                baseWav = Slice(baseWav, frontTrim, baseWav.Length - frontTrim);
+            }
+            if (tailTrim > 0 && baseWav.Length > tailTrim) {
+                baseWav = Slice(baseWav, 0, baseWav.Length - tailTrim);
+            }
+
+            // 首音素淡入 / 尾音素淡出
+            var firstEnv = phrase.Phones[0];
+            var lastEnv = phrase.Phones[^1];
+            int sr = phrase.SampleRateConst;
+
+            double p0x = firstEnv.P0.X, p0y = firstEnv.P0.Y;
+            double p1x = firstEnv.P1.X, p1y = firstEnv.P1.Y;
+            int fadeInLen = Math.Max(0, (int)Math.Round((p1x - p0x) / 1000 * sr));
+            if (fadeInLen > 1 && baseWav.Length > fadeInLen && p0y < p1y) {
+                double startGain = Math.Max(p0y / 100.0, 1e-6);
+                for (int i = 0; i < fadeInLen; i++) {
+                    double g = startGain + (p1y / 100.0 - startGain) * i / (fadeInLen - 1);
+                    baseWav[i] *= g;
+                }
+            }
+            double p3x = lastEnv.P3.X, p3y = lastEnv.P3.Y;
+            double p4x = lastEnv.P4.X, p4y = lastEnv.P4.Y;
+            int fadeOutLen = Math.Max(0, (int)Math.Round((p4x - p3x) / 1000 * sr));
+            if (fadeOutLen > 1 && baseWav.Length > fadeOutLen && p3y > p4y) {
+                int start = baseWav.Length - fadeOutLen;
+                for (int i = 0; i < fadeOutLen; i++) {
+                    double g = p3y / 100.0 + (p4y / 100.0 - p3y / 100.0) * i / (fadeOutLen - 1);
+                    baseWav[start + i] *= g;
+                }
+            }
+
+            var floats = ToFloat(baseWav);
+            return SynthesisEngine.WavBytes(floats);
+        }
+
+        // ══════════════════ post_process.py ══════════════════
+
+        /// <summary>apply_hnsep_postprocess_components。</summary>
+        public static (double[] harmonic, double[] noise) ApplyHnsepPostprocessComponents(
+                double[] harmonic, double[] noise,
+                double[] breathArray, double[] tensionArray, double[] voicingArray,
+                int sr, double[]? f0Curve = null,
+                double[]? brelArray = null, double[]? brehArray = null) {
+            int nSamples = harmonic.Length;
+
+            if (breathArray.Length > 0 && !AllClose(breathArray, 0, atol: 0.5)) {
+                var ratio = ResampleToLen(breathArray, nSamples);
+                for (int i = 0; i < nSamples; i++) {
+                    double r = ratio[i] / 100.0;
+                    double gain = r > 0 ? 1.0 + r * 3.0 : 1.0 + r;
+                    noise[i] *= Math.Clamp(gain, 0.0, 10.0);
+                }
+            }
+
+            bool needBrel = brelArray != null && brelArray.Length > 0 && !AllClose(brelArray, 0, atol: 0.5);
+            bool needBreh = brehArray != null && brehArray.Length > 0 && !AllClose(brehArray, 0, atol: 0.5);
+            if (needBrel || needBreh) {
+                var lowGain = Ones(nSamples);
+                var highGain = Ones(nSamples);
+                if (needBrel) {
+                    var r = ResampleToLen(brelArray!, nSamples);
+                    for (int i = 0; i < nSamples; i++) {
+                        double v = r[i] / 100.0;
+                        lowGain[i] = v > 0 ? 1.0 + v * 3.0 : 1.0 + v;
+                    }
+                }
+                if (needBreh) {
+                    var r = ResampleToLen(brehArray!, nSamples);
+                    for (int i = 0; i < nSamples; i++) {
+                        double v = r[i] / 100.0;
+                        highGain[i] = v > 0 ? 1.0 + v * 3.0 : 1.0 + v;
+                    }
+                }
+                noise = ApplyBreathBandGain(noise, lowGain, highGain, sr);
+            }
+
+            if (voicingArray.Length > 0 && !AllClose(voicingArray, 100, rtol: 0.05)) {
+                var voicingMap = ResampleToLen(voicingArray, nSamples);
+                for (int i = 0; i < nSamples; i++) {
+                    double gain = Math.Clamp(voicingMap[i], 0, 500) / 100.0;
+                    harmonic[i] = gain < 1e-8 ? 0.0 : harmonic[i] * gain;
+                }
+            }
+
+            if (tensionArray.Length > 0 && !AllClose(tensionArray, 0, atol: 0.5)) {
+                var tensionMap = ResampleToLen(tensionArray, nSamples);
+                harmonic = ApplyDynamicTension(harmonic, tensionMap, sr, f0Curve: f0Curve);
+            }
+
+            return (harmonic, noise);
+        }
+
+        /// <summary>tension_filter.apply_breath_band_gain：分频后独立乘增益再相加。</summary>
+        public static double[] ApplyBreathBandGain(double[] waveform, double[] lowGain, double[] highGain,
+                int sr, double crossoverHz = 2000.0) {
+            int n = waveform.Length;
+            if (n == 0) return waveform;
+            double lowMax = 0, highMax = 0;
+            foreach (var v in lowGain) lowMax = Math.Max(lowMax, Math.Abs(v - 1.0));
+            foreach (var v in highGain) highMax = Math.Max(highMax, Math.Abs(v - 1.0));
+            if (lowMax < 0.01 && highMax < 0.01) return waveform;
+
+            // 引擎内 crossover 固定 2000Hz/sr=44100（Python 缓存的常数系数）
+            var sosLow = Math.Abs(crossoverHz - 2000.0) < 0.1 && sr == 44100 ? SosLow : null;
+            var sosHigh = Math.Abs(crossoverHz - 2000.0) < 0.1 && sr == 44100 ? SosHigh : null;
+            if (sosLow == null) throw new NotSupportedException("仅支持 crossover=2000Hz/sr=44100");
+
+            var low = SosFilt(sosLow, waveform);
+            var high = SosFilt(sosHigh, waveform);
+            var result = new double[n];
+            for (int i = 0; i < n; i++) {
+                result[i] = low[i] * lowGain[i] + high[i] * highGain[i];
+            }
+            return result;
+        }
+
+        /// <summary>scipy.signal.sosfilt（biquad 级联，a0 归一化）。</summary>
+        public static double[] SosFilt(double[][] sos, double[] x) {
+            int n = x.Length;
+            var outArr = new double[n];
+            // 各 section 状态
+            int sections = sos.Length;
+            var z = new double[sections, 2];
+            for (int i = 0; i < n; i++) {
+                double val = x[i];
+                for (int s = 0; s < sections; s++) {
+                    double b0 = sos[s][0] / sos[s][3], b1 = sos[s][1] / sos[s][3], b2 = sos[s][2] / sos[s][3];
+                    double a1 = sos[s][4] / sos[s][3], a2 = sos[s][5] / sos[s][3];
+                    double y = b0 * val + z[s, 0];
+                    z[s, 0] = b1 * val - a1 * y + z[s, 1];
+                    z[s, 1] = b2 * val - a2 * y;
+                    val = y;
+                }
+                outArr[i] = val;
+            }
+            return outArr;
+        }
+
+        // ══════════════════ tension_filter.py ══════════════════
+
+        /// <summary>apply_dynamic_tension：STFT 域逐帧频谱倾斜。</summary>
+        public static double[] ApplyDynamicTension(double[] waveform, double[] tensionMap, int sr,
+                double[]? f0Curve = null) {
+            int originalLen = waveform.Length;
+            int padLen = (StftHop - originalLen % StftHop) % StftHop;
+            var padded = new double[originalLen + padLen];
+            Array.Copy(waveform, padded, originalLen);
+
+            var floats = ToFloat(padded);
+            var (re, im, bins, frames) = Stft.Forward(floats, StftNfft, StftHop, hannPeriodic, center: true);
+            int fftBin = bins;
+
+            var tensionFrames = ResampleToLen(tensionMap, frames);
+
+            var x0PerFrame = new double[frames];
+            if (f0Curve != null && f0Curve.Length > 0) {
+                var f0Frames = ResampleToLen(f0Curve, frames);
+                for (int t = 0; t < frames; t++) {
+                    double midpointHz = Math.Clamp(f0Frames[t] * 4.0, 400.0, 6000.0);
+                    if (f0Frames[t] < 30.0) midpointHz = 1500.0;
+                    x0PerFrame[t] = fftBin / ((sr / 2.0) / midpointHz);
+                }
+            } else {
+                double x0Fixed = fftBin / ((sr / 2.0) / 1500);
+                for (int t = 0; t < frames; t++) x0PerFrame[t] = x0Fixed;
+            }
+
+            // mag_db = log(clip(|D|,1e-9))
+            var magDb = new double[bins * frames];
+            var magLinear = new double[bins * frames];
+            for (int i = 0; i < magDb.Length; i++) {
+                double r = re[i], m = im[i];
+                double mag = Math.Sqrt(r * r + m * m);
+                magLinear[i] = mag;
+                magDb[i] = Math.Log(Math.Max(mag, 1e-9));
+            }
+
+            ApplyTiltToFrames(magDb, magLinear, tensionFrames, x0PerFrame, frames, fftBin);
+
+            // ISTFT：mag_out * e^{i·phase}
+            var outRe = new float[bins * frames];
+            var outIm = new float[bins * frames];
+            for (int i = 0; i < outRe.Length; i++) {
+                double magOut = Math.Exp(magDb[i]);
+                double phase = Math.Atan2(im[i], re[i]);
+                outRe[i] = (float)(magOut * Math.Cos(phase));
+                outIm[i] = (float)(magOut * Math.Sin(phase));
+            }
+            var filtered = Stft.Inverse(outRe, outIm, StftNfft, StftHop, hannPeriodic, center: true);
+            int outLen = Math.Min(originalLen, filtered.Length);
+            var result = new double[outLen];
+            for (int i = 0; i < outLen; i++) result[i] = filtered[i];
+
+            // 软限幅
+            double peak = 0;
+            foreach (var v in result) peak = Math.Max(peak, Math.Abs(v));
+            if (peak > 1.0) {
+                for (int i = 0; i < result.Length; i++) result[i] = Math.Tanh(result[i] * 0.9) / 0.9;
+                double newPeak = 0;
+                foreach (var v in result) newPeak = Math.Max(newPeak, Math.Abs(v));
+                if (newPeak > 1e-8) {
+                    double scale = Math.Min(peak, 1.0) / newPeak;
+                    for (int i = 0; i < result.Length; i++) result[i] *= scale;
+                }
+            }
+            return result;
+        }
+
+        /// <summary>_apply_tilt_to_frames：log 幅度域逐帧倾斜滤波 + 能量保持。</summary>
+        private static void ApplyTiltToFrames(double[] magDb, double[] magLinear,
+                double[] tensionFrames, double[] x0PerFrame, int nFrames, int fftBin) {
+            for (int t = 0; t < nFrames; t++) {
+                double tv = tensionFrames[t];
+                double b = tv > 0 ? -tv / 150.0 : -tv / 50.0;
+
+                if (Math.Abs(b) < 0.001) continue;
+
+                double x0 = x0PerFrame[t];
+                if (x0 <= 0) x0 = 1.0;
+
+                // 逐帧能量保持所需的原始总幅度
+                double origSum = 0;
+                for (int f = 0; f < fftBin; f++) origSum += magLinear[f * nFrames + t];
+
+                for (int f = 0; f < fftBin; f++) {
+                    double val = (-b / x0) * f + b;
+                    if (val > 2.0) val = 2.0;
+                    else if (val < -2.0) val = -2.0;
+                    magDb[f * nFrames + t] += val;
+                }
+
+                if (origSum > 1e-12) {
+                    double newSum = 0;
+                    for (int f = 0; f < fftBin; f++) newSum += Math.Exp(magDb[f * nFrames + t]);
+                    if (newSum > 1e-12) {
+                        double comp = Math.Log(origSum / newSum);
+                        for (int f = 0; f < fftBin; f++) magDb[f * nFrames + t] += comp;
+                    }
+                }
+
+                if (b < -0.001) {
+                    double val = b / (-15.0);
+                    val = Math.Clamp(val, 0.0, 0.33);
+                    double bGain = Math.Log(val + 1.0);
+                    if (bGain > 0.0) {
+                        for (int f = 0; f < fftBin; f++) magDb[f * nFrames + t] += bGain;
+                    }
+                }
+            }
+        }
+
+        /// <summary>apply_dynamic_lowcut：STFT 域 Butterworth 高通（F0 跟随）。</summary>
+        public static double[] ApplyDynamicLowcut(double[] waveform, double[] lowcutMap, int sr,
+                double[]? f0Curve = null) {
+            double lowcutMax = 0;
+            foreach (var v in lowcutMap) lowcutMax = Math.Max(lowcutMax, v);
+            if (lowcutMax < 0.5) return waveform;
+
+            int originalLen = waveform.Length;
+            int padLen = (StftHop - originalLen % StftHop) % StftHop;
+            var padded = new double[originalLen + padLen];
+            Array.Copy(waveform, padded, originalLen);
+            var floats = ToFloat(padded);
+            var (re, im, bins, frames) = Stft.Forward(floats, StftNfft, StftHop, hannPeriodic, center: true);
+            int fftBin = bins;
+
+            var lowcutFrames = ResampleToLen(lowcutMap, frames);
+            var x0PerFrame = new double[frames];
+            if (f0Curve != null && f0Curve.Length > 0) {
+                var f0Frames = ResampleToLen(f0Curve, frames);
+                for (int t = 0; t < frames; t++) {
+                    double cutoffHz = (lowcutFrames[t] / 100.0) * f0Frames[t];
+                    if (f0Frames[t] < 30.0) cutoffHz = 0.0;
+                    cutoffHz = Math.Clamp(cutoffHz, 0.0, 2000.0);
+                    x0PerFrame[t] = cutoffHz > 1.0 ? fftBin / ((sr / 2.0) / cutoffHz) : 0.0;
+                }
+            } else {
+                for (int t = 0; t < frames; t++) {
+                    double cutoffHz = Math.Clamp(lowcutFrames[t] * 5.0, 0.0, 500.0);
+                    x0PerFrame[t] = cutoffHz > 1.0 ? fftBin / ((sr / 2.0) / cutoffHz) : 0.0;
+                }
+            }
+
+            var magDb = new double[bins * frames];
+            for (int i = 0; i < magDb.Length; i++) {
+                double r = re[i], m = im[i];
+                magDb[i] = Math.Log(Math.Max(Math.Sqrt(r * r + m * m), 1e-9));
+            }
+
+            for (int t = 0; t < frames; t++) {
+                double cutoffBin = x0PerFrame[t];
+                if (cutoffBin <= 0.5) continue;
+                for (int f = 0; f < fftBin; f++) {
+                    if (f == 0) {
+                        magDb[0 * frames + t] -= 80.0;
+                        continue;
+                    }
+                    double ratio = cutoffBin / f;
+                    double r2 = ratio * ratio;
+                    double gainDb = -10.0 * Math.Log10(1.0 + r2 * r2);
+                    magDb[f * frames + t] += gainDb;
+                }
+            }
+
+            var outRe = new float[bins * frames];
+            var outIm = new float[bins * frames];
+            for (int i = 0; i < outRe.Length; i++) {
+                double magOut = Math.Exp(magDb[i]);
+                double phase = Math.Atan2(im[i], re[i]);
+                outRe[i] = (float)(magOut * Math.Cos(phase));
+                outIm[i] = (float)(magOut * Math.Sin(phase));
+            }
+            var filtered = Stft.Inverse(outRe, outIm, StftNfft, StftHop, hannPeriodic, center: true);
+            int outLen = Math.Min(originalLen, filtered.Length);
+            var result = new double[outLen];
+            for (int i = 0; i < outLen; i++) result[i] = filtered[i];
+            return result;
+        }
+
+        // ══════════════════ warmth.py ══════════════════
+
+        /// <summary>apply_warmth_eq：温暖/清凉通道条（压缩 + 饱和 + STFT EQ + 归一化）。</summary>
+        public static double[] ApplyWarmthEq(double[] waveform, double warmthValue, int sr) {
+            warmthValue = -warmthValue;  // OpenUtau 发送 warm=-100 表示温暖
+            if (Math.Abs(warmthValue) < 0.5) return waveform;
+
+            double warmth = warmthValue / 100.0;
+            var x = (double[])waveform.Clone();
+
+            if (warmth > 0) {
+                double peakDb = 20.0 * Math.Log10(MaxAbs(x) + 1e-12);
+                double threshold = peakDb - 18.0 + (1.0 - warmth) * 6.0;
+                double ratio = 1.0 + warmth * 3.0;
+                x = SoftKneeCompressor(x, threshold, ratio, sr);
+                x = ApplySaturation(x, warmth * 0.3);
+                x = ApplyStftEq(x, 300.0, warmth * 1.25, sigmaOct: 2.4, sr: sr);
+            } else {
+                double cool = -warmth;
+                double peakDb = 20.0 * Math.Log10(MaxAbs(x) + 1e-12);
+                double threshold = peakDb - 20.0;
+                double ratio = 1.0 + cool * 1.0;
+                x = SoftKneeCompressor(x, threshold, ratio, sr);
+                x = ApplyStftEq(x, 5000.0, cool * 2.5, sigmaOct: 3.0, sr: sr);
+            }
+
+            // 能量归一化
+            double rmsIn = Rms(waveform);
+            double rmsOut = Rms(x);
+            if (rmsOut > 1e-12 && rmsIn > 1e-12) {
+                double gain = Math.Clamp(rmsIn / rmsOut, 0.01, 100.0);
+                for (int i = 0; i < x.Length; i++) x[i] *= gain;
+            }
+
+            // 软限幅
+            double peak = MaxAbs(x);
+            if (peak > 0.99) {
+                double scale = 0.99 / peak;
+                for (int i = 0; i < x.Length; i++) x[i] *= scale;
+            }
+            return x;
+        }
+
+        /// <summary>apply_harmonic_compression：纯压缩 + 能量归一化。</summary>
+        public static double[] ApplyHarmonicCompression(double[] waveform, double hcmpValue, int sr) {
+            if (Math.Abs(hcmpValue) < 0.5) return waveform;
+            double hcmp = hcmpValue / 100.0;
+            var x = (double[])waveform.Clone();
+
+            double peakDb = 20.0 * Math.Log10(MaxAbs(x) + 1e-12);
+            double threshold = peakDb - 22.0;
+            double ratio = 1.0 + hcmp * 19.0;
+            x = SoftKneeCompressor(x, threshold, ratio, sr, attackMs: 1.0);
+
+            double rmsIn = Rms(waveform);
+            double rmsOut = Rms(x);
+            if (rmsOut > 1e-12 && rmsIn > 1e-12) {
+                double gain = Math.Clamp(rmsIn / rmsOut, 0.01, 100.0);
+                for (int i = 0; i < x.Length; i++) x[i] *= gain;
+            }
+
+            double peak = MaxAbs(x);
+            if (peak > 0.99) {
+                double scale = 0.99 / peak;
+                for (int i = 0; i < x.Length; i++) x[i] *= scale;
+            }
+            return x;
+        }
+
+        /// <summary>_apply_stft_eq：STFT 域钟形 EQ。</summary>
+        public static double[] ApplyStftEq(double[] xArr, double fc, double gainDb,
+                double sigmaOct = 2.0, int sr = 44100) {
+            int originalLen = xArr.Length;
+            int padLen = (StftHop - originalLen % StftHop) % StftHop;
+            var padded = new double[originalLen + padLen];
+            Array.Copy(xArr, padded, originalLen);
+            var floats = ToFloat(padded);
+            var (re, im, bins, frames) = Stft.Forward(floats, StftNfft, StftHop, hannPeriodic, center: true);
+
+            // 钟形增益曲线（log2 频率域）
+            var gainCurve = new double[bins];
+            double logFc = Math.Log2(fc);
+            for (int b = 0; b < bins; b++) {
+                double freq = (double)b / (bins - 1) * (sr / 2.0);
+                double logF = freq > 1.0 ? Math.Log2(freq) : Math.Log2(Math.Max(1.0 + 1e-9, 1.0));
+                // Python: log_f[~mask] = log_f[mask][0]（第一个正频率的 log2）
+                if (freq <= 1.0) logF = Math.Log2(sr / 2.0 / (bins - 1));
+                double bell = Math.Exp(-0.5 * Math.Pow((logF - logFc) / sigmaOct, 2));
+                double curve = 2.0 * bell - 1.0;
+                if (curve < 0) curve = -Math.Pow(-curve, 0.7);
+                gainCurve[b] = curve * gainDb;
+            }
+
+            var outRe = new float[bins * frames];
+            var outIm = new float[bins * frames];
+            for (int t = 0; t < frames; t++) {
+                for (int b = 0; b < bins; b++) {
+                    double r = re[b * frames + t], m = im[b * frames + t];
+                    double mag = Math.Sqrt(r * r + m * m);
+                    double phase = Math.Atan2(m, r);
+                    double magOut = Math.Exp(Math.Log(Math.Max(mag, 1e-12)) + gainCurve[b]);
+                    outRe[b * frames + t] = (float)(magOut * Math.Cos(phase));
+                    outIm[b * frames + t] = (float)(magOut * Math.Sin(phase));
+                }
+            }
+            var filtered = Stft.Inverse(outRe, outIm, StftNfft, StftHop, hannPeriodic, center: true);
+            int outLen = Math.Min(originalLen, filtered.Length);
+            var result = new double[outLen];
+            for (int i = 0; i < outLen; i++) result[i] = filtered[i];
+            return result;
+        }
+
+        // ══════════════════ _numba_ops.py ══════════════════
+
+        /// <summary>soft_knee_compressor：RMS 软膝压缩器。</summary>
+        public static double[] SoftKneeCompressor(double[] signal, double thresholdDb, double ratio,
+                int sr, double kneeDb = 6.0, double attackMs = 5.0, double releaseMs = 60.0) {
+            int n = signal.Length;
+            if (n == 0) return Array.Empty<double>();
+
+            double rmsWin = Math.Max(1, (int)(sr * 0.01));
+            int half = (int)(rmsWin / 2);
+
+            // 反射填充 x²
+            var padded = new double[n + 2 * half];
+            for (int i = 0; i < half; i++) padded[i] = Sq(signal[half - 1 - i]);
+            for (int i = 0; i < n; i++) padded[half + i] = Sq(signal[i]);
+            for (int i = 0; i < half; i++) padded[half + n + i] = Sq(signal[n - 1 - i]);
+
+            var rms = new double[n];
+            double sumSq = 0;
+            for (int i = 0; i < (int)Math.Min(rmsWin, padded.Length); i++) sumSq += padded[i];
+            double invWin = 1.0 / rmsWin;
+            for (int i = 0; i < n; i++) {
+                rms[i] = Math.Sqrt(sumSq * invWin);
+                if (i + (int)rmsWin < padded.Length) {
+                    sumSq += padded[i + (int)rmsWin] - padded[i];
+                }
+            }
+
+            double halfKnee = kneeDb / 2.0;
+            double oneMinusInvRatio = 1.0 - 1.0 / ratio;
+            double alphaA = attackMs > 0 ? Math.Exp(-1.0 / (sr * attackMs / 1000.0)) : 0.0;
+            double alphaR = releaseMs > 0 ? Math.Exp(-1.0 / (sr * releaseMs / 1000.0)) : 0.0;
+
+            var outArr = new double[n];
+            double prevG = 1.0;
+            for (int i = 0; i < n; i++) {
+                double rd = 20.0 * Math.Log10(Math.Max(rms[i], 1e-12));
+                double os = rd - thresholdDb;
+                double gDb;
+                if (os > halfKnee) {
+                    gDb = -os * oneMinusInvRatio;
+                } else if (os > -halfKnee) {
+                    double ko = os + halfKnee;
+                    gDb = (ko * ko) / (2.0 * kneeDb) * oneMinusInvRatio;
+                } else {
+                    gDb = 0.0;
+                }
+                double g = Math.Pow(10.0, gDb / 20.0);
+                double gSmooth = g < prevG
+                    ? alphaA * prevG + (1.0 - alphaA) * g
+                    : alphaR * prevG + (1.0 - alphaR) * g;
+                prevG = gSmooth;
+                outArr[i] = signal[i] * gSmooth;
+            }
+            return outArr;
+        }
+
+        /// <summary>apply_saturation：电子管式谐波饱和。</summary>
+        public static double[] ApplySaturation(double[] signal, double drive) {
+            int n = signal.Length;
+            if (drive < 0.01 || n == 0) return (double[])signal.Clone();
+
+            double peakIn = 0;
+            foreach (var v in signal) peakIn = Math.Max(peakIn, Math.Abs(v));
+            if (peakIn < 1e-12) return (double[])signal.Clone();
+
+            double invPeak = 1.0 / peakIn;
+            double driveGain = 1.0 + drive * 8.0;
+            double bias = 0.05 * drive;
+            double tanhBias = Math.Tanh(bias);
+            double wet = drive * 0.5;
+            double dry = 1.0 - wet;
+
+            var outArr = new double[n];
+            for (int i = 0; i < n; i++) {
+                double val = signal[i] * invPeak * driveGain;
+                val = Math.Tanh(val + bias) - tanhBias;
+                val = Math.Tanh(val * 1.5);
+                outArr[i] = (dry * (signal[i] * invPeak) + wet * val) * peakIn;
+            }
+            return outArr;
+        }
+
+        // ══════════════════ growl.py ══════════════════
+
+        /// <summary>apply_growl：时域延迟调制咆哮效果（噪声序列与 numpy RandomState(42) 逐值一致）。</summary>
+        public static double[] ApplyGrowl(double[] waveform, double[] growlArray, int sr,
+                double baseFreq = 120.0, double[]? f0 = null, int? f0Hop = null) {
+            int nSamples = waveform.Length;
+            if (growlArray.Length == 0 || AllClose(growlArray, 0, atol: 0.5)) return waveform;
+
+            var growlMap = ResampleToLen(growlArray, nSamples);
+
+            // 每样本颤音频率（跟随音高，限 80~240Hz）
+            var sine = new double[nSamples];
+            var freq = new double[nSamples];
+            if (f0 != null && f0.Length > 0 && f0Hop.HasValue) {
+                var f0Map = ResampleToLen(f0, nSamples);
+                double phase = 0;
+                double dt = 1.0 / sr;
+                for (int i = 0; i < nSamples; i++) {
+                    freq[i] = Math.Clamp(f0Map[i] * 0.35, 80.0, 240.0);
+                    phase += 2.0 * Math.PI * freq[i] * dt;
+                    sine[i] = Math.Sin(phase);
+                }
+            } else {
+                for (int i = 0; i < nSamples; i++) {
+                    freq[i] = baseFreq;
+                    sine[i] = Math.Sin(2.0 * Math.PI * baseFreq * i / (double)sr);
+                }
+            }
+
+            const double maxDelaySec = 0.00012;
+            var modulator = new double[nSamples];
+            var rng = new NumpyRandom(42);   // 与 numpy RandomState(42) 逐值一致
+            var rawNoise = rng.StandardNormal(nSamples);
+            // 低通（滑动均值）
+            int kernelSize = Math.Max(1, (int)(sr / 300));
+            var noise = MovingAverage(rawNoise, kernelSize);
+            double noiseMax = 0;
+            foreach (var v in noise) noiseMax = Math.Max(noiseMax, Math.Abs(v));
+            double noiseScale = 1.0 / (noiseMax + 1e-8);
+            double modPeak = 0;
+            for (int i = 0; i < nSamples; i++) {
+                modulator[i] = 0.88 * sine[i] + 0.12 * noise[i] * noiseScale;
+                modPeak = Math.Max(modPeak, Math.Abs(modulator[i]));
+            }
+            if (modPeak > 1e-8) {
+                for (int i = 0; i < nSamples; i++) modulator[i] /= modPeak;
+            }
+
+            var result = new double[nSamples];
+            double xMax = (nSamples - 1) / (double)sr;
+            for (int i = 0; i < nSamples; i++) {
+                double depth = Math.Pow(growlMap[i] / 100.0, 0.8);
+                double t = i / (double)sr;
+                double tau = Math.Clamp(t + depth * maxDelaySec * modulator[i], 0.0, xMax);
+                // np.interp（端点截断，原始波形域）
+                double pos = tau * sr;
+                result[i] = NpInterpSample(pos, waveform);
+            }
+
+            double peak = 0;
+            foreach (var v in result) peak = Math.Max(peak, Math.Abs(v));
+            if (peak > 1.0) {
+                double scale = 1.0 / peak;
+                for (int i = 0; i < result.Length; i++) result[i] *= scale;
+            }
+            return result;
+        }
+
+        private static double NpInterpSample(double pos, double[] waveform) {
+            if (pos <= 0) return waveform[0];
+            if (pos >= waveform.Length - 1) return waveform[^1];
+            int i = (int)pos;
+            double frac = pos - i;
+            return waveform[i] + frac * (waveform[i + 1] - waveform[i]);
+        }
+
+        private static double[] MovingAverage(double[] x, int kernelSize) {
+            // np.convolve(x, ones(k)/k, 'same')
+            int n = x.Length;
+            var result = new double[n];
+            int half = kernelSize / 2;
+            for (int i = 0; i < n; i++) {
+                double sum = 0;
+                int count = 0;
+                for (int j = 0; j < kernelSize; j++) {
+                    int idx = i - half + j;
+                    if (idx >= 0 && idx < n) { sum += x[idx]; count++; }
+                }
+                result[i] = count > 0 ? sum / kernelSize : 0;
+            }
+            return result;
+        }
+
+        // ══════════════════ 小工具 ══════════════════
+
+        private static double[] ToDouble(float[] x) {
+            var d = new double[x.Length];
+            for (int i = 0; i < x.Length; i++) d[i] = x[i];
+            return d;
+        }
+
+        private static float[] ToFloat(double[] x) {
+            var f = new float[x.Length];
+            for (int i = 0; i < x.Length; i++) f[i] = (float)x[i];
+            return f;
+        }
+
+        private static double[] Add(double[] a, double[] b) {
+            int n = Math.Min(a.Length, b.Length);
+            var result = new double[n];
+            for (int i = 0; i < n; i++) result[i] = a[i] + b[i];
+            return result;
+        }
+
+        private static double[] Ones(int n) {
+            var r = new double[n];
+            for (int i = 0; i < n; i++) r[i] = 1.0;
+            return r;
+        }
+
+        private static double Mean(double[] a) {
+            double s = 0;
+            foreach (var v in a) s += v;
+            return s / a.Length;
+        }
+
+        private static double MaxAbs(double[] a) {
+            double m = 0;
+            foreach (var v in a) m = Math.Max(m, Math.Abs(v));
+            return m;
+        }
+
+        private static double Rms(double[] a) {
+            double s = 0;
+            foreach (var v in a) s += v * v;
+            return Math.Sqrt(s / a.Length);
+        }
+
+        private static double Sq(double v) => v * v;
+
+        private static double[] Slice(double[] a, int start, int len) {
+            var r = new double[len];
+            Array.Copy(a, start, r, 0, len);
+            return r;
+        }
+
+        /// <summary>np.allclose 语义（atol/rtol 均相对参数或 1）。</summary>
+        private static bool AllClose(double[] arr, double target, double atol = 1e-8, double rtol = 1e-5) {
+            foreach (var v in arr) {
+                if (Math.Abs(v - target) > atol + rtol * Math.Abs(target)) return false;
+            }
+            return true;
+        }
+
+        /// <summary>engine.py _pad：首尾以首/末值延拓。</summary>
+        private static double[] PadEdge(double[] arr, int front, int tail) {
+            if (arr.Length == 0) return arr;
+            var result = new double[front + arr.Length + tail];
+            for (int i = 0; i < front; i++) result[i] = arr[0];
+            Array.Copy(arr, 0, result, front, arr.Length);
+            for (int i = 0; i < tail; i++) result[front + arr.Length + i] = arr[^1];
+            return result;
+        }
+
+        /// <summary>interp_to_len 包装（ResampleToLen 与 Python interp_to_len 等价）。</summary>
+        private static double[] ResampleToLen(double[] arr, int targetLen)
+            => Interpolation.InterpToLen(arr, targetLen);
+
+        private static double[] InterpToLenWithPad(double[] arr, int targetLen)
+            => Interpolation.InterpToLen(arr, targetLen);
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/Engine/Pipeline/SynthesisEngine.cs
+++ b/OpenUtau.Core/HiFiUtau/Engine/Pipeline/SynthesisEngine.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NAudio.Wave;
+using OpenUtau.Core.HiFiUtau.Engine.Dsp;
+using Newtonsoft.Json.Linq;
+
+namespace OpenUtau.Core.HiFiUtau.Engine.Pipeline {
+    /// <summary>
+    /// synthesis_pipeline/engine.py 的移植：三段式合成编排。
+    /// SynthesizeMel  ≙ POST /syn_mel
+    /// SynthesizeHnsep ≙ POST /syn_hnsep
+    /// SynthesizePost ≙ POST /syn_post
+    /// </summary>
+    public sealed class SynthesisEngine {
+        private readonly HiddenSplicer splicer;
+        private readonly Hnsep? hnsep;
+        private readonly MelExtractor melExc;
+
+        public SynthesisEngine(HiddenSplicer splicer, Hnsep? hnsep, MelExtractor melExc) {
+            this.splicer = splicer;
+            this.hnsep = hnsep;
+            this.melExc = melExc;
+        }
+
+        public int FrontPadFrames => splicer.FrontPadFrames;
+        public int TailPadFrames => splicer.TailPadFrames;
+        public int ModelHop => splicer.ModelHop;
+        public int SampleRate => splicer.SampleRate;
+        public Hnsep? HnsepModel => hnsep;
+
+        /// <summary>engine.py _build_fragment：按 SPLC 选择管线（仅解析参数/包络/F0，不切音频）。</summary>
+        private PhraseData ParseFragment(JObject jsonData) {
+            return PhraseData.Parse(jsonData);
+        }
+
+        /// <summary>engine.py _build_fragment + frag.cut_audio：mel 阶段专用（后处理不执行 cut_audio）。</summary>
+        private (bool useMel, PhraseData phrase) BuildFragment(JObject jsonData) {
+            var phrase = PhraseData.Parse(jsonData);
+            if (melExc != null) {
+                FragmentMel.CutAudio(phrase, melExc);
+            }
+            return (melExc != null, phrase);
+        }
+
+        /// <summary>engine.py _prepare_mel：phtp → genc → VOL → F0 重采样。</summary>
+        public (PhraseData phrase, double[] f0, bool isMel) PrepareMel(JObject jsonData) {
+            var (useMel, phrase) = BuildFragment(jsonData);
+            if (useMel) {
+                FragmentMel.AdjustVolumeByPhtp(phrase);
+                FragmentMel.ApplyDynamicGenToMels(phrase);
+            } else {
+                Fragment.AdjustVolumeByPhtp(phrase, Fragment.MsPerFrame);
+                Fragment.ApplyDynamicGenToMels(phrase);
+            }
+
+            // VOL：mel += log(gain)
+            foreach (var info in phrase.Phones) {
+                double vol = info.Flag("vol", 100);
+                double gain = vol / 100.0;
+                if (Math.Abs(gain - 1.0) > 1e-6 && info.Mel != null && info.MelFrames > 0) {
+                    double logGain = Math.Log(gain);
+                    for (int i = 0; i < info.Mel.Length; i++) info.Mel[i] += logGain;
+                }
+            }
+
+            double[] f0 = phrase.GetParam("pit", "pitd");
+            f0 = Interpolation.ResampleArray(f0, phrase.HopSize, 512);
+            return (phrase, f0, useMel);
+        }
+
+        /// <summary>engine.py _synthesize_hifigan。</summary>
+        private float[] SynthesizeHifigan(PhraseData phrase, double[] f0, bool isMelPipeline) {
+            _ = isMelPipeline;
+            return splicer.SpliceAndSynthesizeMel(phrase.Phones, f0);
+        }
+
+        /// <summary>POST /syn_mel 等价：mel 拼接 + genc + HiFi-GAN → PCM16 WAV 字节。</summary>
+        public byte[] SynthesizeMel(JObject jsonData) {
+            var (phrase, f0, isMel) = PrepareMel(jsonData);
+            var wav = SynthesizeHifigan(phrase, f0, isMel);
+            return WavBytes(wav);
+        }
+
+        /// <summary>POST /syn_hnsep 等价：谐波/噪声分离 → (harmonic, noise) PCM16 WAV 字节。</summary>
+        public (byte[] harmonic, byte[] noise) SynthesizeHnsep(byte[] wavBytes) {
+            if (hnsep == null) {
+                throw new InvalidOperationException(
+                    "当前合成使用了依赖 HN-SEP 的参数，但 HN-SEP 模型未加载。");
+            }
+            var wav = WavToSamples(wavBytes);
+            var (harmonic, noise) = hnsep.Separate(wav);
+            return (WavBytes(ToFloat(harmonic)), WavBytes(ToFloat(noise)));
+        }
+
+        /// <summary>POST /syn_post 等价：参数应用 → 最终 PCM16 WAV 字节。</summary>
+        public byte[] SynthesizePost(JObject jsonData, byte[]? wavBytes,
+                                     byte[]? harmonicBytes, byte[]? noiseBytes) {
+            // engine.py synthesize_post：仅解析参数/包络/F0，不执行 cut_audio
+            var phrase = ParseFragment(jsonData);
+            float[]? wav = null;
+            float[]? harmonic = null;
+            float[]? noise = null;
+            if (harmonicBytes != null && noiseBytes != null) {
+                harmonic = WavToSamples(harmonicBytes);
+                noise = WavToSamples(noiseBytes);
+            } else if (wavBytes != null) {
+                wav = WavToSamples(wavBytes);
+            } else {
+                throw new ArgumentException("SynthesizePost 必须提供 wavBytes 或 (harmonicBytes, noiseBytes)");
+            }
+            return PostProcess(wav, harmonic, noise, phrase);
+        }
+
+        /// <summary>soundfile 'PCM_16' 编码语义（libsndfile: lrint(v*32768) 后截断饱和）。</summary>
+        public static byte[] WavBytes(float[] samples) {
+            var wav = new MemoryStream();
+            using (var w = new NAudio.Wave.WaveFileWriter(new NAudio.Utils.IgnoreDisposeStream(wav),
+                       new NAudio.Wave.WaveFormat(44100, 16, 1))) {
+                foreach (var s in samples) {
+                    double v = Math.Round((double)s * 32768.0, MidpointRounding.ToEven);
+                    short pcm = (short)Math.Clamp(v, short.MinValue, short.MaxValue);
+                    var bytes = BitConverter.GetBytes(pcm);
+                    w.Write(bytes, 0, 2);
+                }
+            }
+            return wav.ToArray();
+        }
+
+        internal static float[] ToFloat(double[] x) {
+            var f = new float[x.Length];
+            for (int i = 0; i < x.Length; i++) f[i] = (float)x[i];
+            return f;
+        }
+
+        /// <summary>soundfile.read(dtype='float32') 语义。</summary>
+        public static float[] WavToSamples(byte[] wavBytes) {
+            using var ms = new MemoryStream(wavBytes);
+            using var reader = new NAudio.Wave.WaveFileReader(ms);
+            var provider = reader.ToSampleProvider().ToMono(1, 0);
+            var list = new List<float>(wavBytes.Length / 2);
+            var buffer = new float[8192];
+            int read;
+            while ((read = provider.Read(buffer, 0, buffer.Length)) > 0) {
+                for (int i = 0; i < read; i++) list.Add(buffer[i]);
+            }
+            return list.ToArray();
+        }
+
+        /// <summary>engine.py _postprocess —— M3 实现。</summary>
+        private byte[] PostProcess(float[]? wav, float[]? harmonic, float[]? noise, PhraseData phrase) {
+            return PostProcessing.Postprocess(this, wav, harmonic, noise, phrase);
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/HiFiUtauModelStore.cs
+++ b/OpenUtau.Core/HiFiUtau/HiFiUtauModelStore.cs
@@ -1,0 +1,296 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.ML.OnnxRuntime;
+using OpenUtau.Core.HiFiUtau.Engine.Pipeline;
+using OpenUtau.Core.Util;
+using Serilog;
+
+namespace OpenUtau.Core.HiFiUtau {
+    /// <summary>
+    /// 内嵌 HiFiUTAU 引擎的模型定位与加载（进程内推理，无需 Python/HTTP）。
+    ///
+    /// 两款模型独立加载：
+    ///   - 声码器：只接受 OpenUtau vocoder oudep 布局（vocoder.yaml + ONNX），
+    ///     默认 id <c>pc_nsf_hifigan_44.1k_hop512_128bin_2025.02</c>。不加载 part1/part2，也不加载 PyTorch ckpt。
+    ///   - 分离模型：只接受 HN-SEP oudep 布局（oudep.yaml + ONNX），
+    ///     默认 id <c>hnsep_VR_44.1k_hop512_2024.05</c>。
+    /// 探测：偏好设置路径（须为 oudep 解包目录）→ Dependencies 已安装 oudep。
+    /// ONNX 会话经 Util.Onnx 创建（复用"渲染"设置中的 CPU/DirectML 运行时选择），
+    /// 并应用偏好中的推理线程数。
+    /// 模型缺失时不做任何回退——由渲染器抛出明确错误；HTTP 仅属于 Custom Server 渲染器。
+    /// </summary>
+    public sealed class HiFiUtauModelStore {
+        private static readonly Lazy<HiFiUtauModelStore> lazy = new(() => new HiFiUtauModelStore());
+        public static HiFiUtauModelStore Inst => lazy.Value;
+
+        private readonly object loadLock = new();          // 保护懒加载与重载
+        /// <summary>引擎推理串行化锁（重载时也持有它，保证在途渲染完成后再释放旧会话）。</summary>
+        public readonly object EngineLock = new object();
+
+        private HiddenSplicer? splicer;
+        private Hnsep? hnsep;
+        private SynthesisEngine? engine;
+
+        public string? SplicerDir { get; private set; }
+        public string? HnsepDir { get; private set; }
+        public bool SplicerReady => splicer != null;
+        public bool HnsepReady => hnsep != null;
+        public bool EngineReady => engine != null;
+        public string? SplicerError { get; private set; }
+        public string? HnsepError { get; private set; }
+
+        /// <summary>svs-index 上的 PC-NSF-HiFiGAN 2025.02 vocoder oudep id。</summary>
+        public const string PcNsfHifiGanOudepId = "pc_nsf_hifigan_44.1k_hop512_128bin_2025.02";
+
+        /// <summary>WORLDLINE-R2 使用的旧目录名，部分安装仍是这个 id。</summary>
+        public const string PcNsfHifiGanLegacyOudepId = "pc-nsf-hifigan";
+
+        /// <summary>HN-SEP VR 2024.05 oudep id（yxlllc/vocal-remover hnsep_240512）。</summary>
+        public const string HnsepOudepId = "hnsep_VR_44.1k_hop512_2024.05";
+
+        private HiFiUtauModelStore() { }
+
+        // ── 目录探测 ──
+
+        public static bool IsValidVocoderOudepDir(string dir) {
+            if (!File.Exists(Path.Combine(dir, "vocoder.yaml"))) {
+                return false;
+            }
+            try {
+                var cfg = ReadVocoderYaml(dir);
+                return File.Exists(Path.Combine(dir, cfg.Model));
+            } catch {
+                return false;
+            }
+        }
+
+        public static bool LooksLikePytorchCkptDir(string dir)
+            => File.Exists(Path.Combine(dir, "model.ckpt"))
+            && (File.Exists(Path.Combine(dir, "config.json"))
+                || File.Exists(Path.Combine(dir, "config.yaml")));
+
+        static FusedVocoderYaml ReadVocoderYaml(string dir) {
+            var cfg = Yaml.DefaultDeserializer.Deserialize<FusedVocoderYaml>(
+                File.ReadAllText(Path.Combine(dir, "vocoder.yaml")));
+            if (string.IsNullOrEmpty(cfg.Model)) {
+                cfg.Model = "model.onnx";
+            }
+            return cfg;
+        }
+
+        public static bool IsValidHnsepOudepDir(string dir) {
+            if (!File.Exists(Path.Combine(dir, "oudep.yaml"))) {
+                return false;
+            }
+            return Directory.GetFiles(dir, "*.onnx").Length > 0;
+        }
+
+        /// <summary>解析声码器目录（偏好设置覆盖 → 已安装 vocoder oudep）。</summary>
+        public string? FindSplicerDir() {
+            string? custom = Preferences.Default.HifiUtauSplicerPath;
+            if (!string.IsNullOrWhiteSpace(custom)) {
+                return IsValidVocoderOudepDir(custom) ? custom : null;
+            }
+            foreach (string id in new[] { PcNsfHifiGanOudepId, PcNsfHifiGanLegacyOudepId }) {
+                string? installed = PackageManager.Inst.GetInstalledPath(id);
+                if (!string.IsNullOrEmpty(installed) && IsValidVocoderOudepDir(installed)) {
+                    return installed;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>解析分离模型目录（偏好设置覆盖 → 已安装 HN-SEP oudep）。</summary>
+        public string? FindHnsepDir() {
+            string? custom = Preferences.Default.HifiUtauHnsepPath;
+            if (!string.IsNullOrWhiteSpace(custom)) {
+                return IsValidHnsepOudepDir(custom) ? custom : null;
+            }
+            string? installed = PackageManager.Inst.GetInstalledPath(HnsepOudepId);
+            if (!string.IsNullOrEmpty(installed) && IsValidHnsepOudepDir(installed)) {
+                return installed;
+            }
+            return null;
+        }
+
+        // ── 懒加载 ──
+
+        /// <summary>
+        /// 获取内嵌引擎；任一模型缺失或加载失败返回 null（渲染器应抛出明确错误）。
+        /// 线程安全；模型仅加载一次。
+        /// </summary>
+        public SynthesisEngine? GetEngine() {
+            if (engine != null) return engine;
+            lock (loadLock) {
+                if (engine != null) return engine;
+                var s = GetSplicer();
+                if (s == null) return null;
+                var h = GetHnsep();
+                if (h == null) return null;
+                engine = new SynthesisEngine(s, h, new MelExtractor());
+                Log.Information("HiFiUTAU 内嵌引擎就绪");
+                return engine;
+            }
+        }
+
+        private HiddenSplicer? GetSplicer() {
+            if (splicer != null) return splicer;
+            lock (loadLock) {
+                if (splicer != null) return splicer;
+                try {
+                    string? dir = FindSplicerDir();
+                    if (dir == null) {
+                        SplicerDir = null;
+                        string custom = Preferences.Default.HifiUtauSplicerPath;
+                        if (!string.IsNullOrWhiteSpace(custom) && LooksLikePytorchCkptDir(custom)) {
+                            SplicerError = "该目录是 PC-NSF-HiFiGAN 的 PyTorch ckpt 包（model.ckpt）。进程内 HiFiUTAU 只加载 OpenUtau vocoder oudep（vocoder.yaml + ONNX）。请用包管理器安装 pc_nsf_hifigan_44.1k_hop512_128bin_2025.02。";
+                        } else {
+                            SplicerError = "未找到声码器。请在包管理器安装 pc_nsf_hifigan_44.1k_hop512_128bin_2025.02。";
+                        }
+                        Log.Warning("HiFiUTAU 内嵌引擎：{err}", SplicerError);
+                        return null;
+                    }
+                    SplicerDir = dir;
+                    Log.Information("HiFiUTAU 内嵌引擎：加载声码器 {dir}", dir);
+                    splicer = LoadSplicer(dir);
+                    SplicerError = null;
+                } catch (Exception e) {
+                    SplicerError = e.Message;
+                    Log.Error(e, "HiFiUTAU 内嵌引擎：拼接模型加载失败");
+                }
+                return splicer;
+            }
+        }
+
+        private Hnsep? GetHnsep() {
+            if (hnsep != null) return hnsep;
+            lock (loadLock) {
+                if (hnsep != null) return hnsep;
+                try {
+                    string? dir = FindHnsepDir();
+                    if (dir == null) {
+                        HnsepDir = null;
+                        HnsepError = "未找到 HN-SEP。请在包管理器安装 hnsep_VR_44.1k_hop512_2024.05。";
+                        Log.Warning("HiFiUTAU 内嵌引擎：{err}", HnsepError);
+                        return null;
+                    }
+                    HnsepDir = dir;
+                    string modelPath = PickHnsepModel(dir);
+                    Log.Information("HiFiUTAU 内嵌引擎：加载分离模型 {model}", modelPath);
+                    hnsep = new Hnsep(modelPath, CreateSession);
+                    HnsepError = null;
+                } catch (Exception e) {
+                    HnsepError = e.Message;
+                    Log.Error(e, "HiFiUTAU 内嵌引擎：分离模型加载失败");
+                }
+                return hnsep;
+            }
+        }
+
+        HiddenSplicer LoadSplicer(string dir) {
+            var cfg = ReadVocoderYaml(dir);
+            string modelPath = Path.Combine(dir, cfg.Model);
+            var session = CreateSession(modelPath);
+            return new HiddenSplicer(session, cfg.HopSize, cfg.SampleRate, cfg.NumMelBins);
+        }
+
+        private InferenceSession CreateSession(string path) {
+            return Onnx.getInferenceSession(path, OnnxRunnerChoice.Default, so => {
+                int threads = Preferences.Default.HifiUtauIntraOpThreads;
+                if (threads > 0) {
+                    so.IntraOpNumThreads = threads;
+                }
+            });
+        }
+
+        private static string PickHnsepModel(string hnsepDir) {
+            var pt2 = Directory.GetFiles(hnsepDir, "*.pt2.onnx").FirstOrDefault();
+            if (pt2 != null) return pt2;
+            return Directory.GetFiles(hnsepDir, "*.onnx").FirstOrDefault()
+                ?? throw new FileNotFoundException($"hnsep 目录下未找到 ONNX 模型: {hnsepDir}");
+        }
+
+        // ── 预热与重载 ──
+
+        /// <summary>预热：阻塞式加载全部模型（启动预热在后台线程调用）。</summary>
+        public void PreloadAll() {
+            lock (EngineLock) {
+                GetEngine();
+            }
+        }
+
+        /// <summary>重载整个引擎（两款模型），并清空渲染缓存。</summary>
+        public void ReloadAll() {
+            lock (EngineLock) {
+                lock (loadLock) {
+                    ResetSplicer();
+                    ResetHnsep();
+                    engine = null;   // 必须置空，否则 GetEngine 会返回包装着已释放会话的旧引擎
+                }
+                GetEngine();
+                ClearCache();
+            }
+        }
+
+        /// <summary>仅重载拼接模型，并清空渲染缓存。</summary>
+        public void ReloadSplicer() {
+            lock (EngineLock) {
+                lock (loadLock) {
+                    ResetSplicer();
+                    engine = null;
+                }
+                GetEngine();
+                ClearCache();
+            }
+        }
+
+        /// <summary>仅重载分离模型，并清空渲染缓存。</summary>
+        public void ReloadHnsep() {
+            lock (EngineLock) {
+                lock (loadLock) {
+                    ResetHnsep();
+                    engine = null;
+                }
+                GetEngine();
+                ClearCache();
+            }
+        }
+
+        private void ResetSplicer() {
+            splicer?.Dispose();
+            splicer = null;
+            SplicerError = null;
+        }
+
+        private void ResetHnsep() {
+            hnsep?.Dispose();
+            hnsep = null;
+            HnsepError = null;
+        }
+
+        /// <summary>清空三段式渲染缓存（重载后模型内容可能已变化，缓存键不含模型哈希）。</summary>
+        private static void ClearCache() {
+            try {
+                string root = Path.Combine(PathManager.Inst.CachePath, "hifiutau");
+                if (Directory.Exists(root)) {
+                    Directory.Delete(root, true);
+                }
+                foreach (var sub in new[] { "hifigan", "hnsep", "final" }) {
+                    Directory.CreateDirectory(Path.Combine(root, sub));
+                }
+                Log.Information("HiFiUTAU：渲染缓存已清空");
+            } catch (Exception e) {
+                Log.Error(e, "HiFiUTAU：清空渲染缓存失败");
+            }
+        }
+
+        /// <summary>vocoder.yaml 子集，避免 HiFi 依赖 DiffSinger 类型。</summary>
+        class FusedVocoderYaml {
+            public string Model { get; set; } = "model.onnx";
+            public int SampleRate { get; set; } = 44100;
+            public int HopSize { get; set; } = 512;
+            public int NumMelBins { get; set; } = 128;
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/HifiF0Utils.cs
+++ b/OpenUtau.Core/HiFiUtau/HifiF0Utils.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+
+namespace OpenUtau.Core.HiFiUtau {
+    /// <summary>
+    /// 曲线采样工具（由原 CustomRender.CustomF0Utils 迁移，独立于 CustomRenderer）。
+    /// </summary>
+    public static class HifiF0Utils {
+        private const int Interval = 5;
+
+        /// <summary>
+        /// OpenUtau 标准曲线的默认值映射表（abbr -> defaultValue）。
+        /// 对应 Format.Ustx.AddDefaultExpressions 中的配置。
+        /// 注意：dyn（动态曲线）和 shfc（音高偏移曲线）不作为公共字段暴露，
+        /// 需要通过 RenderPhrase.curves 或修改 RenderPhrase 访问。
+        /// </summary>
+        private static readonly Dictionary<string, double> CurveDefaults = new Dictionary<string, double> {
+            { "genc", 0 },
+            { "brec", 0 },
+            { "tenc", 0 },
+            { "voic", 100 },
+            { "lowc", 0 },
+            { "hcmp", 0 },
+            { "brel", 0 },
+            { "breh", 0 },
+        };
+
+        /// <summary>
+        /// 自动发现 RenderPhrase 中所有曲线并采样到目标帧率。
+        /// 返回字典（abbr -> double[]），包含所有标准曲线和自定义曲线。
+        /// </summary>
+        public static Dictionary<string, double[]> SampleAllCurves(
+            RenderPhrase phrase,
+            double frameMs,
+            int totalFrames) {
+            var result = new Dictionary<string, double[]>();
+
+            // 定义标准曲线映射：abbr -> (hasData函数, 采样函数)
+            // 注意：dyn（动态曲线）和 shfc（音高偏移曲线）存储在 RenderPhrase 内部，
+            // 不作为公共字段暴露，因此无法在此采样。
+            // 若需要它们，可在 RenderPhrase 中添加公共访问器。
+            var standardCurves = new (string abbr, Func<bool> hasData, Func<int, double> sample)[] {
+                ("pitd",
+                    () => phrase.pitches != null && phrase.pitches.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        int idx = ClampIndex(ticks, phrase.pitches!.Length);
+                        return MusicMath.ToneToFreq(phrase.pitches[idx] * 0.01);
+                    }),
+                ("genc",
+                    () => phrase.gender != null && phrase.gender.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.gender![ClampIndex(ticks, phrase.gender.Length)];
+                    }),
+                ("brec",
+                    () => phrase.breathiness != null && phrase.breathiness.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.breathiness![ClampIndex(ticks, phrase.breathiness.Length)];
+                    }),
+                ("tenc",
+                    () => phrase.tension != null && phrase.tension.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.tension![ClampIndex(ticks, phrase.tension.Length)];
+                    }),
+                ("voic",
+                    () => phrase.voicing != null && phrase.voicing.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.voicing![ClampIndex(ticks, phrase.voicing.Length)];
+                    }),
+                ("lowc",
+                    () => phrase.lowcut != null && phrase.lowcut.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.lowcut![ClampIndex(ticks, phrase.lowcut.Length)];
+                    }),
+                ("warm",
+                    () => phrase.warmth != null && phrase.warmth.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.warmth![ClampIndex(ticks, phrase.warmth.Length)];
+                    }),
+                ("hcmp",
+                    () => phrase.hcmp != null && phrase.hcmp.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.hcmp![ClampIndex(ticks, phrase.hcmp.Length)];
+                    }),
+                ("brel",
+                    () => phrase.breathLow != null && phrase.breathLow.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.breathLow![ClampIndex(ticks, phrase.breathLow.Length)];
+                    }),
+                ("breh",
+                    () => phrase.breathHigh != null && phrase.breathHigh.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.breathHigh![ClampIndex(ticks, phrase.breathHigh.Length)];
+                    }),
+            };
+
+            // 采样所有标准曲线
+            foreach (var (abbr, hasData, sample) in standardCurves) {
+                if (!hasData()) {
+                    continue;
+                }
+                var curve = new double[totalFrames];
+                for (int i = 0; i < totalFrames; i++) {
+                    curve[i] = sample(i);
+                }
+                result[abbr] = curve;
+            }
+
+            // 采样自定义曲线（由 renderer 自定义的额外曲线）
+            if (phrase.curves != null) {
+                foreach (var tuple in phrase.curves) {
+                    if (tuple.Item2 == null || tuple.Item2.Length == 0) {
+                        continue;
+                    }
+                    var curve = new double[totalFrames];
+                    for (int i = 0; i < totalFrames; i++) {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        curve[i] = tuple.Item2[ClampIndex(ticks, tuple.Item2.Length)];
+                    }
+                    result[tuple.Item1] = curve;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 为指定音素范围内的曲线采样。
+        /// 返回字典（abbr -> double[]），长度为该音素内的帧数。
+        /// </summary>
+        public static Dictionary<string, double[]> SampleCurvesForPhoneme(
+            RenderPhrase phrase,
+            RenderPhone phone,
+            int phoneIndex,
+            double frameMs,
+            int totalFrames) {
+            var result = new Dictionary<string, double[]>();
+
+            // 计算该音素在全局帧范围内的起始和结束帧索引
+            // phrase 的第 0 帧对应绝对时间 (phrase.positionMs - phrase.leadingMs)
+            double phraseBaseMs = phrase.positionMs - phrase.leadingMs;
+            double phoneStartMs = phone.positionMs - phone.leadingMs;
+            double phoneEndMs = phone.endMs;
+
+            int startFrame = Math.Max(0, (int)((phoneStartMs - phraseBaseMs) / frameMs));
+            int endFrame = Math.Min(totalFrames, (int)Math.Ceiling((phoneEndMs - phraseBaseMs) / frameMs));
+            int phoneFrames = Math.Max(1, endFrame - startFrame);
+
+            // 标准曲线（逐音素只保留 genc，其他曲线在全局层面传递）
+            var standardCurves = new (string abbr, Func<bool> hasData, Func<int, double> sample)[] {
+                ("genc",
+                    () => phrase.gender != null && phrase.gender.Length > 0,
+                    i => {
+                        int ticks = GetTicks(phrase, i, frameMs);
+                        return phrase.gender![ClampIndex(ticks, phrase.gender.Length)];
+                    }),
+            };
+
+            foreach (var (abbr, hasData, sample) in standardCurves) {
+                if (!hasData()) {
+                    continue;
+                }
+                var curve = new double[phoneFrames];
+                for (int i = 0; i < phoneFrames; i++) {
+                    int globalIdx = startFrame + i;
+                    if (globalIdx < totalFrames) {
+                        curve[i] = sample(globalIdx);
+                    } else {
+                        curve[i] = sample(totalFrames - 1);
+                    }
+                }
+                result[abbr] = curve;
+            }
+
+            // 自定义曲线
+            if (phrase.curves != null) {
+                foreach (var tuple in phrase.curves) {
+                    if (tuple.Item2 == null || tuple.Item2.Length == 0) {
+                        continue;
+                    }
+                    var curve = new double[phoneFrames];
+                    for (int i = 0; i < phoneFrames; i++) {
+                        int globalIdx = startFrame + i;
+                        if (globalIdx < totalFrames) {
+                            int ticks = GetTicks(phrase, globalIdx, frameMs);
+                            curve[i] = tuple.Item2[ClampIndex(ticks, tuple.Item2.Length)];
+                        } else {
+                            int ticks = GetTicks(phrase, totalFrames - 1, frameMs);
+                            curve[i] = tuple.Item2[ClampIndex(ticks, tuple.Item2.Length)];
+                        }
+                    }
+                    result[tuple.Item1] = curve;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 判断单条曲线是否全部为默认值。
+        /// pitd（音高偏差）永远视为有用，始终返回 false。
+        /// 未知曲线回退默认值 0。
+        /// </summary>
+        public static bool IsCurveDefault(string abbr, double[] curve) {
+            if (abbr == "pitd") {
+                return false; // pitd 永远有用
+            }
+            if (curve == null || curve.Length == 0) {
+                return true;
+            }
+            double defaultValue = CurveDefaults.TryGetValue(abbr, out var def) ? def : 0.0;
+            foreach (var v in curve) {
+                if (v != defaultValue) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// 检查所有曲线是否均为默认值。
+        /// </summary>
+        public static bool AllCurvesDefault(Dictionary<string, double[]> curves) {
+            if (curves == null || curves.Count == 0) {
+                return true;
+            }
+            foreach (var kvp in curves) {
+                if (!IsCurveDefault(kvp.Key, kvp.Value)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetTicks(RenderPhrase phrase, int frameIndex, double frameMs) {
+            double posMs = GetFramePositionMs(phrase, frameIndex, frameMs);
+            double positionOffset = phrase.position - phrase.leading;
+            return (int)(phrase.timeAxis.MsPosToTickPos(posMs) - positionOffset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ClampIndex(int ticks, int length) {
+            return Math.Max(0, Math.Min(length - 1, ticks / Interval));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static double GetFramePositionMs(RenderPhrase phrase, int frameIndex, double frameMs) {
+            double positionMs = phrase.positionMs + frameIndex * frameMs;
+
+            if (phrase.phones.Length == 0) {
+                return positionMs;
+            }
+
+            var firstPhone = phrase.phones[0];
+            if (firstPhone.envelope.Length >= 2) {
+                double preutter = -firstPhone.envelope[0].X;
+                if (preutter > 0) {
+                    return positionMs - preutter;
+                }
+            }
+
+            return positionMs;
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/HifiUtauPhraseJson.cs
+++ b/OpenUtau.Core/HiFiUtau/HifiUtauPhraseJson.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+
+namespace OpenUtau.Core.HiFiUtau {
+    /// <summary>
+    /// 将 RenderPhrase 转换为 HiFiUTAU 内嵌引擎所需的音素 JSON。
+    /// 独立于 Custom Server，可单独维护。
+    /// </summary>
+    public static class HifiUtauPhraseJson {
+        /// <summary>
+        /// 构建完整音素 JSON（hop_size/frame_ms/phoneme_list/Dynamic_parameter）。
+        /// out_wav 由渲染器覆盖为三段式缓存路径。
+        /// </summary>
+        public static JObject Build(RenderPhrase phrase) {
+            // 帧移参数：hop_size=256，对应~5.8ms/帧
+            const int hopSize = 256;
+            const int sampleRate = 44100;
+            double frameMs = 1000.0 * hopSize / sampleRate;
+
+            // 计算目标帧数，考虑leadingMs前导时间
+            int totalFrames = (int)Math.Ceiling((phrase.durationMs + phrase.leadingMs) / frameMs);
+
+            // === 全局曲线（供兼容性使用） ===
+            var curves = HifiF0Utils.SampleAllCurves(phrase, frameMs, totalFrames);
+
+            // === 动态参数：无论是否默认值，始终写入实际数值 ===
+            var dynamicParam = new Dictionary<string, object?>();
+
+            // 已知的标准曲线
+            var knownCurves = new[] { "pitd", "genc", "brec", "tenc", "voic", "lowc", "brel", "breh" };
+            foreach (var abbr in knownCurves) {
+                if (curves.TryGetValue(abbr, out var data)) {
+                    dynamicParam[abbr] = data;
+                }
+            }
+
+            // 自定义曲线
+            foreach (var kvp in curves) {
+                if (Array.IndexOf(knownCurves, kvp.Key) >= 0) {
+                    continue;
+                }
+                dynamicParam[kvp.Key] = kvp.Value;
+            }
+
+            // === 构建逐音素曲线列表（嵌入每个音素） ===
+            var perPhonemeCurves = new Dictionary<string, Dictionary<string, double[]>>();
+            for (int i = 0; i < phrase.phones.Length; i++) {
+                var phone = phrase.phones[i];
+                var curvesForPhone = HifiF0Utils.SampleCurvesForPhoneme(
+                    phrase, phone, i, frameMs, totalFrames);
+                perPhonemeCurves[(i + 1).ToString()] = curvesForPhone;
+            }
+
+            // === 构建音素列表（每个音素自带曲线） ===
+            var phonemeList = BuildPhonemeList(phrase, perPhonemeCurves);
+
+            var jsonData = new {
+                hop_size = hopSize,
+                sample_rate = sampleRate,
+                frame_ms = frameMs,
+                out_wav = Path.Join(PathManager.Inst.CachePath, "hifiutau", $"phrase-{phrase.hash:x16}.wav"),
+                wav_dur = phrase.durationMs,
+                phoneme_list = phonemeList,
+                Dynamic_parameter = dynamicParam,
+            };
+
+            return JObject.FromObject(jsonData);
+        }
+
+        /// <summary>
+        /// 构建音素列表，每个音素包含所有 flags、标准属性和逐音素动态参数曲线。
+        /// </summary>
+        private static Dictionary<string, object> BuildPhonemeList(
+            RenderPhrase phrase,
+            Dictionary<string, Dictionary<string, double[]>> perPhonemeCurves) {
+            var phonemeList = new Dictionary<string, object>();
+
+            for (int i = 0; i < phrase.phones.Length; i++) {
+                var phone = phrase.phones[i];
+                var envelope = phone.envelope;
+                var key = (i + 1).ToString();
+
+                // 自动收集所有 flags：标准属性 + phoneme.flags（来自项目表达式）
+                var noteFlags = new Dictionary<string, object> {
+                    { "vel", phone.velocity * 100.0 },
+                    { "vol", phone.volume * 100.0 },
+                    { "mod", phone.modulation * 100.0 },
+                    { "shft", phone.toneShift },
+                    { "phtp", phone.phonemeType },
+                    { "strt", phone.stretchMode },
+                    { "splc", phone.spliceMode },
+                    { "stms", phone.stretchMs },
+                    { "S", phone.stretchMs }
+                };
+                foreach (var flag in phone.flags) {
+                    // flag: Tuple<flagName, int?, abbr>
+                    noteFlags[flag.Item1] = flag.Item2 ?? 0;
+                }
+
+                float p3X, p3Y, p4X, p4Y;
+
+                if (i < phrase.phones.Length - 1) {
+                    var nextPhone = phrase.phones[i + 1];
+                    var nextEnvelope = nextPhone.envelope;
+
+                    var nextPreutter = -nextEnvelope[0].X;
+                    var nextOverlap = nextEnvelope[1].X - nextEnvelope[0].X;
+                    var tailIntrude = Math.Max(nextPreutter, nextPreutter - nextOverlap);
+                    var tailOverlap = Math.Max(nextOverlap, 0);
+
+                    p3X = (float)(phone.durationMs - tailIntrude);
+                    p4X = (float)(p3X + tailOverlap);
+                    p3Y = envelope[3].Y;
+                    p4Y = envelope[4].Y;
+                } else {
+                    p3X = envelope[3].X;
+                    p3Y = envelope[3].Y;
+                    p4X = envelope[4].X;
+                    p4Y = envelope[4].Y;
+                }
+
+                // 逐音素动态参数曲线
+                Dictionary<string, double[]>? phonemeDynamicParams = null;
+                if (perPhonemeCurves.TryGetValue(key, out var curves) && curves != null && curves.Count > 0) {
+                    phonemeDynamicParams = curves;
+                }
+
+                var phonemeData = new {
+                    phoneme_name = phone.phoneme,
+                    note_pitch = MusicMath.GetToneName(phone.tone),
+                    dur = envelope[4].X,
+                    Note_flags = noteFlags,
+                    phoneme_oto = new {
+                        audio_file_path = phone.oto?.File ?? "",
+                        Offset = phone.oto?.Offset ?? 0.0,
+                        Consonant = phone.oto?.Consonant ?? 0.0,
+                        Cutoff = phone.oto?.Cutoff ?? 0.0,
+                        Preutter = phone.oto?.Preutter ?? 0.0,
+                        Overlap = phone.oto?.Overlap ?? 0.0,
+                    },
+                    envelope = new {
+                        p0 = new { x = envelope[0].X, y = envelope[0].Y },
+                        p1 = new { x = envelope[1].X, y = envelope[1].Y },
+                        p2 = new { x = envelope[2].X, y = envelope[2].Y },
+                        p3 = new { x = p3X, y = p3Y },
+                        p4 = new { x = p4X, y = p4Y }
+                    },
+                    Dynamic_parameter = phonemeDynamicParams
+                };
+                phonemeList[key] = phonemeData;
+            }
+
+            return phonemeList;
+        }
+    }
+}

--- a/OpenUtau.Core/HiFiUtau/HifiUtauRenderer.cs
+++ b/OpenUtau.Core/HiFiUtau/HifiUtauRenderer.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using K4os.Hash.xxHash;
+using NAudio.Wave;
+using Newtonsoft.Json.Linq;
+using OpenUtau.Core;
+using OpenUtau.Core.Format;
+using OpenUtau.Core.HiFiUtau.Engine.Pipeline;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+using Serilog;
+
+namespace OpenUtau.Core.HiFiUtau {
+    /// <summary>
+    /// HiFiUTAU 渲染器 — 内嵌引擎（进程内 ONNX 推理）+ 三级缓存（hifigan / hnsep / final）。
+    ///
+    /// 管线三段（对应原 HTTP 端点 /syn_mel、/syn_hnsep、/syn_post，现为进程内调用）：
+    ///   1. mel 拼接 + 变调(genc) + HiFi-GAN → 缓存 hifiutau/hifigan/{hifiganHash}.wav
+    ///   2. HN-SEP 气声/谐波分离            → 缓存 hifiutau/hnsep/{hifiganHash}.{harmonic,noise}.wav
+    ///   3. 参数应用                        → 缓存 hifiutau/final/{finalHash}.wav
+    ///
+    /// 缓存命中规则：
+    ///   - final 命中 → 直接使用（最快）
+    ///   - 修改旋律/歌词/变调 → 只重算 hifigan（hnsep/final 哈希随 hifigan 变化）
+    ///   - 修改参数（但 hifigan 不变）→ hnsep 缓存直接命中，只重算 post
+    ///   - 所有 HN-SEP 相关参数均为默认值 → 完全跳过分离
+    ///
+    /// 本渲染器不回退到 HTTP——模型缺失或内嵌引擎被禁用时抛出明确错误；
+    /// HTTP 仅属于 Custom Server 渲染器。
+    /// </summary>
+    public class HifiUtauRenderer : IRenderer {
+        // 基于 phrase.hash 的互斥锁，防止相同内容并发重复提交
+        private static readonly ConcurrentDictionary<ulong, SemaphoreSlim> _hashLocks =
+            new ConcurrentDictionary<ulong, SemaphoreSlim>();
+
+        public HifiUtauRenderer() {
+        }
+
+        public USingerType SingerType => USingerType.Classic;
+
+        public bool SupportsRenderPitch => false;
+
+        public bool SupportsExpression(UExpressionDescriptor descriptor) {
+            return true;
+        }
+
+        public RenderResult Layout(RenderPhrase phrase) {
+            return new RenderResult() {
+                leadingMs = phrase.leadingMs,
+                positionMs = phrase.positionMs,
+                estimatedLengthMs = phrase.durationMs + phrase.leadingMs,
+            };
+        }
+
+        public Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo,
+            CancellationTokenSource cancellation, bool isPreRender = false, RenderPhraseEvents? renderEvents = null) {
+            return RenderImpl(phrase, progress, trackNo, cancellation, isPreRender);
+        }
+
+        internal async Task<RenderResult> RenderImpl(RenderPhrase phrase, Progress progress, int trackNo,
+            CancellationTokenSource cancellation, bool isPreRender) {
+            string progressInfo =
+                $"Track {trackNo + 1}: HifiUtau \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
+            var result = Layout(phrase);
+
+            // ── 计算缓存哈希 ──
+            ulong hifiganHash = ComputeHifiganHash(phrase);
+            ulong finalHash = ComputeFinalHash(phrase, hifiganHash);
+            bool needsHnsep = NeedsHnsep(phrase);
+
+            var cacheRoot = Path.Join(PathManager.Inst.CachePath, "hifiutau");
+            var hifiganDir = Path.Join(cacheRoot, "hifigan");
+            var hnsepDir = Path.Join(cacheRoot, "hnsep");
+            var finalDir = Path.Join(cacheRoot, "final");
+            Directory.CreateDirectory(hifiganDir);
+            Directory.CreateDirectory(hnsepDir);
+            Directory.CreateDirectory(finalDir);
+
+            string hifiganPath = Path.Join(hifiganDir, $"{hifiganHash:x16}.wav");
+            string harmonicPath = Path.Join(hnsepDir, $"{hifiganHash:x16}.harmonic.wav");
+            string noisePath = Path.Join(hnsepDir, $"{hifiganHash:x16}.noise.wav");
+            string finalPath = Path.Join(finalDir, $"{finalHash:x16}.wav");
+            phrase.AddCacheFile(finalPath);
+
+            // 快路径：final 缓存命中（无锁）
+            if (File.Exists(finalPath)) {
+                result.samples = LoadSamples(finalPath);
+                if (result.samples != null) {
+                    Renderers.ApplyDynamics(phrase, result);
+                }
+                progress.Complete(phrase.phones.Length, progressInfo);
+                return result;
+            }
+
+            // 基于 hash 的互斥锁 + double-check
+            var hashLock = GetOrCreateHashLock(phrase.hash);
+            await hashLock.WaitAsync(cancellation.Token).ConfigureAwait(false);
+            try {
+                if (File.Exists(finalPath)) {
+                    result.samples = LoadSamples(finalPath);
+                    if (result.samples != null) {
+                        Renderers.ApplyDynamics(phrase, result);
+                    }
+                    progress.Complete(phrase.phones.Length, progressInfo);
+                    return result;
+                }
+
+                // 基础音素 JSON（一次构建，各段复用）
+                var baseJson = HifiUtauPhraseJson.Build(phrase);
+
+                // ── 阶段1: mel 拼接 + 变调 + HiFi-GAN ──
+                if (!File.Exists(hifiganPath)) {
+                    var payload = (JObject)baseJson.DeepClone();
+                    payload["out_wav"] = hifiganPath;
+                    byte[] wav;
+                    lock (HiFiUtauModelStore.Inst.EngineLock) {
+                        // 引擎引用只在 EngineLock 内获取与使用：重载同样持锁，
+                        // 保证"会话释放"与"会话使用"永不交错
+                        wav = RequireEngine().SynthesizeMel(payload);
+                    }
+                    File.WriteAllBytes(hifiganPath, wav);
+                }
+
+                // ── 阶段2: HN-SEP 气声/谐波分离（仅当需要时） ──
+                if (needsHnsep && (!File.Exists(harmonicPath) || !File.Exists(noisePath))) {
+                    byte[] harmonic, noise;
+                    lock (HiFiUtauModelStore.Inst.EngineLock) {
+                        (harmonic, noise) = RequireEngine().SynthesizeHnsep(File.ReadAllBytes(hifiganPath));
+                    }
+                    File.WriteAllBytes(harmonicPath, harmonic);
+                    File.WriteAllBytes(noisePath, noise);
+                }
+
+                // ── 阶段3: 参数应用 ──
+                var postPayload = (JObject)baseJson.DeepClone();
+                byte[]? wavBytes = null, harmonicBytes = null, noiseBytes = null;
+                if (needsHnsep) {
+                    harmonicBytes = File.ReadAllBytes(harmonicPath);
+                    noiseBytes = File.ReadAllBytes(noisePath);
+                } else {
+                    wavBytes = File.ReadAllBytes(hifiganPath);
+                }
+                byte[] finalWav;
+                lock (HiFiUtauModelStore.Inst.EngineLock) {
+                    finalWav = RequireEngine().SynthesizePost(postPayload, wavBytes, harmonicBytes, noiseBytes);
+                }
+                File.WriteAllBytes(finalPath, finalWav);
+            } finally {
+                hashLock.Release();
+            }
+
+            if (!File.Exists(finalPath)) {
+                throw new IOException("final 缓存文件未生成");
+            }
+            result.samples = LoadSamples(finalPath);
+            if (result.samples != null) {
+                Renderers.ApplyDynamics(phrase, result);
+            }
+            progress.Complete(phrase.phones.Length, progressInfo);
+            return result;
+        }
+
+        /// <summary>
+        /// 解析可用的内嵌引擎；不可用时抛出带可翻译说明的错误（由渲染管线弹出错误框）。
+        /// 每个阶段调用一次，使设置变更/重载能在短语渲染间隙生效。
+        /// </summary>
+        private static SynthesisEngine RequireEngine() {
+            if (!Preferences.Default.HifiUtauEmbedded) {
+                throw new MessageCustomizableException(
+                    "HiFiUTAU embedded engine is disabled in preferences (Preferences > Rendering > HiFiUTAU).",
+                    "<translate:errors.hifiutau.disabled>",
+                    null,
+                    false);
+            }
+            var engine = HiFiUtauModelStore.Inst.GetEngine();
+            if (engine == null) {
+                var store = HiFiUtauModelStore.Inst;
+                string detail = string.Join(" | ",
+                    new[] { store.SplicerError, store.HnsepError }.Where(s => !string.IsNullOrEmpty(s)));
+                throw new MessageCustomizableException(
+                    $"HiFiUTAU embedded engine models are missing or failed to load. {detail}",
+                    "<translate:errors.hifiutau.nomodels>",
+                    null,
+                    false);
+            }
+            return engine;
+        }
+
+        // ════════════════════════════════════════════════════════════════
+        //  缓存哈希
+        // ════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// hifigan 缓存哈希：所有影响 HiFi-GAN 之前输入的字段
+        /// （音素/oto/vel/vol/phtp/envelope/splc 已含在 phone.hash；另加 F0 与 genc）。
+        /// </summary>
+        private static ulong ComputeHifiganHash(RenderPhrase phrase) {
+            using (var stream = new MemoryStream()) {
+                using (var writer = new BinaryWriter(stream)) {
+                    writer.Write(phrase.singer?.Id ?? string.Empty);
+                    writer.Write(phrase.renderer?.ToString() ?? string.Empty);
+                    writer.Write(phrase.timeAxis.Timestamp);
+                    foreach (var phone in phrase.phones) {
+                        writer.Write(phone.hash);
+                    }
+                    WriteFloatArray(writer, phrase.pitches); // F0（含 pitd 偏差）
+                    WriteFloatArray(writer, phrase.gender);  // genc
+                    return XXH64.DigestOf(stream.ToArray());
+                }
+            }
+        }
+
+        /// <summary>
+        /// final 缓存哈希：hifiganHash + 所有影响参数应用阶段的曲线。
+        /// dyn 除外（仍由 C# 端 ApplyDynamics 施加，不入缓存键）。
+        /// </summary>
+        private static ulong ComputeFinalHash(RenderPhrase phrase, ulong hifiganHash) {
+            using (var stream = new MemoryStream()) {
+                using (var writer = new BinaryWriter(stream)) {
+                    writer.Write(hifiganHash);
+                    WriteFloatArray(writer, phrase.breathiness);  // brec
+                    WriteFloatArray(writer, phrase.tension);      // tenc
+                    WriteFloatArray(writer, phrase.voicing);      // voic
+                    WriteFloatArray(writer, phrase.breathLow);    // brel
+                    WriteFloatArray(writer, phrase.breathHigh);   // breh
+                    WriteFloatArray(writer, phrase.warmth);       // warm
+                    WriteFloatArray(writer, phrase.hcmp);         // hcmp
+                    WriteFloatArray(writer, phrase.lowcut);       // lowc
+                    // growl (gwl) 位于自定义曲线中
+                    var growl = phrase.curves?.FirstOrDefault(c => c.Item1 == Format.Ustx.GWL)?.Item2;
+                    WriteFloatArray(writer, growl);
+                    return XXH64.DigestOf(stream.ToArray());
+                }
+            }
+        }
+
+        /// <summary>
+        /// 是否需要 HN-SEP 分离：与引擎侧判定一致。
+        /// breath/tension/brel/breh/warm/hcmp 任一处偏离默认 0，或 voicing 偏离默认 100。
+        /// </summary>
+        private static bool NeedsHnsep(RenderPhrase phrase) {
+            return AnyNotClose(phrase.breathiness, 0, 0.5)
+                || AnyNotClose(phrase.tension, 0, 0.5)
+                || !AllClose(phrase.voicing, 100, 0.05)
+                || AnyNotClose(phrase.breathLow, 0, 0.5)
+                || AnyNotClose(phrase.breathHigh, 0, 0.5)
+                || AnyNotClose(phrase.warmth, 0, 0.5)
+                || AnyNotClose(phrase.hcmp, 0, 0.5);
+        }
+
+        private static bool AnyNotClose(float[] arr, float value, double atol) {
+            if (arr == null || arr.Length == 0) {
+                return false;
+            }
+            foreach (var v in arr) {
+                if (Math.Abs(v - value) > atol) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool AllClose(float[] arr, float value, double rtol) {
+            if (arr == null || arr.Length == 0) {
+                return true;
+            }
+            foreach (var v in arr) {
+                if (Math.Abs(v - value) > rtol * Math.Abs(value) + 1e-8) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static void WriteFloatArray(BinaryWriter writer, float[] array) {
+            if (array == null) {
+                writer.Write("null");
+                return;
+            }
+            foreach (var v in array) {
+                writer.Write(v);
+            }
+        }
+
+        // ════════════════════════════════════════════════════════════════
+        //  其它
+        // ════════════════════════════════════════════════════════════════
+
+        private static float[] LoadSamples(string path) {
+            using (var waveStream = new WaveFileReader(path)) {
+                return Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
+            }
+        }
+
+        private static SemaphoreSlim GetOrCreateHashLock(ulong hash) {
+            var newLock = new SemaphoreSlim(1, 1);
+            var hashLock = _hashLocks.GetOrAdd(hash, newLock);
+            if (hashLock != newLock) {
+                newLock.Dispose();
+            }
+            return hashLock;
+        }
+
+        public RenderPitchResult LoadRenderedPitch(RenderPhrase phrase) {
+            return null!;
+        }
+
+        public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
+            return new List<RenderRealCurveResult>(0);
+        }
+
+        public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {
+            return new UExpressionDescriptor[] { };
+        }
+
+        public override string ToString() => Renderers.HIFIUTAU;
+    }
+}

--- a/OpenUtau.Core/PlaybackManager.cs
+++ b/OpenUtau.Core/PlaybackManager.cs
@@ -406,7 +406,12 @@ namespace OpenUtau.Core {
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exporting to {exportPath}."));
 
                     CheckFileWritable(exportPath);
-                    WaveFileWriter.CreateWaveFile16(exportPath, new ExportAdapter(projectMix));
+                    var mixAdapter = new ExportAdapter(projectMix);
+                    if (UsesMonoRenderer(project)) {
+                        WaveFileWriter.CreateWaveFile16(exportPath, mixAdapter.ToMono(1, 0));
+                    } else {
+                        WaveFileWriter.CreateWaveFile16(exportPath, mixAdapter);
+                    }
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exported to {exportPath}."));
                 } catch (IOException ioe) {
                     var customEx = new MessageCustomizableException($"Failed to export {exportPath}.", $"<translate:errors.failed.export>: {exportPath}", ioe);
@@ -447,6 +452,19 @@ namespace OpenUtau.Core {
                     DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Failed to render."));
                 }
+            });
+        }
+
+        static bool UsesMonoRenderer(UProject project) {
+            if (project?.tracks == null) {
+                return false;
+            }
+            return project.tracks.Any(track => {
+                var renderer = track.RendererSettings?.renderer;
+                return renderer == Renderers.HIFIUTAU
+                    || renderer == Renderers.CUSTOM_SERVER
+                    || renderer == "HIFIUTAU_LOCAL"
+                    || renderer == "HIFIUTAU_ONLINE";
             });
         }
 

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -76,6 +76,12 @@ namespace OpenUtau.Core.Render {
         // voicevox & enunu args
         public readonly int toneShift;
 
+        // HiFiUTAU / Custom Server note-level options
+        public readonly int phonemeType;
+        public readonly int stretchMode;
+        public readonly int spliceMode;
+        public readonly float stretchMs;
+
         public readonly UOto oto;
         public readonly UOto oto2;
         public readonly ulong hash;
@@ -134,6 +140,14 @@ namespace OpenUtau.Core.Render {
             envelope = phoneme.envelope.data.ToArray();
             direct = phoneme.GetExpression(project, track, Format.Ustx.DIR).Item1 == 1;
             toneShift = (int)phoneme.GetExpression(project, track, Format.Ustx.SHFT).Item1;
+            phonemeType = track.TryGetExpDescriptor(project, Format.Ustx.PHTP, out _)
+                ? (int)phoneme.GetExpression(project, track, Format.Ustx.PHTP).Item1 : 0;
+            stretchMode = track.TryGetExpDescriptor(project, Format.Ustx.STRT, out _)
+                ? (int)phoneme.GetExpression(project, track, Format.Ustx.STRT).Item1 : 0;
+            spliceMode = track.TryGetExpDescriptor(project, Format.Ustx.SPLC, out _)
+                ? (int)phoneme.GetExpression(project, track, Format.Ustx.SPLC).Item1 : 0;
+            stretchMs = track.TryGetExpDescriptor(project, Format.Ustx.STMS, out _)
+                ? phoneme.GetExpression(project, track, Format.Ustx.STMS).Item1 : 0;
 
             oto = phoneme.oto;
             if (oto != null && !string.IsNullOrEmpty(targetColor)) {
@@ -151,6 +165,10 @@ namespace OpenUtau.Core.Render {
                     writer.Write(duration);
                     writer.Write(phoneme ?? string.Empty);
                     writer.Write(tone);
+                    writer.Write(phonemeType);
+                    writer.Write(stretchMode);
+                    writer.Write(spliceMode);
+                    writer.Write(stretchMs);
 
                     writer.Write(resampler ?? string.Empty);
                     foreach (var flag in flags) {
@@ -204,6 +222,11 @@ namespace OpenUtau.Core.Render {
         public readonly float[] tension;
         public readonly float[] voicing;
         public readonly float[] xsy;
+        public readonly float[] lowcut;
+        public readonly float[] warmth;
+        public readonly float[] hcmp;
+        public readonly float[] breathLow;
+        public readonly float[] breathHigh;
         public readonly Tuple<string, float[]>[] curves;//custom curves defined by renderer
         public readonly ulong preEffectHash;
         public readonly ulong hash;
@@ -472,6 +495,13 @@ namespace OpenUtau.Core.Render {
                             }
                         }
                         break;
+                    case Format.Ustx.LOWC: lowcut = curveSampled; break;
+                    case Format.Ustx.WARM:
+                        if (!curve.IsEmpty) { warmth = curveSampled; }
+                        break;
+                    case Format.Ustx.HCMP: hcmp = curveSampled; break;
+                    case Format.Ustx.BREL: breathLow = curveSampled; break;
+                    case Format.Ustx.BREH: breathHigh = curveSampled; break;
                     default:
                         curves.Add(Tuple.Create(curve.abbr,curveSampled));
                         break;
@@ -528,7 +558,7 @@ namespace OpenUtau.Core.Render {
                         writer.Write(phone.hash);
                     }
                     if (postEffect) {
-                        foreach (var array in new float[][] { pitches, dynamics, gender, breathiness, toneShift, tension, voicing, xsy }) {
+                        foreach (var array in new float[][] { pitches, dynamics, gender, breathiness, toneShift, tension, voicing, xsy, lowcut, warmth, hcmp, breathLow, breathHigh }) {
                             if (array == null) {
                                 writer.Write("null");
                             } else {

--- a/OpenUtau.Core/Render/Renderers.cs
+++ b/OpenUtau.Core/Render/Renderers.cs
@@ -15,8 +15,10 @@ namespace OpenUtau.Core.Render {
         public const string VOGEN = "VOGEN";
         public const string DIFFSINGER = "DIFFSINGER";
         public const string VOICEVOX = "VOICEVOX";
+        public const string HIFIUTAU = "HIFIUTAU";
+        public const string CUSTOM_SERVER = "CUSTOM_SERVER";
 
-        static readonly string[] classicRenderers = new[] { WORLDLINE_R, CLASSIC };
+        static readonly string[] classicRenderers = new[] { WORLDLINE_R, CLASSIC, HIFIUTAU, CUSTOM_SERVER };
         static readonly string[] enunuRenderers = new[] { ENUNU };
         static readonly string[] vogenRenderers = new[] { VOGEN };
         static readonly string[] diffSingerRenderers = new[] { DIFFSINGER };
@@ -43,16 +45,26 @@ namespace OpenUtau.Core.Render {
         public static List<string> getRendererOptions() {
             return new List<string> {
                 "WORLDLINE-R",
-                "Classic"
+                "Classic",
+                "HiFiUTAU",
+                "Custom Server"
             };
         }
 
         public static string GetDefaultRenderer(USingerType singerType) {
-            if (Preferences.Default.DefaultRenderer == "Classic" && singerType == USingerType.Classic) {
-                return CLASSIC;
-            } else {
-                return GetSupportedRenderers(singerType)[0];
+            if (singerType == USingerType.Classic) {
+                switch (Preferences.Default.DefaultRenderer) {
+                    case "Classic":
+                        return CLASSIC;
+                    case "HiFiUTAU":
+                    case "HiFiUTAU Local":
+                    case "HiFiUTAU Online":
+                        return HIFIUTAU;
+                    case "Custom Server":
+                        return CUSTOM_SERVER;
+                }
             }
+            return GetSupportedRenderers(singerType)[0];
         }
 
         public static IRenderer CreateRenderer(string renderer) {
@@ -70,6 +82,10 @@ namespace OpenUtau.Core.Render {
                 return new DiffSinger.DiffSingerRenderer();
             } else if (renderer == VOICEVOX) {
                 return new Voicevox.VoicevoxRenderer();
+            } else if (renderer == HIFIUTAU || renderer == "HIFIUTAU_LOCAL" || renderer == "HIFIUTAU_ONLINE") {
+                return new HiFiUtau.HifiUtauRenderer();
+            } else if (renderer == CUSTOM_SERVER) {
+                return new CustomRender.CustomServerRenderer();
             }
             return null;
         }

--- a/OpenUtau.Core/Ustx/UTrack.cs
+++ b/OpenUtau.Core/Ustx/UTrack.cs
@@ -12,6 +12,8 @@ namespace OpenUtau.Core.Ustx {
         public string renderer;
         public string resampler;
         public string wavtool;
+        public string serverUrl;
+        public string endpoint;
 
         [YamlIgnore] public IRenderer Renderer { get; set; }
         [YamlIgnore] public IResampler Resampler { get; set; }
@@ -30,8 +32,23 @@ namespace OpenUtau.Core.Ustx {
             if (string.IsNullOrEmpty(renderer)) {
                 renderer = Renderers.GetDefaultRenderer(track.Singer.SingerType);
             }
+            if (renderer == "HIFIUTAU_LOCAL" || renderer == "HIFIUTAU_ONLINE") {
+                renderer = Renderers.HIFIUTAU;
+            }
             if (renderer != Renderer?.ToString()) {
                 Renderer = Renderers.CreateRenderer(renderer);
+            }
+            if (renderer == Renderers.CUSTOM_SERVER) {
+                if (string.IsNullOrEmpty(serverUrl)) {
+                    serverUrl = Util.Preferences.Default.DefaultServerUrl;
+                }
+                if (string.IsNullOrEmpty(endpoint)) {
+                    endpoint = Util.Preferences.Default.DefaultEndpoint;
+                }
+                if (Renderer is CustomRender.CustomServerRenderer customServerRenderer) {
+                    customServerRenderer.ServerUrl = serverUrl;
+                    customServerRenderer.Endpoint = endpoint;
+                }
             }
             if (renderer == Renderers.CLASSIC) {
                 if (string.IsNullOrEmpty(resampler)) {
@@ -63,6 +80,8 @@ namespace OpenUtau.Core.Ustx {
                 renderer = renderer,
                 resampler = resampler,
                 wavtool = wavtool,
+                serverUrl = serverUrl,
+                endpoint = endpoint,
             };
         }
     }

--- a/OpenUtau.Core/Util/Onnx.cs
+++ b/OpenUtau.Core/Util/Onnx.cs
@@ -129,37 +129,55 @@ namespace OpenUtau.Core {
             return options;
         }
 
-        public static InferenceSession getInferenceSession(byte[] model, OnnxRunnerChoice runnerChoice = OnnxRunnerChoice.Default) {
+        public static InferenceSession getInferenceSession(byte[] model, OnnxRunnerChoice runnerChoice = OnnxRunnerChoice.Default, Action<SessionOptions>? configure = null) {
             if (runnerChoice == OnnxRunnerChoice.CPU ||
                 (runnerChoice == OnnxRunnerChoice.CPUForCoreML && Preferences.Default.OnnxRunner == "CoreML")) {
-                return new InferenceSession(model);
+                if (configure == null) {
+                    return new InferenceSession(model);
+                }
+                var cpuOptions = new SessionOptions();
+                configure(cpuOptions);
+                return new InferenceSession(model, cpuOptions);
             } else {
                 // Try with CoreML subgraphs enabled first, fallback to default if it fails
                 if (OS.IsMacOS() && Preferences.Default.OnnxRunner == "CoreML") {
                     try {
-                        return new InferenceSession(model, getOnnxSessionOptions(coremlEnableOnSubgraphs: true));
+                        var coremlOptions = getOnnxSessionOptions(coremlEnableOnSubgraphs: true);
+                        configure?.Invoke(coremlOptions);
+                        return new InferenceSession(model, coremlOptions);
                     } catch (Exception e) {
                         Log.Warning(e, "Failed to create session with CoreML subgraphs enabled, falling back to default settings");
                     }
                 }
-                return new InferenceSession(model, getOnnxSessionOptions());
+                var options = getOnnxSessionOptions();
+                configure?.Invoke(options);
+                return new InferenceSession(model, options);
             }
         }
 
-        public static InferenceSession getInferenceSession(string modelPath, OnnxRunnerChoice runnerChoice = OnnxRunnerChoice.Default) {
+        public static InferenceSession getInferenceSession(string modelPath, OnnxRunnerChoice runnerChoice = OnnxRunnerChoice.Default, Action<SessionOptions>? configure = null) {
             if (runnerChoice == OnnxRunnerChoice.CPU ||
                 (runnerChoice == OnnxRunnerChoice.CPUForCoreML && Preferences.Default.OnnxRunner == "CoreML")) {
-                return new InferenceSession(modelPath);
+                if (configure == null) {
+                    return new InferenceSession(modelPath);
+                }
+                var cpuOptions = new SessionOptions();
+                configure(cpuOptions);
+                return new InferenceSession(modelPath, cpuOptions);
             } else {
                 // Try with CoreML subgraphs enabled first, fallback to default if it fails
                 if (OS.IsMacOS() && Preferences.Default.OnnxRunner == "CoreML") {
                     try {
-                        return new InferenceSession(modelPath, getOnnxSessionOptions(coremlEnableOnSubgraphs: true));
+                        var coremlOptions = getOnnxSessionOptions(coremlEnableOnSubgraphs: true);
+                        configure?.Invoke(coremlOptions);
+                        return new InferenceSession(modelPath, coremlOptions);
                     } catch (Exception e) {
                         Log.Warning(e, "Failed to create session with CoreML subgraphs enabled, falling back to default settings");
                     }
                 }
-                return new InferenceSession(modelPath, getOnnxSessionOptions());
+                var options = getOnnxSessionOptions();
+                configure?.Invoke(options);
+                return new InferenceSession(modelPath, options);
             }
         }
 

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -290,6 +290,14 @@ errors.txt
             public bool MixFxApplyOnExportMixdown = true;
             public List<MixFxUserPreset> MixFxUserPresets = new List<MixFxUserPreset>();
 
+            public string DefaultServerUrl = "http://localhost:8000";
+            public string DefaultEndpoint = "/synthesize";
+            public bool HifiUtauEmbedded = true;
+            public string HifiUtauSplicerPath = string.Empty;
+            public string HifiUtauHnsepPath = string.Empty;
+            public bool HifiUtauPreload = false;
+            public int HifiUtauIntraOpThreads = 0;
+
             // Legacy
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public int? Theme;

--- a/OpenUtau.Test/Core/Render/HifiUtauCustomServerRendererTest.cs
+++ b/OpenUtau.Test/Core/Render/HifiUtauCustomServerRendererTest.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OpenUtau.Core;
+using OpenUtau.Core.CustomRender;
+using OpenUtau.Core.Format;
+using OpenUtau.Core.HiFiUtau;
+using OpenUtau.Core.HiFiUtau.Engine.Pipeline;
+using OpenUtau.Core.Render;
+using OpenUtau.Core.Ustx;
+using Xunit;
+
+namespace OpenUtau.Test.Core.Render {
+    [CollectionDefinition("HifiUtauSerial", DisableParallelization = true)]
+    public class HifiUtauSerialCollection { }
+
+    /// <summary>
+    /// HiFiUTAU / Custom Server 新增面的可用性测试。
+    /// 只覆盖产品契约：渲染器接线、oudep 布局、音素 JSON、mel 拼接位置。
+    /// 不覆盖 ONNX 推理、HTTP 往返、STFT/mel 数值金标准。
+    /// </summary>
+    public class HifiUtauCustomServerRendererTest {
+        [Collection("HifiUtauSerial")]
+        public class Renderer {
+            [Fact]
+            public void HifiUtau_IsInProcessClassicRenderer() {
+                var renderer = Renderers.CreateRenderer(Renderers.HIFIUTAU);
+                Assert.IsType<HifiUtauRenderer>(renderer);
+                Assert.Equal(Renderers.HIFIUTAU, renderer!.ToString());
+                Assert.Equal(USingerType.Classic, renderer.SingerType);
+                Assert.DoesNotContain("HTTP", renderer.GetType().FullName);
+            }
+
+            [Fact]
+            public void HifiUtau_MigratesLegacyRendererNames() {
+                Assert.IsType<HifiUtauRenderer>(Renderers.CreateRenderer("HIFIUTAU_LOCAL"));
+                Assert.IsType<HifiUtauRenderer>(Renderers.CreateRenderer("HIFIUTAU_ONLINE"));
+            }
+
+            [Fact]
+            public void CustomServer_StaysIndependentOfHifiUtau() {
+                var renderer = Renderers.CreateRenderer(Renderers.CUSTOM_SERVER);
+                Assert.IsType<CustomServerRenderer>(renderer);
+                Assert.Equal(Renderers.CUSTOM_SERVER, renderer!.ToString());
+                Assert.Equal(USingerType.Classic, renderer.SingerType);
+                Assert.IsNotType<HifiUtauRenderer>(renderer);
+            }
+
+            [Fact]
+            public void ClassicSinger_OffersBothNewRenderersWithoutDroppingWorldline() {
+                var supported = Renderers.GetSupportedRenderers(USingerType.Classic);
+                Assert.Equal(
+                    new[] { Renderers.WORLDLINE_R, Renderers.CLASSIC, Renderers.HIFIUTAU, Renderers.CUSTOM_SERVER },
+                    supported);
+            }
+
+            [Fact]
+            public void TrackSettings_MigratesLegacyHifiNameAndBindsCustomServerUrl() {
+                var project = new UProject();
+                var track = project.tracks[0];
+                track.Singer = new FoundClassicSinger();
+
+                track.RendererSettings.renderer = "HIFIUTAU_LOCAL";
+                track.RendererSettings.Validate(track);
+                Assert.Equal(Renderers.HIFIUTAU, track.RendererSettings.renderer);
+                Assert.IsType<HifiUtauRenderer>(track.RendererSettings.Renderer);
+
+                track.RendererSettings.renderer = Renderers.CUSTOM_SERVER;
+                track.RendererSettings.serverUrl = "http://127.0.0.1:9000";
+                track.RendererSettings.endpoint = "/synthesize";
+                track.RendererSettings.Validate(track);
+                var custom = Assert.IsType<CustomServerRenderer>(track.RendererSettings.Renderer);
+                Assert.Equal("http://127.0.0.1:9000", custom.ServerUrl);
+                Assert.Equal("/synthesize", custom.Endpoint);
+            }
+
+            [Fact]
+            public void TrackSettings_PersistsRendererAndServerUrlInYaml() {
+                var settings = new URenderSettings {
+                    renderer = Renderers.CUSTOM_SERVER,
+                    serverUrl = "http://127.0.0.1:9000",
+                    endpoint = "/synthesize",
+                };
+                var loaded = Yaml.DefaultDeserializer.Deserialize<URenderSettings>(
+                    Yaml.DefaultSerializer.Serialize(settings));
+                Assert.Equal(Renderers.CUSTOM_SERVER, loaded.renderer);
+                Assert.Equal("http://127.0.0.1:9000", loaded.serverUrl);
+                Assert.Equal("/synthesize", loaded.endpoint);
+            }
+
+            [Fact]
+            public void CustomServer_SplitsFullUrlIntoHostAndEndpoint() {
+                var renderer = new CustomServerRenderer("http://127.0.0.1:9000/synthesize");
+                Assert.Equal("http://127.0.0.1:9000", renderer.ServerUrl);
+                Assert.Equal("/synthesize", renderer.Endpoint);
+            }
+        }
+
+        public class Oudep {
+            [Fact]
+            public void VocoderOudep_RequiresYamlAndNamedOnnx() {
+                using var dir = new TempDir();
+                File.WriteAllText(Path.Combine(dir.Path, "vocoder.yaml"),
+                    "name: pc_nsf_hifigan_44.1k_hop512_128bin_2025.02\nmodel: model.onnx\n");
+                File.WriteAllBytes(Path.Combine(dir.Path, "model.onnx"), new byte[] { 1 });
+                Assert.True(HiFiUtauModelStore.IsValidVocoderOudepDir(dir.Path));
+            }
+
+            [Fact]
+            public void VocoderOudep_RejectsMissingNamedOnnx() {
+                using var dir = new TempDir();
+                File.WriteAllText(Path.Combine(dir.Path, "vocoder.yaml"),
+                    "name: pc_nsf_hifigan_44.1k_hop512_128bin_2025.02\nmodel: missing.onnx\n");
+                File.WriteAllBytes(Path.Combine(dir.Path, "model.onnx"), new byte[] { 1 });
+                Assert.False(HiFiUtauModelStore.IsValidVocoderOudepDir(dir.Path));
+            }
+
+            [Fact]
+            public void VocoderOudep_RejectsPytorchCkptDirectory() {
+                using var dir = new TempDir();
+                File.WriteAllText(Path.Combine(dir.Path, "config.json"), "{}");
+                File.WriteAllBytes(Path.Combine(dir.Path, "model.ckpt"), new byte[] { 1 });
+                Assert.True(HiFiUtauModelStore.LooksLikePytorchCkptDir(dir.Path));
+                Assert.False(HiFiUtauModelStore.IsValidVocoderOudepDir(dir.Path));
+            }
+
+            [Fact]
+            public void VocoderOudepId_MatchesInstalledPackageName() {
+                Assert.Equal("pc_nsf_hifigan_44.1k_hop512_128bin_2025.02",
+                    HiFiUtauModelStore.PcNsfHifiGanOudepId);
+            }
+
+            [Fact]
+            public void HnsepOudep_RequiresOudepYamlAndOnnx() {
+                using var dir = new TempDir();
+                File.WriteAllText(Path.Combine(dir.Path, "oudep.yaml"),
+                    "id: hnsep_VR_44.1k_hop512_2024.05\nclass: Hnsep\n");
+                File.WriteAllBytes(Path.Combine(dir.Path, "hnsep.onnx"), new byte[] { 1 });
+                Assert.True(HiFiUtauModelStore.IsValidHnsepOudepDir(dir.Path));
+            }
+
+            [Fact]
+            public void HnsepOudep_RejectsRawOnnxDirectory() {
+                using var dir = new TempDir();
+                File.WriteAllText(Path.Combine(dir.Path, "config.yaml"), "sr: 44100\n");
+                File.WriteAllBytes(Path.Combine(dir.Path, "hnsep.onnx"), new byte[] { 1 });
+                Assert.False(HiFiUtauModelStore.IsValidHnsepOudepDir(dir.Path));
+            }
+
+            [Fact]
+            public void HnsepOudepId_MatchesPackedPackageName() {
+                Assert.Equal("hnsep_VR_44.1k_hop512_2024.05", HiFiUtauModelStore.HnsepOudepId);
+            }
+        }
+
+        [Collection("HifiUtauSerial")]
+        public class Expressions {
+            [Fact]
+            public void RegistersHifiExpressions_WithoutUtauFlagOnStretchMs() {
+                var project = new UProject();
+                Ustx.AddDefaultExpressions(project);
+
+                Assert.Equal(UExpressionType.Curve, project.expressions[Ustx.GWL].type);
+                Assert.Equal(UExpressionType.Curve, project.expressions[Ustx.LOWC].type);
+                Assert.Equal(UExpressionType.Curve, project.expressions[Ustx.WARM].type);
+                Assert.Equal(UExpressionType.Options, project.expressions[Ustx.PHTP].type);
+                Assert.Equal(UExpressionType.Options, project.expressions[Ustx.STRT].type);
+                Assert.Equal(UExpressionType.Options, project.expressions[Ustx.SPLC].type);
+                Assert.True(string.IsNullOrEmpty(project.expressions[Ustx.STMS].flag));
+            }
+
+            [Fact]
+            public void StretchMs_DoesNotLeakIntoResamplerFlags() {
+                var phrase = PhraseFactory.Create(
+                    configure: (project, track, phoneme) => {
+                        phoneme.SetExpression(project, track, Ustx.STMS, 12);
+                        phoneme.SetExpression(project, track, Ustx.GEN, 30);
+                    });
+                var flags = phrase.Phoneme.GetResamplerFlags(phrase.Project, phrase.Track);
+                Assert.DoesNotContain(flags, f => f.Item3 == Ustx.STMS);
+                Assert.DoesNotContain(flags, f => f.Item1 == "S");
+                Assert.Contains(flags, f => f.Item3 == Ustx.GEN && f.Item1 == "g");
+            }
+        }
+
+        [Collection("HifiUtauSerial")]
+        public class PhraseJson {
+            [Fact]
+            public void RenderPhone_CarriesHifiNoteOptions() {
+                var phrase = PhraseFactory.Create(
+                    configure: (project, track, phoneme) => {
+                        phoneme.SetExpression(project, track, Ustx.PHTP, 2);
+                        phoneme.SetExpression(project, track, Ustx.STRT, 1);
+                        phoneme.SetExpression(project, track, Ustx.SPLC, 1);
+                        phoneme.SetExpression(project, track, Ustx.STMS, 12);
+                    });
+                var phone = Assert.Single(phrase.Render.phones);
+                Assert.Equal(2, phone.phonemeType);
+                Assert.Equal(1, phone.stretchMode);
+                Assert.Equal(1, phone.spliceMode);
+                Assert.Equal(12, phone.stretchMs);
+            }
+
+            [Fact]
+            public void HifiPhraseJson_IsParseableByInProcessEngine() {
+                var phrase = PhraseFactory.Create(
+                    configure: (project, track, phoneme) => {
+                        phoneme.SetExpression(project, track, Ustx.STMS, 12);
+                        phoneme.SetExpression(project, track, Ustx.SPLC, 1);
+                    });
+                var data = PhraseData.Parse(HifiUtauPhraseJson.Build(phrase.Render));
+                Assert.Equal(256, data.HopSize);
+                var phone = Assert.Single(data.Phones);
+                Assert.Equal("a", phone.Name);
+                Assert.Equal(12, phone.Flag("stms", -1));
+                Assert.Equal(1, phone.Flag("splc", -1));
+                Assert.True(phone.Flags.ContainsKey("vel"));
+            }
+
+            [Fact]
+            public void CustomPhraseJson_IsIndependentHttpPayload() {
+                var phrase = PhraseFactory.Create(
+                    renderer: Renderers.CUSTOM_SERVER,
+                    configure: (project, track, phoneme) => {
+                        phoneme.SetExpression(project, track, Ustx.STMS, 12);
+                    });
+                var json = CustomPhraseJson.Build(phrase.Render);
+                Assert.Equal(256, json.Value<int>("hop_size"));
+                Assert.Equal(44100, json.Value<int>("sample_rate"));
+                Assert.NotNull(json["phoneme_list"]);
+                Assert.NotNull(json["Dynamic_parameter"]);
+                Assert.Equal("a", json["phoneme_list"]["1"]["phoneme_name"].ToString());
+                Assert.Equal(12, (double)json["phoneme_list"]["1"]["Note_flags"]["stms"]);
+            }
+        }
+
+        public class MelSplice {
+            [Fact]
+            public void PositionsOverlapThePreviousPhoneOnTheTimeline() {
+                var first = Phone(p0: 0, p1: 5, p4: 100);
+                var second = Phone(p0: 0, p1: 10, p4: 80);
+                var (starts, preutters, _, _, vfs, ends) = FragmentMel.CalcPositionsAndRatiosMs(
+                    new List<PhoneInfo> { first, second });
+
+                double spm = 44100 / 1000.0;
+                Assert.Equal(0, starts[0]);
+                Assert.Equal(90 * spm, starts[1], 6);
+                Assert.Equal(170 * spm, ends[1], 6);
+                Assert.Equal(1, vfs[0]);
+                Assert.Equal(90 * spm, preutters[1], 6);
+            }
+
+            static PhoneInfo Phone(double p0, double p1, double p4) {
+                var info = new PhoneInfo {
+                    P0 = new EnvPoint { X = p0, Y = 0 },
+                    P1 = new EnvPoint { X = p1, Y = 100 },
+                    P4 = new EnvPoint { X = p4, Y = 0 },
+                    Oto = new OtoEntry { Consonant = 20, Preutter = 10 },
+                };
+                info.Flags["vel"] = 100;
+                return info;
+            }
+        }
+
+        sealed class FoundClassicSinger : USinger {
+            readonly UOto oto = new UOto();
+
+            public FoundClassicSinger() {
+                found = true;
+                loaded = true;
+            }
+
+            public override string Id => "hifi-test-classic";
+            public override string Name => "hifi-test-classic";
+            public override USingerType SingerType => USingerType.Classic;
+            public override IList<USubbank> Subbanks => Array.Empty<USubbank>();
+            public override bool TryGetOto(string phoneme, out UOto oto) {
+                oto = this.oto;
+                return true;
+            }
+        }
+
+        sealed class PhraseFactory {
+            public UProject Project { get; init; } = null!;
+            public UTrack Track { get; init; } = null!;
+            public UPhoneme Phoneme { get; init; } = null!;
+            public RenderPhrase Render { get; init; } = null!;
+
+            public static PhraseFactory Create(
+                string renderer = Renderers.HIFIUTAU,
+                Action<UProject, UTrack, UPhoneme> configure = null) {
+                var project = new UProject();
+                Ustx.AddDefaultExpressions(project);
+                var track = project.tracks[0];
+                track.Singer = new FoundClassicSinger();
+                track.RendererSettings.renderer = renderer;
+                if (renderer == Renderers.CUSTOM_SERVER) {
+                    track.RendererSettings.serverUrl = "http://127.0.0.1:8000";
+                    track.RendererSettings.endpoint = "/synthesize";
+                }
+                track.RendererSettings.Validate(track);
+
+                var note = UNote.Create();
+                note.lyric = "a";
+                note.tone = 60;
+                note.position = 0;
+                note.duration = 480;
+                note.ExtendedDuration = 480;
+                note.pitch.AddPoint(new PitchPoint(-5, 0));
+                note.pitch.AddPoint(new PitchPoint(5, 0));
+
+                var part = new UVoicePart {
+                    trackNo = 0,
+                    position = 0,
+                    duration = 960,
+                };
+                part.notes.Add(note);
+
+                var phoneme = new UPhoneme {
+                    Parent = note,
+                    phoneme = "a",
+                    position = 0,
+                };
+                configure?.Invoke(project, track, phoneme);
+                note.Validate(new ValidateOptions(), project, track, part);
+                phoneme.Validate(new ValidateOptions(), project, track, part, note);
+                Assert.False(phoneme.Error, phoneme.ErrorException?.ToString() ?? "phoneme.Error");
+                part.phonemes.Add(phoneme);
+
+                var phrases = RenderPhrase.FromPart(project, track, part);
+                return new PhraseFactory {
+                    Project = project,
+                    Track = track,
+                    Phoneme = phoneme,
+                    Render = Assert.Single(phrases),
+                };
+            }
+        }
+
+        sealed class TempDir : IDisposable {
+            public string Path { get; } = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "ou-hifi-" + Guid.NewGuid().ToString("N"));
+
+            public TempDir() => Directory.CreateDirectory(Path);
+
+            public void Dispose() {
+                try {
+                    if (Directory.Exists(Path)) {
+                        Directory.Delete(Path, true);
+                    }
+                } catch {
+                }
+            }
+        }
+    }
+}

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -132,8 +132,10 @@ OpenUtau aims to be an open source editing environment for UTAU community, with 
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>
   <system:String x:Key="dialogs.timesig.caption">Time Signature</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Track Settings</system:String>
+  <system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>
   <system:String x:Key="dialogs.tracksettings.location">Location</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>
+  <system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>
   <system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>
   <system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>
@@ -195,6 +197,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>
   <system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>
   <system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>
+  <system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>
+  <system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>
   <system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>
@@ -351,6 +355,18 @@ Syntax: prefix,suffix</system:String>
   <system:String x:Key="mergevoicebank.setvoicecolor">Set new names for voice colors (shown in CLR expression).</system:String>
   <system:String x:Key="mergevoicebank.title">Merge voicebanks</system:String>
 
+  <system:String x:Key="mixfx.applyonexport">Apply when exporting mixdown</system:String>
+  <system:String x:Key="mixfx.caption">Track Polish</system:String>
+  <system:String x:Key="mixfx.enabled">Enable on this track</system:String>
+  <system:String x:Key="mixfx.library">Library</system:String>
+  <system:String x:Key="mixfx.library.default">Default</system:String>
+  <system:String x:Key="mixfx.library.delete">Delete</system:String>
+  <system:String x:Key="mixfx.library.placeholder">Select a saved preset...</system:String>
+  <system:String x:Key="mixfx.library.save">Save...</system:String>
+  <system:String x:Key="mixfx.preset">Preset</system:String>
+  <system:String x:Key="mixfx.recommended">Apply Default Settings</system:String>
+  <system:String x:Key="mixfx.recommended.tip">Vocal Air + Gentle compression + Small Room</system:String>
+
   <system:String x:Key="notedefaults.lyric">Lyric</system:String>
   <system:String x:Key="notedefaults.lyric.enter">When Enter</system:String>
   <system:String x:Key="notedefaults.lyric.knife">When Knife Tool</system:String>
@@ -436,6 +452,8 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="packages.uninstall">Uninstall</system:String>
   <system:String x:Key="packages.unknownversion">unknown version</system:String>
   <system:String x:Key="packages.update">Update</system:String>
+
+  <system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>
 
   <system:String x:Key="phoneticassistant.caption">Phonetic Assistant</system:String>
   <system:String x:Key="phoneticassistant.copy">Copy</system:String>
@@ -559,10 +577,6 @@ Warning: this option removes custom presets.</system:String>
 
   <system:String x:Key="prefs.advanced">Advanced</system:String>
   <system:String x:Key="prefs.advanced.beta">Beta</system:String>
-  <system:String x:Key="prefs.channel">Release Channel</system:String>
-  <system:String x:Key="prefs.channel.stable">Stable</system:String>
-  <system:String x:Key="prefs.channel.beta">Beta</system:String>
-  <system:String x:Key="prefs.channel.alpha">Alpha</system:String>
   <system:String x:Key="prefs.advanced.lyricshelper">Lyrics Helper</system:String>
   <system:String x:Key="prefs.advanced.lyricshelper.brackets">Lyrics Helper Adds Brackets</system:String>
   <system:String x:Key="prefs.advanced.rememberfiletypes">Remember these file types in "Open Recent"</system:String>
@@ -586,10 +600,10 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>
   <system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>
   <system:String x:Key="prefs.appearance.lang">Language</system:String>
-  <system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>
   <system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>
-  <system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>
   <system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>
+  <system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>
+  <system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>
   <system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>
   <system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>
@@ -601,9 +615,36 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>
   <system:String x:Key="prefs.caption">Preferences</system:String>
+  <system:String x:Key="prefs.channel">Release Channel</system:String>
+  <system:String x:Key="prefs.channel.alpha">Alpha</system:String>
+  <system:String x:Key="prefs.channel.beta">Beta</system:String>
+  <system:String x:Key="prefs.channel.stable">Stable</system:String>
   <system:String x:Key="prefs.diffsinger">DiffSinger</system:String>
   <system:String x:Key="prefs.editing">Editing</system:String>
   <system:String x:Key="prefs.general">General</system:String>
+  <system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>
+  <system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>
+  <system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>
+  <system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>
+  <system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>
+  <system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>
+  <system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>
+  <system:String x:Key="prefs.hifiutau.reload.all">All</system:String>
+  <system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>
+  <system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>
+  <system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>
+  <system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>
+  <system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>
+  <system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>
+  <system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>
+  <system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>
+  <system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>
+  <system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>
+  <system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>
+  <system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>
+  <system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>
   <system:String x:Key="prefs.note.restart">Note: please restart OpenUtau after changing this item.</system:String>
   <system:String x:Key="prefs.otoeditor">Oto Editor</system:String>
   <system:String x:Key="prefs.otoeditor.select">Default Oto Editor</system:String>
@@ -635,10 +676,10 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>
+  <system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>
   <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>
   <system:String x:Key="prefs.rendering.diffsingervariancelocalpitchpatch">DiffSinger Local Variance Update for Pitch Edits</system:String>
   <system:String x:Key="prefs.rendering.gamebackend">GAME Inference Backend</system:String>
   <system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>
@@ -761,6 +802,10 @@ The voicebank may not work on another OS.</system:String>
   <system:String x:Key="singersetup.textfileencoding.prompt">Choose an encoding that make file contents look right.</system:String>
   <system:String x:Key="singersetup.title">Singer Setup</system:String>
 
+  <system:String x:Key="themeeditor.cancel">Cancel</system:String>
+  <system:String x:Key="themeeditor.save">Save</system:String>
+  <system:String x:Key="themeeditor.title">Theme Editor</system:String>
+
   <system:String x:Key="tip.aliasbox">Override Alias</system:String>
   <system:String x:Key="tip.exps">Numerical,Options Type
     Left Button Draw: Set expressions
@@ -797,6 +842,7 @@ General
   <system:String x:Key="tracks.duplicatesettings">Duplicate Track Settings</system:String>
   <system:String x:Key="tracks.favorite">Favorites</system:String>
   <system:String x:Key="tracks.installsinger">Install singer</system:String>
+  <system:String x:Key="tracks.mixfx">Track Polish...</system:String>
   <system:String x:Key="tracks.more">More</system:String>
   <system:String x:Key="tracks.movedown">Move Down</system:String>
   <system:String x:Key="tracks.moveup">Move Up</system:String>
@@ -841,23 +887,4 @@ General
   <system:String x:Key="welcome.recent">Recent</system:String>
   <system:String x:Key="welcome.start">Start</system:String>
   <system:String x:Key="welcome.template">Template</system:String>
-
-  <system:String x:Key="themeeditor.title">Theme Editor</system:String>
-  <system:String x:Key="themeeditor.save">Save</system:String>
-  <system:String x:Key="themeeditor.cancel">Cancel</system:String>
-  <system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>
-
-  <!-- Mix Effects (post-processing) -->
-  <system:String x:Key="mixfx.caption">Track Polish</system:String>
-  <system:String x:Key="mixfx.enabled">Enable on this track</system:String>
-  <system:String x:Key="mixfx.preset">Preset</system:String>
-  <system:String x:Key="mixfx.recommended">Apply Default Settings</system:String>
-  <system:String x:Key="mixfx.recommended.tip">Vocal Air + Gentle compression + Small Room</system:String>
-  <system:String x:Key="mixfx.applyonexport">Apply when exporting mixdown</system:String>
-  <system:String x:Key="mixfx.library">Library</system:String>
-  <system:String x:Key="mixfx.library.placeholder">Select a saved preset...</system:String>
-  <system:String x:Key="mixfx.library.save">Save...</system:String>
-  <system:String x:Key="mixfx.library.delete">Delete</system:String>
-  <system:String x:Key="mixfx.library.default">Default</system:String>
-  <system:String x:Key="tracks.mixfx">Track Polish...</system:String>
 </ResourceDictionary>

--- a/OpenUtau/Strings/Strings.de-DE.axaml
+++ b/OpenUtau/Strings/Strings.de-DE.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Zeitsignatur</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Spureinstellungen</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Position</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Als Standard festlegen</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -452,6 +456,8 @@ Warnung: Diese Option entfernt alle benutzerdefinierten Einstellungen.</system:S
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Phonetik Assistent</system:String>
   <system:String x:Key="phoneticassistant.copy">Kopieren</system:String>
 
@@ -598,6 +604,9 @@ Warnung: Diese Option entfernt alle benutzerdefinierten Einstellungen.</system:S
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Sprache</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Die Noten anderer Tonspuren im Piano-Modus anzeigen.</system:String>
   <system:String x:Key="prefs.appearance.showicon">Icon im Piano-Modus anzeigen</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Portrait im Piano-Modus anzeigen</system:String>
@@ -610,9 +619,36 @@ Warnung: Diese Option entfernt alle benutzerdefinierten Einstellungen.</system:S
   <system:String x:Key="prefs.cache.clearonquit">Cache beim Beenden leeren</system:String>
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <system:String x:Key="prefs.caption">Einstellungen</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Anmerkung: Bitte starten Sie OpenUtau neu nachdem Sie diese Einstellung verändert haben.</system:String>
   <!--<system:String x:Key="prefs.otoeditor">Oto Editor</system:String>-->
   <system:String x:Key="prefs.otoeditor.select">Standard Oto Editor</system:String>
@@ -632,6 +668,7 @@ Warnung: Diese Option entfernt alle benutzerdefinierten Einstellungen.</system:S
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <system:String x:Key="prefs.playback.backend.auto">Automatisch</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Auto-Scroll Abstand</system:String>
   <system:String x:Key="prefs.playback.device">Wiedergabegerät</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Beim Pausieren</system:String>
@@ -643,6 +680,7 @@ Warnung: Diese Option entfernt alle benutzerdefinierten Einstellungen.</system:S
   <!--<system:String x:Key="prefs.rendering">Rendering</system:String>-->
   <system:String x:Key="prefs.rendering.defaultrenderer">Standard Renderer (für classic voicebanks)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Tiefe</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -774,6 +812,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Wählen Sie eine Kodierung, welche Dateinamen richtig aussehen lässt.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Alias überschreiben</system:String>

--- a/OpenUtau/Strings/Strings.es-ES.axaml
+++ b/OpenUtau/Strings/Strings.es-ES.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <!--<system:String x:Key="dialogs.timesig.caption">Time Signature</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.caption">Track Settings</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -452,6 +456,8 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <!--<system:String x:Key="phoneticassistant.caption">Phonetic Assistant</system:String>-->
   <!--<system:String x:Key="phoneticassistant.copy">Copy</system:String>-->
 
@@ -597,6 +603,9 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <!--<system:String x:Key="prefs.appearance.lang">Language</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>-->
@@ -609,9 +618,36 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>-->
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <system:String x:Key="prefs.caption">Preferencias</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <!--<system:String x:Key="prefs.note.restart">Note: please restart OpenUtau after changing this item.</system:String>-->
   <!--<system:String x:Key="prefs.otoeditor">Oto Editor</system:String>-->
   <!--<system:String x:Key="prefs.otoeditor.select">Default Oto Editor</system:String>-->
@@ -631,6 +667,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Posición del cursor</system:String>
   <system:String x:Key="prefs.playback.device">Dispositivo de reproducción</system:String>
   <!--<system:String x:Key="prefs.playback.lockstarttime">On Pausing</system:String>-->
@@ -642,6 +679,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.rendering">Rendering</system:String>-->
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -769,6 +807,8 @@ The voicebank may not work on another OS.</system:String>-->
   <!--<system:String x:Key="singersetup.textfileencoding.prompt">Choose an encoding that make file contents look right.</system:String>-->
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <!--<system:String x:Key="tip.aliasbox">Override Alias</system:String>-->

--- a/OpenUtau/Strings/Strings.es-MX.axaml
+++ b/OpenUtau/Strings/Strings.es-MX.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Medida del compás</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Ajustes de la pista</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Ubicación</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Renderizador</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Usar como predeterminado</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">Por favor, instala Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Este caracter no es permitido en una expresión regular</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">Error de expresión regular</system:String>
@@ -452,6 +456,8 @@ Advertencia: Esta opción eliminará las bases personalizadas.</system:String>
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Asistente fonético</system:String>
   <system:String x:Key="phoneticassistant.copy">Copiar</system:String>
 
@@ -598,6 +604,9 @@ Advertencia: Esta opción eliminará las bases personalizadas.</system:String>
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Lenguaje</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Mostrar notas de otras pistas en el piano</system:String>
   <system:String x:Key="prefs.appearance.showicon">Mostrar icono en el piano</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Mostrar foto en el piano</system:String>
@@ -610,9 +619,36 @@ Advertencia: Esta opción eliminará las bases personalizadas.</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Limpiar cache al salir</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">Cache de Tensor de DiffSinger</system:String>
   <system:String x:Key="prefs.caption">Ajustes</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <system:String x:Key="prefs.editing">Edición</system:String>
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Nota: Por favor, reinicia OpenUTAU después de cambiar esta opción.</system:String>
   <system:String x:Key="prefs.otoeditor">Editor de OTO</system:String>
   <system:String x:Key="prefs.otoeditor.select">Editor predeterminado</system:String>
@@ -632,6 +668,7 @@ Advertencia: Esta opción eliminará las bases personalizadas.</system:String>
   <system:String x:Key="prefs.playback.backend">Backend de audio</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Escoger automáticamente</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Posición del cursor</system:String>
   <system:String x:Key="prefs.playback.device">Dispositivo de reproducción</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Cuando se pausa...</system:String>
@@ -643,6 +680,7 @@ Advertencia: Esta opción eliminará las bases personalizadas.</system:String>
   <system:String x:Key="prefs.rendering">Renderización</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Renderizador predeterminado (para voces UTAU)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">Profundidad de renderización</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -774,6 +812,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Escoge una codificación que no tenga errores.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Cambiar alias</system:String>

--- a/OpenUtau/Strings/Strings.fi-FI.axaml
+++ b/OpenUtau/Strings/Strings.fi-FI.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <!--<system:String x:Key="dialogs.timesig.caption">Time Signature</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.caption">Track Settings</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -452,6 +456,8 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <!--<system:String x:Key="phoneticassistant.caption">Phonetic Assistant</system:String>-->
   <!--<system:String x:Key="phoneticassistant.copy">Copy</system:String>-->
 
@@ -597,6 +603,9 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Kieli</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>-->
@@ -609,9 +618,36 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>-->
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <system:String x:Key="prefs.caption">Asetukset</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">HUOM: Käynnistäthän OpenUtau uudelleen muutettuasi tätä asetusta.</system:String>
   <!--<system:String x:Key="prefs.otoeditor">Oto Editor</system:String>-->
   <!--<system:String x:Key="prefs.otoeditor.select">Default Oto Editor</system:String>-->
@@ -631,6 +667,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <!--<system:String x:Key="prefs.playback.cursorposition">Auto-Scroll Margin</system:String>-->
   <system:String x:Key="prefs.playback.device">Äänentoistolaite</system:String>
   <!--<system:String x:Key="prefs.playback.lockstarttime">On Pausing</system:String>-->
@@ -642,6 +679,7 @@ Warning: this option removes custom presets.</system:String>-->
   <system:String x:Key="prefs.rendering">Renderöi</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -769,6 +807,8 @@ The voicebank may not work on another OS.</system:String>-->
   <!--<system:String x:Key="singersetup.textfileencoding.prompt">Choose an encoding that make file contents look right.</system:String>-->
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <!--<system:String x:Key="tip.aliasbox">Override Alias</system:String>-->

--- a/OpenUtau/Strings/Strings.fr-FR.axaml
+++ b/OpenUtau/Strings/Strings.fr-FR.axaml
@@ -136,8 +136,10 @@ Nouveau tempo :</system:String>
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Mesure</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Paramètres de piste</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Emplacement</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Système de rendu</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Assigner par défaut</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -199,6 +201,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">Essayez d'installer le dernier Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Caractère interdit en regex</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- Erreur liée à la regex -</system:String>
@@ -453,6 +457,8 @@ Attention : cela va effacer les préréglages.</system:String>
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Assistant phonétique</system:String>
   <system:String x:Key="phoneticassistant.copy">Copier</system:String>
 
@@ -595,6 +601,9 @@ Attention : cela va effacer les préréglages.</system:String>
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Langue</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Montrer les notes des autres pistes sur le piano roll</system:String>
   <system:String x:Key="prefs.appearance.showicon">Montrer l'icône sur le piano roll</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Montrer le portrait sur le piano roll</system:String>
@@ -607,9 +616,36 @@ Attention : cela va effacer les préréglages.</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Effacer le cache à la fermeture du logiciel</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">Cache du Tensor de DiffSinger</system:String>
   <system:String x:Key="prefs.caption">Préférences</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <system:String x:Key="prefs.editing">Édition</system:String>
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Note: veuillez redémarrer OpenUtau après avoir changé cette option.</system:String>
   <system:String x:Key="prefs.otoeditor">Editeur d'Oto</system:String>
   <system:String x:Key="prefs.otoeditor.select">Editeur d'Oto par défaut</system:String>
@@ -629,6 +665,7 @@ Attention : cela va effacer les préréglages.</system:String>
   <system:String x:Key="prefs.playback.backend">Backend Audio</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Automatique</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Position du curseur</system:String>
   <system:String x:Key="prefs.playback.device">Sortie Audio</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">En pause</system:String>
@@ -640,6 +677,7 @@ Attention : cela va effacer les préréglages.</system:String>
   <system:String x:Key="prefs.rendering">Rendu</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Système de rendu par défaut (pour les voix classiques)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">Render Depth du DiffSinger</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -771,6 +809,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Choisissez un encodage où le contenu des fichiers est lisible.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Remplacer l'alias</system:String>

--- a/OpenUtau/Strings/Strings.id-ID.axaml
+++ b/OpenUtau/Strings/Strings.id-ID.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Tanda Waktu</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Pengaturan Trek</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Lokasi</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Perender</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Tetapkan Sebagai Bawaan</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -452,6 +456,8 @@ Peringatan: opsi ini menghapus prasetel khusus.</system:String>
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Asisten Fonetik</system:String>
   <system:String x:Key="phoneticassistant.copy">Salin</system:String>
 
@@ -598,6 +604,9 @@ Peringatan: opsi ini menghapus prasetel khusus.</system:String>
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Bahasa</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Tampilkan not trek lain di piano roll</system:String>
   <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Tampilkan foto potret di piano roll</system:String>
@@ -610,9 +619,36 @@ Peringatan: opsi ini menghapus prasetel khusus.</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Hapus cache saat keluar</system:String>
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <system:String x:Key="prefs.caption">Preferensi</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Catatan: silakan restart OpenUtau setelah mengubah item ini.</system:String>
   <system:String x:Key="prefs.otoeditor">Pengedit Oto</system:String>
   <system:String x:Key="prefs.otoeditor.select">Pengedit Oto Bawaan</system:String>
@@ -632,6 +668,7 @@ Peringatan: opsi ini menghapus prasetel khusus.</system:String>
   <system:String x:Key="prefs.playback.backend">Latar Belakang Audio</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Otomatis</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Margin Gulir Otomatis</system:String>
   <system:String x:Key="prefs.playback.device">Perangkat Pemutaran</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Saat Menjeda</system:String>
@@ -643,6 +680,7 @@ Peringatan: opsi ini menghapus prasetel khusus.</system:String>
   <system:String x:Key="prefs.rendering">Merender</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Perender bawaan (untuk voicebank klasik)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">Kedalaman Render DiffSinger</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -774,6 +812,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Pilih pengkodean yang membuat konten berkas terlihat benar.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Timpa Alias</system:String>

--- a/OpenUtau/Strings/Strings.it-IT.axaml
+++ b/OpenUtau/Strings/Strings.it-IT.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Indicazione di tempo</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Impostazioni traccia</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Percorso</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Imposta default</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -452,6 +456,8 @@ Attenzione: questa opzione rimuove tutti i preset salvati.</system:String>
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Assistente fonetico</system:String>
   <system:String x:Key="phoneticassistant.copy">Copia</system:String>
 
@@ -598,6 +604,9 @@ Tieni premuto Ctrl per selezionare</system:String>
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Lingua</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Mostra note di altre tracce sul piano roll</system:String>
   <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Mostra immagine del cantante sul piano roll</system:String>
@@ -610,9 +619,36 @@ Tieni premuto Ctrl per selezionare</system:String>
   <!--<system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>-->
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <system:String x:Key="prefs.caption">Preferenze</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Nota: riavvia OpenUtau dopo aver modificato questo elemento.</system:String>
   <system:String x:Key="prefs.otoeditor">Oto editor</system:String>
   <system:String x:Key="prefs.otoeditor.select">Oto editor di default</system:String>
@@ -632,6 +668,7 @@ Tieni premuto Ctrl per selezionare</system:String>
   <system:String x:Key="prefs.playback.backend">Backend Audio</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Automatico</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Posizione del cursore</system:String>
   <system:String x:Key="prefs.playback.device">Dispositivo audio</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Pausa alla posizione corrente</system:String>
@@ -643,6 +680,7 @@ Tieni premuto Ctrl per selezionare</system:String>
   <system:String x:Key="prefs.rendering">Renderizzazione</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -774,6 +812,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Seleziona la codifica corretta.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Annulla Alias</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">拍子</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">トラック設定</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">フォルダを開く</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">レンダラー</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">デフォルト設定として保存</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="errors.failed.synth.cutoffexceedduration">原音設定エラー：右ブランクが前すぎます</system:String>
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">最新のVisual C++ランタイムをインストールしてください。 https://learn.microsoft.com/ja-JP/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">正規表現に使用できない文字が含まれています</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- 正規表現エラー -</system:String>
@@ -452,6 +456,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">音素変換アシスタント</system:String>
   <system:String x:Key="phoneticassistant.copy">コピー</system:String>
 
@@ -598,6 +604,9 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <system:String x:Key="prefs.appearance.diffsingerlangcodehide">音素に併記される言語コードを非表示</system:String>
   <system:String x:Key="prefs.appearance.lang">言語</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">ピアノロール上に他トラックの音符を表示</system:String>
   <system:String x:Key="prefs.appearance.showicon">ピアノロールウィンドウにアイコンを表示</system:String>
   <system:String x:Key="prefs.appearance.showportrait">ピアノロール上に背景イラストを表示</system:String>
@@ -610,9 +619,36 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="prefs.cache.clearonquit">終了時にキャッシュを消去する</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor をキャッシュする</system:String>
   <system:String x:Key="prefs.caption">環境設定</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <system:String x:Key="prefs.editing">編集</system:String>
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Note: この設定を変更した後は、OpenUtauを再起動してください。</system:String>
   <system:String x:Key="prefs.otoeditor">原音設定</system:String>
   <system:String x:Key="prefs.otoeditor.select">デフォルトの原音設定エディタ</system:String>
@@ -632,6 +668,7 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="prefs.playback.backend">オーディオバックエンド</system:String>
   <system:String x:Key="prefs.playback.backend.auto">自動</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">カーソルの場所</system:String>
   <system:String x:Key="prefs.playback.device">再生デバイス</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">一時停止した時のカーソル</system:String>
@@ -643,6 +680,7 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="prefs.rendering">レンダリング</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Classic UTAU音源のデフォルトレンダラー</system:String>
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps：Acoustic</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps：ピッチ</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps：Variance</system:String>
@@ -774,6 +812,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">テキストが文字化けしないエンコードを選択してください。</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">エイリアスの手動指定</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">박자표</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">트랙 설정</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">위치 열기</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">렌더러</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">이 값을 기본값으로</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -452,6 +456,8 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">음소 도우미</system:String>
   <system:String x:Key="phoneticassistant.copy">복사</system:String>
 
@@ -598,6 +604,9 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">언어</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">피아노 롤에 다른 트랙의 노트 표시</system:String>
   <system:String x:Key="prefs.appearance.showicon">피아노 롤에 가수 아이콘 표시</system:String>
   <system:String x:Key="prefs.appearance.showportrait">피아노 롤에 가수 스탠딩 표시</system:String>
@@ -610,9 +619,36 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.cache.clearonquit">나갈 때 자동으로 캐시 삭제</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger 텐서 캐시</system:String>
   <system:String x:Key="prefs.caption">환경 설정</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">참고: 설정을 반영하려면 OpenUtau를 재시작하세요.</system:String>
   <system:String x:Key="prefs.otoeditor">원음설정 에디터</system:String>
   <system:String x:Key="prefs.otoeditor.select">기본 원음설정 에디터</system:String>
@@ -632,6 +668,7 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.playback.backend">오디오 백엔드</system:String>
   <system:String x:Key="prefs.playback.backend.auto">자동</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">자동 스크롤 여백</system:String>
   <system:String x:Key="prefs.playback.device">오디오 출력 장치</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">일시정지할 때</system:String>
@@ -643,6 +680,7 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.rendering">렌더링</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">기본 렌더러 (Classic 음원용)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger 렌더링 깊이(Depth)</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -774,6 +812,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">텍스트가 정상적으로 보이는 인코딩을 골라 주세요.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">에일리어스 덮어쓰기</system:String>

--- a/OpenUtau/Strings/Strings.nl-NL.axaml
+++ b/OpenUtau/Strings/Strings.nl-NL.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Tijd Signatuur</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Track instellingen</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Locatie</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Stel in als standaard</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">Probeer de nieuwste versie van Visual C++ Redistributable te installeren. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Teken niet toegestaan ​​in reguliere expressie</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- fout in reguliere expressie -</system:String>
@@ -452,6 +456,8 @@ Waarschuwing: deze optie verwijdert aangepaste voorinstellingen.</system:String>
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Fonetische assistent</system:String>
   <system:String x:Key="phoneticassistant.copy">Kopieer</system:String>
 
@@ -594,6 +600,9 @@ Ctrl ingedrukt houden om te selecteren</system:String>
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Taal</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Toon portret op pianorol</system:String>
@@ -606,9 +615,36 @@ Ctrl ingedrukt houden om te selecteren</system:String>
   <!--<system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>-->
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <system:String x:Key="prefs.caption">Voorkeuren</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">*herstart OpenUtau a.u.b. na het wijzigen van dit item.*</system:String>
   <system:String x:Key="prefs.otoeditor">Oto bewerker</system:String>
   <system:String x:Key="prefs.otoeditor.select">Standaard oto bewerker</system:String>
@@ -628,6 +664,7 @@ Ctrl ingedrukt houden om te selecteren</system:String>
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <system:String x:Key="prefs.playback.backend.auto">Automatisch</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Cursorpositie</system:String>
   <system:String x:Key="prefs.playback.device">Afspeelapparaat</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Op pauze</system:String>
@@ -639,6 +676,7 @@ Ctrl ingedrukt houden om te selecteren</system:String>
   <system:String x:Key="prefs.rendering">Renderen</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -768,6 +806,8 @@ The voicebank may not work on another OS.</system:String>-->
   <!--<system:String x:Key="singersetup.textfileencoding.prompt">Choose an encoding that make file contents look right.</system:String>-->
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Overschrijf Alias</system:String>

--- a/OpenUtau/Strings/Strings.pl-PL.axaml
+++ b/OpenUtau/Strings/Strings.pl-PL.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Takt</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Ustawienia ścieżki</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Lokalizacja</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Silnik</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Ustaw jako domyślny</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">Spróbuj zainstalować najnowsze Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Niedozwolony znak w wyrażeniu regularnym</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- Błąd wyrażenia regularnego -</system:String>
@@ -452,6 +456,8 @@ Uwaga: ta opcja usuwa presety własne.</system:String>
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Asystent fonetyczny</system:String>
   <system:String x:Key="phoneticassistant.copy">Kopiuj</system:String>
 
@@ -598,6 +604,9 @@ Uwaga: ta opcja usuwa presety własne.</system:String>
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Język</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Pokaż nuty innych ścieżek na piano roll</system:String>
   <system:String x:Key="prefs.appearance.showicon">Pokaż ikony na piano roll</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Pokaż portret na piano roll</system:String>
@@ -610,9 +619,36 @@ Uwaga: ta opcja usuwa presety własne.</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Wyczyść pamięć podręczną przy zamknięciu</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">Pamięć podręczna tensora DiffSinger</system:String>
   <system:String x:Key="prefs.caption">Ustawienia</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Uwaga: proszę uruchomić ponownie OpenUtau po zmienie tej opcji.</system:String>
   <system:String x:Key="prefs.otoeditor">Edytor OTO</system:String>
   <system:String x:Key="prefs.otoeditor.select">Domyślny edytor OTO</system:String>
@@ -632,6 +668,7 @@ Uwaga: ta opcja usuwa presety własne.</system:String>
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <system:String x:Key="prefs.playback.backend.auto">Automatyczny</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Margines automatycznego przewijania</system:String>
   <system:String x:Key="prefs.playback.device">Urządzenie odtwarzania</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Podczas pauzy</system:String>
@@ -643,6 +680,7 @@ Uwaga: ta opcja usuwa presety własne.</system:String>
   <system:String x:Key="prefs.rendering">Renderowanie</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Domyślny silnik (dla klasycznych voicebanków)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">Głębia renderu DiffSinger</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -774,6 +812,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Wybierz kodowanie, w którym treść plików jest czytelna.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Nadpisz alias</system:String>

--- a/OpenUtau/Strings/Strings.pt-BR.axaml
+++ b/OpenUtau/Strings/Strings.pt-BR.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Assinatura de Tempo</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Configurações de Faixa</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Local</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Renderizador</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Definir como Padrão</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">Tente instalar a versão mais recente do Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Caractere não permitido na expressão regular</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- erro de expressão regular -</system:String>
@@ -452,6 +456,8 @@ Aviso: esta opção remove predefinições personalizadas.</system:String>
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Assistente Fonético</system:String>
   <system:String x:Key="phoneticassistant.copy">Copiar</system:String>
 
@@ -594,6 +600,9 @@ Segure Ctrl para selecionar</system:String>
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Idioma</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Mostrar notas fantasma</system:String>
   <system:String x:Key="prefs.appearance.showicon">Mostrar ícone no piano roll</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Mostrar retrato no piano roll</system:String>
@@ -606,9 +615,36 @@ Segure Ctrl para selecionar</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Limpar o cache ao sair</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">Cache do DiffSinger Tensor</system:String>
   <system:String x:Key="prefs.caption">Preferências</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <system:String x:Key="prefs.editing">Edição</system:String>
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Nota: reinicie o OpenUtau após alterar este item.</system:String>
   <system:String x:Key="prefs.otoeditor">Editor de Oto</system:String>
   <system:String x:Key="prefs.otoeditor.select">Editor de Oto Padr</system:String>
@@ -628,6 +664,7 @@ Segure Ctrl para selecionar</system:String>
   <system:String x:Key="prefs.playback.backend">Back-end de áudio</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Automático</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Posição do Cursor</system:String>
   <system:String x:Key="prefs.playback.device">Dispositivo de Reprodução</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Quando Parar</system:String>
@@ -639,6 +676,7 @@ Segure Ctrl para selecionar</system:String>
   <system:String x:Key="prefs.rendering">Renderização</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Renderizador padrão (para bancos de voz clássicos)</system:String>
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -770,6 +808,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Escolha uma codificação que faça o conteúdo do arquivo parecer correto.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Substituir Alias</system:String>

--- a/OpenUtau/Strings/Strings.ro-RO.axaml
+++ b/OpenUtau/Strings/Strings.ro-RO.axaml
@@ -134,8 +134,10 @@ OpenUtau aims to be an open source editing environment for UTAU community, with 
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <!--<system:String x:Key="dialogs.timesig.caption">Time Signature</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.caption">Track Settings</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -197,6 +199,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -451,6 +455,8 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <!--<system:String x:Key="phoneticassistant.caption">Phonetic Assistant</system:String>-->
   <!--<system:String x:Key="phoneticassistant.copy">Copy</system:String>-->
 
@@ -596,6 +602,9 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <!--<system:String x:Key="prefs.appearance.lang">Language</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>-->
@@ -608,9 +617,36 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>-->
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <!--<system:String x:Key="prefs.caption">Preferences</system:String>-->
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <!--<system:String x:Key="prefs.note.restart">Note: please restart OpenUtau after changing this item.</system:String>-->
   <!--<system:String x:Key="prefs.otoeditor">Oto Editor</system:String>-->
   <!--<system:String x:Key="prefs.otoeditor.select">Default Oto Editor</system:String>-->
@@ -630,6 +666,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <!--<system:String x:Key="prefs.playback.cursorposition">Auto-Scroll Margin</system:String>-->
   <!--<system:String x:Key="prefs.playback.device">Playback Device</system:String>-->
   <!--<system:String x:Key="prefs.playback.lockstarttime">On Pausing</system:String>-->
@@ -641,6 +678,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.rendering">Rendering</system:String>-->
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -766,6 +804,8 @@ The voicebank may not work on another OS.</system:String>-->
   <!--<system:String x:Key="singersetup.textfileencoding.prompt">Choose an encoding that make file contents look right.</system:String>-->
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <!--<system:String x:Key="tip.aliasbox">Override Alias</system:String>-->

--- a/OpenUtau/Strings/Strings.ru-RU.axaml
+++ b/OpenUtau/Strings/Strings.ru-RU.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Такт</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Параметры трека</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Расположение</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Рендер</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Установить по умолчанию</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">Попробуйте установить Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Символ не разрешён в регулярном выражении</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- ошибка регулярного выражения -</system:String>
@@ -452,6 +456,8 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Фонетический помощник</system:String>
   <system:String x:Key="phoneticassistant.copy">Скопировть</system:String>
 
@@ -594,6 +600,9 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <system:String x:Key="prefs.appearance.diffsingerlangcodehide">Спрятать Языковой префикс </system:String>
   <system:String x:Key="prefs.appearance.lang">Язык</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Отображать ноты других треков на пианоролле</system:String>
   <system:String x:Key="prefs.appearance.showicon">Отображать иконку на пианоролле</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Отображать портрет на пианоролле</system:String>
@@ -606,9 +615,36 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.cache.clearonquit">Очищать кэш при выходе</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">Тензорный кэш DiffSinger</system:String>
   <system:String x:Key="prefs.caption">Параметры</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <system:String x:Key="prefs.diffsinger">ДиффСингер</system:String>
   <system:String x:Key="prefs.editing">Редактирование</system:String>
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Примечание: пожалуйста, перезапустите OpenUtau после изменения этого пункта.</system:String>
   <system:String x:Key="prefs.otoeditor">Редактор oto</system:String>
   <system:String x:Key="prefs.otoeditor.select">Редактор oto по умолчанию</system:String>
@@ -628,6 +664,7 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.playback.backend">Звуковой бэкенд</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Автоматический</system:String>
   <system:String x:Key="prefs.playback.backend.mini">МиниАудио</system:String>
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Поле автопрокрутки</system:String>
   <system:String x:Key="prefs.playback.device">Устройство воспроизведения</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">На паузе</system:String>
@@ -639,6 +676,7 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.rendering">Рендеринг</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Рендерер по-умолчанию (для классических войсбанков)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">Глубина рендеринга DiffSinger</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <system:String x:Key="prefs.rendering.diffsingersteps">Количество шагов для рендера acoustic Diffsinger</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepspitch">Количество шагов для рендера питча Diffsinger</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepsvariance">Количество шагов для рендера variance Diffsinger</system:String>
@@ -770,6 +808,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Выберите кодировку, в которой содержимое файла будет выглядеть правильно.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Заменить алиасы</system:String>

--- a/OpenUtau/Strings/Strings.th-TH.axaml
+++ b/OpenUtau/Strings/Strings.th-TH.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">เครื่องหมายกำหนดจังหวะ</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.caption">Track Settings</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -452,6 +456,8 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">ผู้ช่วยการออกเสียง</system:String>
   <system:String x:Key="phoneticassistant.copy">คัดลอก</system:String>
 
@@ -594,6 +600,9 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">ภาษา</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">แสดงภาพเหมือนบน Piano roll</system:String>
@@ -606,9 +615,36 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>-->
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <system:String x:Key="prefs.caption">การตั้งค่า</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <!--<system:String x:Key="prefs.editing">Editing</system:String>-->
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">หมายเหตุ: โปรดรีสตาร์ท OpenUtau หลังจากเปลี่ยนรายการนี้</system:String>
   <!--<system:String x:Key="prefs.otoeditor">Oto Editor</system:String>-->
   <!--<system:String x:Key="prefs.otoeditor.select">Default Oto Editor</system:String>-->
@@ -628,6 +664,7 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.playback.backend">ระบบเสียงหลังบ้าน</system:String>
   <system:String x:Key="prefs.playback.backend.auto">อัตโนมัติ</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">ระยะขอบเลื่อนอัตโนมัติ</system:String>
   <system:String x:Key="prefs.playback.device">เครื่องเล่นซ้ำ</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">หยุดชั่วคราว</system:String>
@@ -639,6 +676,7 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.rendering">กำลังประมวลผล</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -768,6 +806,8 @@ The voicebank may not work on another OS.</system:String>-->
   <!--<system:String x:Key="singersetup.textfileencoding.prompt">Choose an encoding that make file contents look right.</system:String>-->
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <!--<system:String x:Key="tip.aliasbox">Override Alias</system:String>-->

--- a/OpenUtau/Strings/Strings.tr-TR.axaml
+++ b/OpenUtau/Strings/Strings.tr-TR.axaml
@@ -133,8 +133,10 @@
 Devam edip mevcut çalma kafasından sonra, notaların olmadığı en yakın konumdan bölmek ister misiniz?</system:String>
   <system:String x:Key="dialogs.timesig.caption">Vuruş İşareti</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Parça Ayarları</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Konum</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Varsayılan Yap</system:String>
   <system:String x:Key="dialogs.transcribe.allnotfound">Hiçbir transkripsiyon modeli yüklü değil. Lütfen Paket Yöneticisi'nden GAME'i yükleyin veya manuel olarak {0} adresinden indirin.</system:String>
   <system:String x:Key="dialogs.transcribe.caption">Sesi Notaya Dönüştür</system:String>
@@ -196,6 +198,8 @@ Devam edip mevcut çalma kafasından sonra, notaların olmadığı en yakın kon
   <system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto hatası: cutoff ses dosyası süresini aşıyor</system:String>
   <system:String x:Key="errors.failed.transcribe.rmvpe">RMVPE ONNX modeli yüklenemedi. Paket Yöneticisi'nden yükleyin veya rmvpe.onnx dosyasını {0} konumuna koyun</system:String>
   <system:String x:Key="errors.failed.transcribe.some">SOME yüklenemedi. Lütfen SOME'i {0} adresinden indirin</system:String>
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">En son Visual C++ Yeniden Dağıtılabilir paketini yüklemeyi deneyin. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Düzenli ifadede izin verilmeyen karakter</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- düzenli ifade hatası -</system:String>
@@ -450,6 +454,8 @@ Uyarı: Bu seçenek özel önayarları kaldırır.</system:String>
   <system:String x:Key="packages.unknownversion">bilinmeyen sürüm</system:String>
   <system:String x:Key="packages.update">Güncelle</system:String>
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Fonetik Asistan</system:String>
   <system:String x:Key="phoneticassistant.copy">Kopyala</system:String>
 
@@ -595,6 +601,9 @@ Uyarı: Bu seçenek özel önayarları kaldırır.</system:String>
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <system:String x:Key="prefs.appearance.diffsingerlangcodehide">Fonem düzenleyicisinden dil önekini gizle</system:String>
   <system:String x:Key="prefs.appearance.lang">Dil</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Piyano rulosunda diğer parçaların notalarını göster</system:String>
   <system:String x:Key="prefs.appearance.showicon">Piyano rulosunda ikon göster</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Piyano rulosunda portre göster</system:String>
@@ -607,9 +616,36 @@ Uyarı: Bu seçenek özel önayarları kaldırır.</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Çıkışta önbelleği temizle</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Önbelleği</system:String>
   <system:String x:Key="prefs.caption">Tercihler</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <system:String x:Key="prefs.editing">Düzenleme</system:String>
   <system:String x:Key="prefs.general">Genel</system:String>
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Not: Bu öğeyi değiştirdikten sonra OpenUtau'yu yeniden başlatın.</system:String>
   <system:String x:Key="prefs.otoeditor">Oto Editörü</system:String>
   <system:String x:Key="prefs.otoeditor.select">Varsayılan Oto Editörü</system:String>
@@ -629,6 +665,7 @@ Uyarı: Bu seçenek özel önayarları kaldırır.</system:String>
   <system:String x:Key="prefs.playback.backend">Ses Arka Ucu</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Otomatik</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Otomatik Kaydırma Marjı</system:String>
   <system:String x:Key="prefs.playback.device">Çalma Cihazı</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Duraklatma sırasında</system:String>
@@ -640,6 +677,7 @@ Uyarı: Bu seçenek özel önayarları kaldırır.</system:String>
   <system:String x:Key="prefs.rendering">Render</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Varsayılan renderer (klasik ses bankaları için)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Derinliği</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Akustik için Render Adımları</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Pitch için Render Adımları</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Varyans için Render Adımları</system:String>
@@ -765,6 +803,8 @@ Ses bankası başka bir işletim sisteminde çalışmayabilir.</system:String>
   <system:String x:Key="singersetup.textfileencoding.prompt">Dosya içeriklerinin doğru görünmesi için bir kodlama seçin.</system:String>
   <system:String x:Key="singersetup.title">Ses Bankası Kurulumu</system:String>
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <system:String x:Key="themeeditor.title">Tema Düzenleyici</system:String>
 
   <system:String x:Key="tip.aliasbox">Alias'ı geçersiz kıl</system:String>

--- a/OpenUtau/Strings/Strings.vi-VN.axaml
+++ b/OpenUtau/Strings/Strings.vi-VN.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">Số chỉ nhịp</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Thiết lập track</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <system:String x:Key="dialogs.tracksettings.location">Mở thư mục</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Trình render</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Đặt thành mặc định</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <system:String x:Key="errors.install.cpp">Cần cần đặt bản mới nhất của Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Không được dùng kí tự này trong biểu thức chính quy</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- lỗi biểu thức chính quy -</system:String>
@@ -452,6 +456,8 @@ Lưu ý: tuỳ chọn này cũng sẽ xoá các tổ hợp thiết lập của b
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <system:String x:Key="phoneticassistant.caption">Phân tích cách phát âm</system:String>
   <system:String x:Key="phoneticassistant.copy">Sao chép</system:String>
 
@@ -598,6 +604,9 @@ Lưu ý: tuỳ chọn này cũng sẽ xoá các tổ hợp thiết lập của b
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Ngôn ngữ</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">Hiện nốt các track khác trong Piano Roll</system:String>
   <system:String x:Key="prefs.appearance.showicon">Hiện icon trong Piano Roll</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Hiện avatar trong Piano Roll</system:String>
@@ -610,9 +619,36 @@ Lưu ý: tuỳ chọn này cũng sẽ xoá các tổ hợp thiết lập của b
   <system:String x:Key="prefs.cache.clearonquit">Dọn bộ nhớ đệm khi thoát chương trình</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">Bộ nhớ đệm Tensor của DiffSinger</system:String>
   <system:String x:Key="prefs.caption">Tuỳ chọn</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <system:String x:Key="prefs.editing">Chỉnh sửa</system:String>
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">Lưu ý: tắt mở lại OpenUTAU sau khi thay đổi thiết lập này.</system:String>
   <system:String x:Key="prefs.otoeditor">Trình chỉnh thiết lập nguồn âm</system:String>
   <system:String x:Key="prefs.otoeditor.select">Trình chỉnh thiết lập mặc định</system:String>
@@ -632,6 +668,7 @@ Lưu ý: tuỳ chọn này cũng sẽ xoá các tổ hợp thiết lập của b
   <system:String x:Key="prefs.playback.backend">Trình phát âm thanh</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Tự động</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">Vị trí con trỏ phát nhạc</system:String>
   <system:String x:Key="prefs.playback.device">Thiết bị phát nhạc</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">Khi dừng phát nhạc</system:String>
@@ -643,6 +680,7 @@ Lưu ý: tuỳ chọn này cũng sẽ xoá các tổ hợp thiết lập của b
   <system:String x:Key="prefs.rendering">Render</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Trình render mặc định (thư viện UTAU cổ điển)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">Chiều sâu render DiffSinger</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -774,6 +812,8 @@ The voicebank may not work on another OS.</system:String>-->
   <system:String x:Key="singersetup.textfileencoding.prompt">Chọn bảng mã sao cho văn bản hiển thị đúng.</system:String>
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">Đổi tên hiệu</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -135,8 +135,10 @@
 是否改为在播放头之后最近的无音符位置进行拆分？</system:String>
   <system:String x:Key="dialogs.timesig.caption">拍号</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">音轨设置</system:String>
+  <system:String x:Key="dialogs.tracksettings.endpoint">端点</system:String>
   <system:String x:Key="dialogs.tracksettings.location">位置</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">渲染器</system:String>
+  <system:String x:Key="dialogs.tracksettings.serverurl">服务器地址</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">设为默认</system:String>
   <system:String x:Key="dialogs.transcribe.allnotfound">当前未安装任何音频转写模型。请通过包管理器安装 GAME，或从此处手动下载：{0}</system:String>
   <system:String x:Key="dialogs.transcribe.caption">音频转写</system:String>
@@ -198,6 +200,8 @@
   <system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto 错误：cutoff 超出音频长度</system:String>
   <system:String x:Key="errors.failed.transcribe.rmvpe">加载 RMVPE ONNX 模型失败。请从插件管理器安装，或将 rmvpe.onnx 放到 {0}</system:String>
   <system:String x:Key="errors.failed.transcribe.some">加载 SOME 模型失败。请从此处下载：{0}</system:String>
+  <system:String x:Key="errors.hifiutau.disabled">HiFiUTAU 内嵌引擎已在 偏好设置 > HiFiUTAU 中禁用。</system:String>
+  <system:String x:Key="errors.hifiutau.nomodels">未找到 HiFiUTAU 模型。请在包管理器安装 pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 和 hnsep_VR_44.1k_hop512_2024.05。不要使用 PyTorch 的 model.ckpt 压缩包。</system:String>
   <system:String x:Key="errors.install.cpp">请安装最新的 Visual C++ 运行环境。 https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">正则表达式包含不支持的字符</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- 正则表达式错误 -</system:String>
@@ -422,7 +426,7 @@
   <system:String x:Key="packages.caption">插件</system:String>
   <system:String x:Key="packages.col.action">操作</system:String>
   <system:String x:Key="packages.col.developer">开发者</system:String>
-  <system:String x:Key="packages.col.id">Id</system:String>
+  <!--<system:String x:Key="packages.col.id">Id</system:String>-->
   <system:String x:Key="packages.col.installed">已安装</system:String>
   <system:String x:Key="packages.col.name">名称</system:String>
   <system:String x:Key="packages.col.version">版本</system:String>
@@ -451,6 +455,8 @@
   <system:String x:Key="packages.uninstall">卸载</system:String>
   <system:String x:Key="packages.unknownversion">未知版本</system:String>
   <system:String x:Key="packages.update">更新</system:String>
+
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
 
   <system:String x:Key="phoneticassistant.caption">语音学助手</system:String>
   <system:String x:Key="phoneticassistant.copy">复制</system:String>
@@ -594,6 +600,9 @@
   <system:String x:Key="prefs.appearance.detachpianoroll">在独立窗口中显示钢琴卷帘</system:String>
   <system:String x:Key="prefs.appearance.diffsingerlangcodehide">在音素编辑器中隐藏语言前缀</system:String>
   <system:String x:Key="prefs.appearance.lang">语言</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">在钢琴窗上显示其他音轨的音符</system:String>
   <system:String x:Key="prefs.appearance.showicon">在钢琴窗上显示歌手图标</system:String>
   <system:String x:Key="prefs.appearance.showportrait">在钢琴窗上显示歌手背景图</system:String>
@@ -606,9 +615,36 @@
   <system:String x:Key="prefs.cache.clearonquit">退出时清空缓存</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger 张量缓存</system:String>
   <system:String x:Key="prefs.caption">使用偏好</system:String>
-  <system:String x:Key="prefs.diffsinger">DiffSinger</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
+  <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <system:String x:Key="prefs.editing">编辑</system:String>
   <system:String x:Key="prefs.general">常规</system:String>
+  <system:String x:Key="prefs.hifiutau.customserver">Custom Server 后端地址</system:String>
+  <system:String x:Key="prefs.hifiutau.customserver.hint">"Custom Server" 渲染器使用的默认服务器地址（如 http://localhost:8000）。未单独设置地址的曲目使用此值。</system:String>
+  <system:String x:Key="prefs.hifiutau.embedded">使用内嵌引擎（进程内 ONNX 推理）</system:String>
+  <system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP 覆盖路径（留空则使用包管理器中的 hnsep_VR_44.1k_hop512_2024.05）。目录须含 oudep.yaml 和 HN-SEP ONNX。</system:String>
+  <system:String x:Key="prefs.hifiutau.preload">启动时预热引擎</system:String>
+  <system:String x:Key="prefs.hifiutau.preload.hint">编辑器启动时在后台加载模型，避免首次渲染卡顿。重启应用后生效。</system:String>
+  <system:String x:Key="prefs.hifiutau.reload">重载引擎</system:String>
+  <system:String x:Key="prefs.hifiutau.reload.all">全部</system:String>
+  <system:String x:Key="prefs.hifiutau.reload.hint">应用模型目录/线程数变更，并清空渲染缓存。</system:String>
+  <system:String x:Key="prefs.hifiutau.reload.hnsep">分离</system:String>
+  <system:String x:Key="prefs.hifiutau.reload.splicer">拼接</system:String>
+  <system:String x:Key="prefs.hifiutau.splicerpath">声码器覆盖路径（留空则使用包管理器中的 pc_nsf_hifigan_44.1k_hop512_128bin_2025.02）。目录须含 vocoder.yaml 及其指向的 ONNX，不是 model.ckpt。</system:String>
+  <system:String x:Key="prefs.hifiutau.status.format">模式：{0}
+拼接模型：{1}（{2}）
+分离模型：{3}（{4}）</system:String>
+  <system:String x:Key="prefs.hifiutau.status.mode.disabled">已禁用</system:String>
+  <system:String x:Key="prefs.hifiutau.status.mode.embedded">内嵌</system:String>
+  <system:String x:Key="prefs.hifiutau.status.notfound">未找到</system:String>
+  <system:String x:Key="prefs.hifiutau.status.notloaded">未加载</system:String>
+  <system:String x:Key="prefs.hifiutau.status.ready">已加载</system:String>
+  <system:String x:Key="prefs.hifiutau.threads">ONNX 推理线程数（单次推理）</system:String>
+  <system:String x:Key="prefs.hifiutau.threads.hint">0 = 自动。限制单次推理的 CPU 占用；重载引擎后生效。</system:String>
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">注意: 修改本项后请重启OpenUtau</system:String>
   <system:String x:Key="prefs.otoeditor">原音设定编辑器</system:String>
   <system:String x:Key="prefs.otoeditor.select">默认原音设定编辑器</system:String>
@@ -627,7 +663,8 @@
   <system:String x:Key="prefs.playback.autoscrollmode.stationarycursor">固定播放标记</system:String>
   <system:String x:Key="prefs.playback.backend">音频后端</system:String>
   <system:String x:Key="prefs.playback.backend.auto">自动</system:String>
-  <system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>
+  <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">自动滚动边界</system:String>
   <system:String x:Key="prefs.playback.device">回放设备</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">暂停时</system:String>
@@ -639,13 +676,13 @@
   <system:String x:Key="prefs.rendering">渲染</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">传统音源的默认渲染器</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger 渲染深度</system:String>
+  <system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger 音高局部重录</system:String>
   <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger 声学渲染步数</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger 音高渲染步数</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger 音色渲染步数</system:String>
   <system:String x:Key="prefs.rendering.diffsingervariancelocalpitchpatch">音高编辑时的 DiffSinger 局部音色更新</system:String>
   <system:String x:Key="prefs.rendering.gamebackend">GAME 推理后端</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger 音高局部重录</system:String>
-  <system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>
+  <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <system:String x:Key="prefs.rendering.onnxrunner">机器学习运行器</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">相位修正</system:String>
   <system:String x:Key="prefs.rendering.prerender">预渲染</system:String>
@@ -664,8 +701,8 @@
     警告：渲染线程过多可能会导致OpenUtau运行缓慢
   </system:String>
   <system:String x:Key="prefs.rendering.threads.numthreads">最大渲染线程数</system:String>
-  <system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>
-  <system:String x:Key="prefs.utau">UTAU</system:String>
+  <!--<system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>-->
+  <!--<system:String x:Key="prefs.utau">UTAU</system:String>-->
 
   <system:String x:Key="progress.cachecleared">缓存已清除</system:String>
   <system:String x:Key="progress.clearingcache">正在清除缓存...</system:String>
@@ -771,6 +808,8 @@
   <system:String x:Key="singersetup.textfileencoding.prompt">请选择一种编码，使文件内容看起来是正确的。</system:String>
   <system:String x:Key="singersetup.title">歌手安装</system:String>
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <system:String x:Key="themeeditor.title">主题编辑器</system:String>
 
   <system:String x:Key="tip.aliasbox">手动选择别名</system:String>
@@ -836,7 +875,7 @@
 
   <system:String x:Key="updater.caption">检查更新</system:String>
   <system:String x:Key="updater.description">开放歌声合成平台</system:String>
-  <system:String x:Key="updater.github">GitHub</system:String>
+  <!--<system:String x:Key="updater.github">GitHub</system:String>-->
   <system:String x:Key="updater.status.available">有新更新 v{0} !</system:String>
   <system:String x:Key="updater.status.checking">检查更新中...</system:String>
   <system:String x:Key="updater.status.notavailable">已更新至最新</system:String>

--- a/OpenUtau/Strings/Strings.zh-TW.axaml
+++ b/OpenUtau/Strings/Strings.zh-TW.axaml
@@ -135,8 +135,10 @@
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>-->
   <system:String x:Key="dialogs.timesig.caption">拍號</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">音軌設定</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.endpoint">Endpoint</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <system:String x:Key="dialogs.tracksettings.renderer">算繪器</system:String>
+  <!--<system:String x:Key="dialogs.tracksettings.serverurl">Server URL</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">設為預設</system:String>
   <!--<system:String x:Key="dialogs.transcribe.allnotfound">No transcription models are installed. Please install GAME via the Package Manager or download manually from {0}.</system:String>-->
   <!--<system:String x:Key="dialogs.transcribe.caption">Transcribe Audio</system:String>-->
@@ -198,6 +200,8 @@ Do you want to continue by splitting at the nearest position after current playh
   <!--<system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.rmvpe">Error loading RMVPE ONNX model. Install it from the Package Manager, or put rmvpe.onnx in {0}</system:String>-->
   <!--<system:String x:Key="errors.failed.transcribe.some">Error loading SOME. Please download SOME from {0}</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.disabled">The HiFiUTAU embedded engine is disabled in Preferences > HiFiUTAU.</system:String>-->
+  <!--<system:String x:Key="errors.hifiutau.nomodels">HiFiUTAU models not found. Install pc_nsf_hifigan_44.1k_hop512_128bin_2025.02 and hnsep_VR_44.1k_hop512_2024.05 from the Package Manager. Do not use the PyTorch model.ckpt zip.</system:String>-->
   <!--<system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>-->
   <!--<system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>-->
@@ -452,6 +456,8 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="packages.unknownversion">unknown version</system:String>-->
   <!--<system:String x:Key="packages.update">Update</system:String>-->
 
+  <!--<system:String x:Key="phoneme.show.error">Alt + Click to view the full error</system:String>-->
+
   <!--<system:String x:Key="phoneticassistant.caption">Phonetic Assistant</system:String>-->
   <system:String x:Key="phoneticassistant.copy">複製</system:String>
 
@@ -594,6 +600,9 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="prefs.appearance.detachpianoroll">Show piano roll in separate window</system:String>-->
   <!--<system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>-->
   <system:String x:Key="prefs.appearance.lang">語言</system:String>
+  <!--<system:String x:Key="prefs.appearance.notehoverglow">Note hover glow</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotebounce">Bounce notes on playback</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.playbacknotehighlight">Highlight notes on playback</system:String>-->
   <system:String x:Key="prefs.appearance.showghostnotes">在鋼琴卷軸上顯示其他音軌的音符</system:String>
   <system:String x:Key="prefs.appearance.showicon">在鋼琴卷軸上顯示角色頭像</system:String>
   <system:String x:Key="prefs.appearance.showportrait">在鋼琴卷軸上顯示角色背景圖</system:String>
@@ -606,9 +615,36 @@ Syntax: prefix,suffix</system:String>-->
   <!--<system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>-->
   <!--<system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>-->
   <system:String x:Key="prefs.caption">偏好設定</system:String>
+  <!--<system:String x:Key="prefs.channel">Release Channel</system:String>-->
+  <!--<system:String x:Key="prefs.channel.alpha">Alpha</system:String>-->
+  <!--<system:String x:Key="prefs.channel.beta">Beta</system:String>-->
+  <!--<system:String x:Key="prefs.channel.stable">Stable</system:String>-->
   <!--<system:String x:Key="prefs.diffsinger">DiffSinger</system:String>-->
   <system:String x:Key="prefs.editing">編輯</system:String>
   <!--<system:String x:Key="prefs.general">General</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver">Custom Server backend address</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.customserver.hint">Default server URL used by the Custom Server renderer (e.g. http://localhost:8000). New tracks without an explicit URL use this value.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.embedded">Use embedded engine (in-process ONNX inference)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.hnseppath">HN-SEP override (empty = Package Manager hnsep_VR_44.1k_hop512_2024.05). Directory must contain oudep.yaml and the HN-SEP ONNX.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload">Preload engine on startup</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.preload.hint">Loads models in the background while the editor starts. Takes effect on next launch.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload">Reload engine</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.all">All</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hint">Applies model directory / thread changes and clears the render cache.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.hnsep">HN-SEP</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.reload.splicer">Splicer</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.splicerpath">Vocoder override (empty = Package Manager pc_nsf_hifigan_44.1k_hop512_128bin_2025.02). Directory must contain vocoder.yaml and the ONNX named in it, not model.ckpt.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.format">Mode: {0}
+Splicer model: {1} ({2})
+HN-SEP model: {3} ({4})</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.disabled">Disabled</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.mode.embedded">Embedded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notfound">not found</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.notloaded">not loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.status.ready">loaded</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads">ONNX inference threads (per call)</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.threads.hint">0 = automatic. Limits CPU usage per inference; applied after reloading the engine.</system:String>-->
+  <!--<system:String x:Key="prefs.hifiutau.title">HiFiUTAU</system:String>-->
   <system:String x:Key="prefs.note.restart">注意: 請重新啟動 OpenUtau 以套用變更</system:String>
   <system:String x:Key="prefs.otoeditor">Oto 編輯器</system:String>
   <system:String x:Key="prefs.otoeditor.select">預設 Oto 編輯器</system:String>
@@ -628,6 +664,7 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.playback.backend">音訊後端</system:String>
   <system:String x:Key="prefs.playback.backend.auto">自動</system:String>
   <!--<system:String x:Key="prefs.playback.backend.mini">MiniAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.backend.sdl3">SDL 3</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">開始捲動位置</system:String>
   <system:String x:Key="prefs.playback.device">播放裝置</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">暫停時</system:String>
@@ -639,6 +676,7 @@ Syntax: prefix,suffix</system:String>-->
   <system:String x:Key="prefs.rendering">算繪</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">傳統音源的預設算繪器</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger 算繪深度</system:String>
+  <!--<system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>-->
@@ -770,6 +808,8 @@ The voicebank may not work on another OS.</system:String>-->
   <!--<system:String x:Key="singersetup.textfileencoding.prompt">Choose an encoding that make file contents look right.</system:String>-->
   <!--<system:String x:Key="singersetup.title">Singer Setup</system:String>-->
 
+  <!--<system:String x:Key="themeeditor.cancel">Cancel</system:String>-->
+  <!--<system:String x:Key="themeeditor.save">Save</system:String>-->
   <!--<system:String x:Key="themeeditor.title">Theme Editor</system:String>-->
 
   <system:String x:Key="tip.aliasbox">覆寫別名</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -13,6 +13,7 @@ using ReactiveUI;
 using ReactiveUI.SourceGenerators;
 using ReactiveUI.Primitives;
 using ReactiveUI.Avalonia;
+using OpenUtau.Core.HiFiUtau;
 using OpenUtau.Core.Render;
 using Serilog;
 
@@ -136,6 +137,16 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public partial bool DiffSingerLangCodeHide { get; set; }
         [Reactive] public partial bool DiffSingerLocalRetaking { get; set; }
 
+        // HiFiUTAU / Custom Server
+        [Reactive] public partial bool HifiUtauEmbedded { get; set; }
+        [Reactive] public partial string HifiUtauSplicerPath { get; set; } = string.Empty;
+        [Reactive] public partial string HifiUtauHnsepPath { get; set; } = string.Empty;
+        [Reactive] public partial bool HifiUtauPreload { get; set; }
+        public List<int> HifiUtauThreadsOptions { get; } = new List<int> { 0, 1, 2, 4, 8 };
+        [Reactive] public partial int HifiUtauIntraOpThreads { get; set; }
+        [Reactive] public partial string CustomServerUrl { get; set; } = string.Empty;
+        [Reactive] public partial string HifiUtauStatus { get; set; } = string.Empty;
+
         // Advanced
         [Reactive] public partial bool RememberMid { get; set; }
         [Reactive] public partial bool RememberUst { get; set; }
@@ -184,6 +195,13 @@ namespace OpenUtau.App.ViewModels {
             OnnxGpuOptions = Onnx.getGpuInfo();
             OnnxGpu = OnnxGpuOptions.FirstOrDefault(x => x.deviceId == Preferences.Default.OnnxGpu, OnnxGpuOptions[0]);
             ShowOnnxGpu = OnnxRunner == "DirectML";
+            HifiUtauEmbedded = Preferences.Default.HifiUtauEmbedded;
+            HifiUtauSplicerPath = Preferences.Default.HifiUtauSplicerPath;
+            HifiUtauHnsepPath = Preferences.Default.HifiUtauHnsepPath;
+            HifiUtauPreload = Preferences.Default.HifiUtauPreload;
+            HifiUtauIntraOpThreads = Preferences.Default.HifiUtauIntraOpThreads;
+            CustomServerUrl = Preferences.Default.DefaultServerUrl;
+            RefreshHifiUtauStatus();
             // GAME backend: ONNX is the default, GGML is available when installed.
             // The options list always includes both so the ComboBox UX is stable.
             GameBackend = Preferences.Default.GameBackend switch {
@@ -410,6 +428,41 @@ namespace OpenUtau.App.ViewModels {
                     Preferences.Default.OnnxGpu = index.deviceId;
                     Preferences.Save();
                 });
+            this.WhenAnyValue(vm => vm.HifiUtauEmbedded)
+                .Subscribe(value => {
+                    Preferences.Default.HifiUtauEmbedded = value;
+                    Preferences.Save();
+                    RefreshHifiUtauStatus();
+                });
+            this.WhenAnyValue(vm => vm.HifiUtauPreload)
+                .Subscribe(value => {
+                    Preferences.Default.HifiUtauPreload = value;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.HifiUtauSplicerPath)
+                .Subscribe(path => {
+                    Preferences.Default.HifiUtauSplicerPath = path ?? string.Empty;
+                    Preferences.Save();
+                    RefreshHifiUtauStatus();
+                });
+            this.WhenAnyValue(vm => vm.HifiUtauHnsepPath)
+                .Subscribe(path => {
+                    Preferences.Default.HifiUtauHnsepPath = path ?? string.Empty;
+                    Preferences.Save();
+                    RefreshHifiUtauStatus();
+                });
+            this.WhenAnyValue(vm => vm.HifiUtauIntraOpThreads)
+                .Subscribe(value => {
+                    Preferences.Default.HifiUtauIntraOpThreads = value;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.CustomServerUrl)
+                .Subscribe(url => {
+                    if (!string.IsNullOrWhiteSpace(url)) {
+                        Preferences.Default.DefaultServerUrl = url;
+                        Preferences.Save();
+                    }
+                });
             this.WhenAnyValue(vm => vm.GameBackend)
                 .Subscribe(index => {
                     Preferences.Default.GameBackend = index == "GGML" ? "ggml" : "onnx";
@@ -534,6 +587,48 @@ namespace OpenUtau.App.ViewModels {
 
         public void ToggleOnnxGpuDisplay(bool show) {
             ShowOnnxGpu = show;
+        }
+
+        public void SetHifiUtauSplicerPath(string path) {
+            Preferences.Default.HifiUtauSplicerPath = path ?? string.Empty;
+            Preferences.Save();
+            HifiUtauSplicerPath = Preferences.Default.HifiUtauSplicerPath;
+            RefreshHifiUtauStatus();
+        }
+
+        public void SetHifiUtauHnsepPath(string path) {
+            Preferences.Default.HifiUtauHnsepPath = path ?? string.Empty;
+            Preferences.Save();
+            HifiUtauHnsepPath = Preferences.Default.HifiUtauHnsepPath;
+            RefreshHifiUtauStatus();
+        }
+
+        public void ResetHifiUtauPaths() {
+            Preferences.Default.HifiUtauSplicerPath = string.Empty;
+            Preferences.Default.HifiUtauHnsepPath = string.Empty;
+            Preferences.Save();
+            HifiUtauSplicerPath = string.Empty;
+            HifiUtauHnsepPath = string.Empty;
+            RefreshHifiUtauStatus();
+        }
+
+        public void RefreshHifiUtauStatus() {
+            var store = HiFiUtauModelStore.Inst;
+            string mode = Preferences.Default.HifiUtauEmbedded
+                ? ThemeManager.GetString("prefs.hifiutau.status.mode.embedded")
+                : ThemeManager.GetString("prefs.hifiutau.status.mode.disabled");
+            string splicer = store.SplicerReady
+                ? ThemeManager.GetString("prefs.hifiutau.status.ready")
+                : (store.SplicerError ?? ThemeManager.GetString("prefs.hifiutau.status.notloaded"));
+            string hnsep = store.HnsepReady
+                ? ThemeManager.GetString("prefs.hifiutau.status.ready")
+                : (store.HnsepError ?? ThemeManager.GetString("prefs.hifiutau.status.notloaded"));
+            HifiUtauStatus = string.Format(ThemeManager.GetString("prefs.hifiutau.status.format"),
+                mode,
+                store.SplicerDir ?? ThemeManager.GetString("prefs.hifiutau.status.notfound"),
+                splicer,
+                store.HnsepDir ?? ThemeManager.GetString("prefs.hifiutau.status.notfound"),
+                hnsep);
         }
     }
 }

--- a/OpenUtau/ViewModels/TrackSettingsViewModel.cs
+++ b/OpenUtau/ViewModels/TrackSettingsViewModel.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using DynamicData.Binding;
 using OpenUtau.Classic;
 using OpenUtau.Core;
+using OpenUtau.Core.CustomRender;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
@@ -20,6 +21,11 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public partial IWavtool? Wavtool { get; set; }
         [Reactive] public partial bool NeedsWavtool { get; set; }
         [Reactive] public partial bool IsNotClassic { get; set; }
+        [Reactive] public partial bool IsCustomServer { get; set; }
+        [Reactive] public partial bool IsHiFiUtau { get; set; }
+        [Reactive] public partial bool IsServerRenderer { get; set; }
+        [Reactive] public partial string ServerUrl { get; set; } = "http://localhost:8000";
+        [Reactive] public partial string Endpoint { get; set; } = "/synthesize";
 
         ObservableCollectionExtended<IResampler> resamplers =
             new ObservableCollectionExtended<IResampler>();
@@ -50,6 +56,14 @@ namespace OpenUtau.App.ViewModels {
                 NeedsResampler = Renderers.CLASSIC == renderer;
                 NeedsWavtool = Renderers.CLASSIC == renderer;
                 IsNotClassic = Renderers.CLASSIC != renderer;
+                IsCustomServer = renderer == Renderers.CUSTOM_SERVER;
+                IsHiFiUtau = renderer == Renderers.HIFIUTAU;
+                IsServerRenderer = IsCustomServer;
+
+                if (IsCustomServer && Track.RendererSettings.Renderer is CustomServerRenderer customServerRenderer) {
+                    ServerUrl = customServerRenderer.ServerUrl;
+                    Endpoint = customServerRenderer.Endpoint;
+                }
             }
             this.WhenAnyValue(x => x.Resampler)
                 .OfType<IResampler>()
@@ -93,16 +107,37 @@ namespace OpenUtau.App.ViewModels {
             }
         }
 
-        public void Finish() {
-            if (Renderers.CLASSIC != Track.RendererSettings.renderer) {
-                return;
+        public void SetDefaultServerUrl() {
+            if (IsCustomServer) {
+                Preferences.Default.DefaultServerUrl = ServerUrl;
+                Preferences.Default.DefaultEndpoint = Endpoint;
+                Preferences.Save();
             }
-            DocManager.Inst.StartUndoGroup("command.track.setting");
-            var settings = Track.RendererSettings.Clone();
-            settings.resampler = Resampler?.ToString() ?? string.Empty;
-            settings.wavtool = Wavtool?.ToString() ?? string.Empty;
-            DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, Track, settings));
-            DocManager.Inst.EndUndoGroup();
+        }
+
+        public void Finish() {
+            if (Renderers.CLASSIC == Track.RendererSettings.renderer) {
+                DocManager.Inst.StartUndoGroup("command.track.setting");
+                var settings = Track.RendererSettings.Clone();
+                settings.resampler = Resampler?.ToString() ?? string.Empty;
+                settings.wavtool = Wavtool?.ToString() ?? string.Empty;
+                DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, Track, settings));
+                DocManager.Inst.EndUndoGroup();
+            } else if (IsCustomServer) {
+                DocManager.Inst.StartUndoGroup("command.track.setting");
+                var settings = Track.RendererSettings.Clone();
+                settings.renderer = Renderers.CUSTOM_SERVER;
+                settings.serverUrl = ServerUrl;
+                settings.endpoint = Endpoint;
+                DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, Track, settings));
+                DocManager.Inst.EndUndoGroup();
+            } else if (IsHiFiUtau) {
+                DocManager.Inst.StartUndoGroup("command.track.setting");
+                var settings = Track.RendererSettings.Clone();
+                settings.renderer = Renderers.HIFIUTAU;
+                DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, Track, settings));
+                DocManager.Inst.EndUndoGroup();
+            }
         }
     }
 }

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -57,6 +57,7 @@
       <ListBoxItem Content="{DynamicResource prefs.appearance}"/>
       <ListBoxItem Content="{DynamicResource prefs.utau}"/>
       <ListBoxItem Content="{DynamicResource prefs.diffsinger}"/>
+      <ListBoxItem Content="{DynamicResource prefs.hifiutau.title}"/>
       <ListBoxItem Content="{DynamicResource prefs.advanced}"/>
     </ListBox>
     <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
@@ -354,6 +355,54 @@
             <TextBlock Text="{DynamicResource prefs.rendering.diffsingerpitchlocalretaking}" HorizontalAlignment="Left" />
             <ToggleSwitch IsChecked="{Binding DiffSingerLocalRetaking}" />
           </Grid>
+        </StackPanel>
+
+        <!-- HiFiUTAU -->
+        <StackPanel>
+          <Grid Margin="0,10,0,0">
+            <TextBlock Text="{DynamicResource prefs.hifiutau.embedded}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding HifiUtauEmbedded}"/>
+          </Grid>
+          <TextBlock Margin="0,4,0,0" FontSize="11" TextWrapping="Wrap"
+                     Text="{Binding HifiUtauStatus}" />
+          <TextBlock Text="{DynamicResource prefs.hifiutau.splicerpath}" Margin="0,10,0,0"/>
+          <TextBox Text="{Binding HifiUtauSplicerPath}" PlaceholderText=".../Dependencies/pc_nsf_hifigan_44.1k_hop512_128bin_2025.02"/>
+          <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
+            <Button Grid.Column="0" Content="{DynamicResource button.select}"
+                    HorizontalAlignment="Stretch" Click="SelectHifiUtauSplicerPath"/>
+            <Button Grid.Column="2" Content="{DynamicResource button.reset}"
+                    HorizontalAlignment="Stretch" Click="ResetHifiUtauPaths"/>
+          </Grid>
+          <TextBlock Text="{DynamicResource prefs.hifiutau.hnseppath}" Margin="0,10,0,0"/>
+          <TextBox Text="{Binding HifiUtauHnsepPath}" PlaceholderText=".../Dependencies/hnsep_VR_44.1k_hop512_2024.05"/>
+          <Button HorizontalAlignment="Stretch" Content="{DynamicResource button.select}"
+                  Click="SelectHifiUtauHnsepPath"/>
+          <Grid Margin="0,10,0,0">
+            <TextBlock Text="{DynamicResource prefs.hifiutau.preload}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding HifiUtauPreload}"/>
+          </Grid>
+          <TextBlock FontSize="11" TextWrapping="Wrap"
+                     Text="{DynamicResource prefs.hifiutau.preload.hint}"/>
+          <TextBlock Text="{DynamicResource prefs.hifiutau.threads}" Margin="0,10,0,0"/>
+          <ComboBox HorizontalAlignment="Stretch" ItemsSource="{Binding HifiUtauThreadsOptions}"
+                    SelectedItem="{Binding HifiUtauIntraOpThreads}"/>
+          <TextBlock FontSize="11" TextWrapping="Wrap"
+                     Text="{DynamicResource prefs.hifiutau.threads.hint}"/>
+          <TextBlock Text="{DynamicResource prefs.hifiutau.reload}" Margin="0,10,0,0"/>
+          <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*,10,*">
+            <Button Grid.Column="0" Content="{DynamicResource prefs.hifiutau.reload.all}"
+                    HorizontalAlignment="Stretch" Click="ReloadHifiUtauAll"/>
+            <Button Grid.Column="2" Content="{DynamicResource prefs.hifiutau.reload.splicer}"
+                    HorizontalAlignment="Stretch" Click="ReloadHifiUtauSplicer"/>
+            <Button Grid.Column="4" Content="{DynamicResource prefs.hifiutau.reload.hnsep}"
+                    HorizontalAlignment="Stretch" Click="ReloadHifiUtauHnsep"/>
+          </Grid>
+          <TextBlock FontSize="11" TextWrapping="Wrap"
+                     Text="{DynamicResource prefs.hifiutau.reload.hint}"/>
+          <TextBlock Text="{DynamicResource prefs.hifiutau.customserver}" Margin="0,10,0,0"/>
+          <TextBox Text="{Binding CustomServerUrl}" PlaceholderText="http://localhost:8000"/>
+          <TextBlock FontSize="11" TextWrapping="Wrap"
+                     Text="{DynamicResource prefs.hifiutau.customserver.hint}"/>
         </StackPanel>
 
         <!-- Advanced -->

--- a/OpenUtau/Views/PreferencesDialog.axaml.cs
+++ b/OpenUtau/Views/PreferencesDialog.axaml.cs
@@ -8,6 +8,8 @@ using Avalonia.Platform.Storage;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Colors;
 using OpenUtau.Core;
+using OpenUtau.Core.HiFiUtau;
+using Serilog;
 
 namespace OpenUtau.App.Views {
     public partial class PreferencesDialog : Window {
@@ -162,6 +164,56 @@ namespace OpenUtau.App.Views {
                 File.Delete(CustomTheme.Themes[viewModel!.ThemeName]);
                 viewModel!.RefreshThemes();
                 viewModel!.ThemeName = previousTheme;
+            }
+        }
+
+        async void SelectHifiUtauSplicerPath(object sender, RoutedEventArgs e) {
+            var path = await FilePicker.OpenFolderAboutSinger(this, "prefs.hifiutau.splicerpath");
+            if (string.IsNullOrEmpty(path)) {
+                return;
+            }
+            viewModel!.SetHifiUtauSplicerPath(path);
+        }
+
+        async void SelectHifiUtauHnsepPath(object sender, RoutedEventArgs e) {
+            var path = await FilePicker.OpenFolderAboutSinger(this, "prefs.hifiutau.hnseppath");
+            if (string.IsNullOrEmpty(path)) {
+                return;
+            }
+            viewModel!.SetHifiUtauHnsepPath(path);
+        }
+
+        void ResetHifiUtauPaths(object sender, RoutedEventArgs e) {
+            viewModel!.ResetHifiUtauPaths();
+        }
+
+        async void ReloadHifiUtauAll(object sender, RoutedEventArgs e) {
+            await ReloadHifiUtauImpl(() => HiFiUtauModelStore.Inst.ReloadAll());
+        }
+
+        async void ReloadHifiUtauSplicer(object sender, RoutedEventArgs e) {
+            await ReloadHifiUtauImpl(() => HiFiUtauModelStore.Inst.ReloadSplicer());
+        }
+
+        async void ReloadHifiUtauHnsep(object sender, RoutedEventArgs e) {
+            await ReloadHifiUtauImpl(() => HiFiUtauModelStore.Inst.ReloadHnsep());
+        }
+
+        async Task ReloadHifiUtauImpl(Action reload) {
+            LoadingWindow.BeginLoading(this);
+            Exception? error = await Task.Run(() => {
+                try {
+                    reload();
+                    return null;
+                } catch (Exception ex) {
+                    Log.Error(ex, "Failed to reload HiFiUTAU engine.");
+                    return ex;
+                }
+            });
+            viewModel!.RefreshHifiUtauStatus();
+            LoadingWindow.EndLoading();
+            if (error != null) {
+                await MessageBox.ShowError(this, error, "Failed to reload HiFiUTAU engine");
             }
         }
     }

--- a/OpenUtau/Views/SplashWindow.axaml.cs
+++ b/OpenUtau/Views/SplashWindow.axaml.cs
@@ -62,6 +62,9 @@ namespace OpenUtau.App.Views {
                 DocManager.Inst.PostOnUIThread = action => Avalonia.Threading.Dispatcher.UIThread.Post(action);
                 Log.Information("Initialized OpenUtau.");
                 InitAudio();
+                if (Core.Util.Preferences.Default.HifiUtauPreload) {
+                    _ = Task.Run(() => Core.HiFiUtau.HiFiUtauModelStore.Inst.PreloadAll());
+                }
             }).ContinueWith(t => {
                 if (t.IsFaulted) {
                     Log.Error(t.Exception?.Flatten(), "Failed to Start.");

--- a/OpenUtau/Views/TrackSettingsDialog.axaml
+++ b/OpenUtau/Views/TrackSettingsDialog.axaml
@@ -6,10 +6,24 @@
         x:Class="OpenUtau.App.Views.TrackSettingsDialog"
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource dialogs.tracksettings.caption}"
-        Height="184" Width="320" WindowStartupLocation="CenterOwner" CanResize="False">
+        Height="214" Width="320" WindowStartupLocation="CenterOwner" CanResize="False">
   <Border Margin="{Binding $parent.WindowDecorationMargin}">
     <StackPanel Margin="8">
       <TextBlock Text="{DynamicResource warning.renderer}" IsVisible="{Binding IsNotClassic}"/>
+
+      <TextBlock Text="{DynamicResource dialogs.tracksettings.serverurl}" IsVisible="{Binding IsServerRenderer}"/>
+      <TextBox HorizontalAlignment="Stretch" IsVisible="{Binding IsServerRenderer}"
+               Text="{Binding ServerUrl}" PlaceholderText="http://localhost:8000"/>
+
+      <TextBlock Text="{DynamicResource dialogs.tracksettings.endpoint}" IsVisible="{Binding IsCustomServer}"/>
+      <TextBox HorizontalAlignment="Stretch" IsVisible="{Binding IsCustomServer}"
+               Text="{Binding Endpoint}" PlaceholderText="/synthesize"/>
+
+      <Grid ColumnDefinitions="*,8,*" IsVisible="{Binding IsServerRenderer}">
+        <Button Grid.Column="2" Content="{DynamicResource dialogs.tracksettings.setasdefault}"
+                HorizontalAlignment="Stretch" Command="{Binding SetDefaultServerUrl}"/>
+      </Grid>
+
       <TextBlock Text="{DynamicResource prefs.rendering.resampler}" IsVisible="{Binding NeedsResampler}"/>
       <ComboBox Grid.Column="0" HorizontalAlignment="Stretch" IsVisible="{Binding NeedsResampler}"
                 ItemsSource="{Binding Resamplers}"


### PR DESCRIPTION
This pull request introduces a new utility for sampling and exporting pitch and parameter curves from `RenderPhrase` objects, aimed at supporting custom rendering servers. The major additions are a comprehensive curve sampling utility (`CustomF0Utils`) and a JSON builder (`CustomPhraseJson`) that transforms a `RenderPhrase` into a detailed JSON structure suitable for external processing.

The most important changes include:

**Curve Sampling Utilities:**

* Added `CustomF0Utils` class with methods to sample all standard and custom parameter curves from a `RenderPhrase` at a specified frame rate, and to sample curves for individual phonemes. This enables consistent extraction of pitch and expression data for downstream processing.
* Implemented methods to check if curves are at their default values, both for individual curves and for all curves in a set, supporting efficient data filtering.

**JSON Export for Custom Render Servers:**

* Added `CustomPhraseJson` class to serialize a `RenderPhrase` into a JSON format compatible with custom server HTTP endpoints, including all relevant timing, parameter, and per-phoneme information.
* The JSON structure includes global dynamic parameters, per-phoneme curves, detailed envelope and OTO data, and frame timing information, facilitating integration with external renderers.

These changes provide a robust foundation for exporting and analyzing UTAU phrase data in external tools and custom rendering pipelines.Classic tracks can select HIFIUTAU (ONNX, vocoder and HN-SEP oudep) or CUSTOM_SERVER (HTTP POST /synthesize). Vocoder accepts only the OpenUtau pc_nsf_hifigan oudep; HN-SEP accepts hnsep_VR_44.1k_hop512_2024.05.