### PR TITLE
Improvements to the Note Hover Glow

### DIFF
--- a/OpenUtau/Controls/NotesCanvas.cs
+++ b/OpenUtau/Controls/NotesCanvas.cs
@@ -241,7 +241,11 @@ namespace OpenUtau.App.Controls {
         protected override void OnPointerMoved(PointerEventArgs e) {
             base.OnPointerMoved(e);
             lastPointerPos = e.GetPosition(this);
-            UpdateHoveredNote();
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) {
+                SetHoveredNote(null);
+            } else {
+                UpdateHoveredNote();
+            }
         }
 
         protected override void OnPointerExited(PointerEventArgs e) {
@@ -269,19 +273,7 @@ namespace OpenUtau.App.Controls {
                 SetHoveredNote(null);
                 return;
             }
-            double tick = viewModel.PointToTick(lastPointerPos);
-            int tone = viewModel.PointToTone(lastPointerPos);
-            UNote? found = null;
-            foreach (var note in Part.notes) {
-                if (note.position > tick && note.LeftBound > tick) {
-                    break;
-                }
-                if (note.LeftBound <= tick && tick < note.RightBound && note.AdjustedTone == tone) {
-                    found = note;
-                    break;
-                }
-            }
-            SetHoveredNote(found);
+            SetHoveredNote(viewModel.SelectableNote);
         }
 
         void SetHoveredNote(UNote? note) {
@@ -353,8 +345,8 @@ namespace OpenUtau.App.Controls {
             return pen;
         }
 
-        void DrawHoverGlow(DrawingContext context, Point leftTop, Size size, double radius, float glow) {
-            if (glow <= 0.01f || !(ThemeManager.AccentBrush1 is ISolidColorBrush solid)) {
+        void DrawHoverGlow(DrawingContext context, Point leftTop, Size size, double radius, IBrush brush, float glow) {
+            if (glow <= 0.01f || !(brush is ISolidColorBrush solid)) {
                 return;
             }
             byte alpha = (byte)Math.Clamp((int)Math.Round(glow * 100), 0, 255);
@@ -579,7 +571,7 @@ namespace OpenUtau.App.Controls {
             }
             context.DrawRectangle(brush, null, new Rect(leftTop, rightBottom), 2, 2);
             if (Preferences.Default.NoteHoverGlow) {
-                DrawHoverGlow(context, leftTop, size, 2, GetHoverGlow(note));
+                DrawHoverGlow(context, leftTop, size, 2, brush, GetHoverGlow(note));
             }
             if (TrackHeight < 10 || note.lyric.Length == 0) {
                 return;

--- a/OpenUtau/Controls/PianoRoll.axaml.cs
+++ b/OpenUtau/Controls/PianoRoll.axaml.cs
@@ -737,6 +737,7 @@ namespace OpenUtau.App.Controls {
 
         private void NotesCanvasLeftPointerPressed(Control control, PointerPoint point, PointerPressedEventArgs args) {
             EditTools tool = ViewModel.EditTool.CurrentTool;
+            // Pitch Tools (PITD)
             if (ViewModel.EditTool.IsPitchTool) {
                 ViewModel.NotesViewModel.DeselectNotes();
                 if (args.KeyModifiers != cmdKey) {
@@ -755,13 +756,14 @@ namespace OpenUtau.App.Controls {
                     return;
                 }
             }
+            // Eraser Tool
             if (tool == EditTools.EraserTool && args.KeyModifiers != cmdKey) {
                 ViewModel.NotesViewModel.DeselectNotes();
                 editState = new NoteEraseEditState(control, ViewModel, this, MouseButton.Left);
                 Cursor = ViewConstants.cursorNo;
                 return;
             }
-
+            // Pitch Point Tool
             var pitchPointTool = tool == EditTools.PitchPointTool && args.KeyModifiers != cmdKey;
             var pitHitInfo = ViewModel.NotesViewModel.HitTest.HitTestPitchPoint(point.Position, pitchPointTool);
             if (pitHitInfo.Note != null) {
@@ -770,7 +772,7 @@ namespace OpenUtau.App.Controls {
                 return;
             }
             if (pitchPointTool) return;
-
+            // Other Tools or holding cmdKey
             var vbrHitInfo = ViewModel.NotesViewModel.HitTest.HitTestVibrato(point.Position);
             if (vbrHitInfo.hit) {
                 if (vbrHitInfo.hitToggle) {
@@ -852,10 +854,12 @@ namespace OpenUtau.App.Controls {
                 ViewModel.NotesContextMenuItems.Clear();
             }
             var selectedNotes = ViewModel.NotesViewModel.Selection.ToList();
+            // Pitch Tools (PITD)
             if (ViewModel.EditTool.IsPitchTool) {
                 editState = new ResetPitchState(control, ViewModel, this);
                 return;
             }
+            // Pitch point context menu
             if (ViewModel.NotesViewModel.ShowPitch) {
                 var pitHitInfo = ViewModel.NotesViewModel.HitTest.HitTestPitchPoint(point.Position, false);
                 if (pitHitInfo.Note != null) {
@@ -916,6 +920,7 @@ namespace OpenUtau.App.Controls {
                     return;
                 }
             }
+            // Note context menu
             if (ViewModel.EditTool.IsMatch([EditTools.CursorTool, EditTools.PenTool, EditTools.KnifeTool]) || args.KeyModifiers == cmdKey) {
                 var hitInfo = ViewModel.NotesViewModel.HitTest.HitTestNote(point.Position);
                 var vibHitInfo = ViewModel.NotesViewModel.HitTest.HitTestVibrato(point.Position);
@@ -994,6 +999,7 @@ namespace OpenUtau.App.Controls {
             if (ValueTipCanvas != null) {
                 valueTipPointerPosition = args.GetCurrentPoint(ValueTipCanvas!).Position;
             }
+            // Edit Status update (while dragging)
             if (editState != null) {
                 editState.altShiftHeld = args.KeyModifiers == (KeyModifiers.Alt | KeyModifiers.Shift);
                 editState.shiftHeld = args.KeyModifiers == KeyModifiers.Shift;
@@ -1005,6 +1011,14 @@ namespace OpenUtau.App.Controls {
             if (ViewModel?.NotesViewModel?.HitTest == null) {
                 return;
             }
+            // For note hover glow
+            var noteHitInfo = ViewModel.NotesViewModel.HitTest.HitTestNote(point.Position);
+            if (noteHitInfo.hitBody && (ViewModel.EditTool.IsMatch([EditTools.CursorTool, EditTools.PenTool, EditTools.PenPlusTool, EditTools.EraserTool, EditTools.KnifeTool]) || args.KeyModifiers == cmdKey)) {
+                ViewModel.NotesViewModel.SelectableNote = noteHitInfo.note;
+            } else {
+                ViewModel.NotesViewModel.SelectableNote = null;
+            }
+            // Mouse cursor changes
             if (ViewModel.EditTool.IsMatch([EditTools.DrawPitchTool, EditTools.PitchLineTool, EditTools.PitchSCurveTool, EditTools.PitchSineWaveTool, EditTools.PitchSmoothenTool, EditTools.EraserTool]) && args.KeyModifiers != cmdKey) {
                 Cursor = null;
                 return;
@@ -1029,7 +1043,6 @@ namespace OpenUtau.App.Controls {
                 }
                 return;
             }
-            var noteHitInfo = ViewModel.NotesViewModel.HitTest.HitTestNote(point.Position);
             if (noteHitInfo.hitResizeArea) {
                 Cursor = ViewConstants.cursorSizeWE;
                 return;

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -105,6 +105,7 @@ namespace OpenUtau.App.ViewModels {
         private readonly ObservableAsPropertyHelper<double> smallChangeY;
 
         public readonly NoteSelectionViewModel Selection = new NoteSelectionViewModel();
+        public UNote? SelectableNote;
 
         internal NotesViewModelHitTest HitTest;
         private int _lastNoteLength = 480;


### PR DESCRIPTION
- Whether the glow appears is determined by the selected Edit Tool. Because pitch-editing tools do not operate on notes, visual feedback is shown only when the tool can actually grab or cut a note.
- Previously, the glow would disappear only at the moment a note was clicked and would reappear when the pointer moved. Now the glow is suppressed while the pointer is pressed — i.e., the glow disappears when you click a note and only returns after you finish dragging and release the pointer.
- The glow color follows the note's color.
- I added comments because the piano roll's mouse event handling has become more complex.