### PR TITLE
Added Developer Tools and Diagnostics Support During DEBUG

### DIFF
--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -17,6 +17,9 @@ namespace OpenUtau.App {
         public override void Initialize() {
             Log.Information("Initializing application.");
             AvaloniaXamlLoader.Load(this);
+#if DEBUG
+            this.AttachDeveloperTools();
+#endif
             InitializeCulture();
             InitializeTheme();
             Log.Information("Initialized application.");

--- a/OpenUtau/OpenUtau.csproj
+++ b/OpenUtau/OpenUtau.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageReference Include="Avalonia.Wayland" Version="12.1.0" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
     <PackageReference Include="DynamicData" Version="9.4.33" />
     <PackageReference Include="MonoMac.Core" Version="0.0.23728" />


### PR DESCRIPTION
Addressed an issue where developer tools became unavailable following an AvaloniaUI update. To allow for debugging screens and various features, code was added to App.axaml.cs to enable developer tools only during DEBUG builds. Additionally, a reference to the AvaloniaUI.DiagnosticsSupport package was added to OpenUtau.csproj to enable developer diagnostics support.