### PR TITLE
Add the DAW integration API (OpenUtau.Core/DawIntegration)

### DIFF
--- a/OpenUtau.Core/DawIntegration/API.md
+++ b/OpenUtau.Core/DawIntegration/API.md
@@ -90,8 +90,10 @@ side.
 
 The plugin publishes one JSON file per instance:
 
-- **Path:** `%TEMP%/OpenUtau/PluginServers/<name>.json` (the per-user temporary directory
-  on every supported OS).
+- **Path:** `%TEMP%/OpenUtau/PluginServers/<name>.json` — the per-user temporary directory on
+  Windows and macOS. On Linux, where `TMPDIR` may resolve to a shared directory such as `/tmp`,
+  OpenUtau enforces the trust boundary of §11 before scanning or publishing (owner-only
+  directory permissions; a directory it does not own is refused).
 - **Schema:**
 
 ```json
@@ -404,14 +406,19 @@ disconnect (user)  → optional final update → "close" → teardown
 - Version identification lives in the discovery file and the `init` response (§4.2).
 - **1.1 → 1.2:** `updateTracks` gained the optional per-track `singer` and `engine`
   informational fields. Nothing else changed; 1.1 implementations interoperate unchanged.
+  The newer side **MUST** omit these two fields when the peer negotiated a minor below 2.
 
 ## 11. Security and Trust Model
 
 - Loopback only, dynamic port, no authentication. Any local process running as the same
   user can read the project document and rendered audio. This matches the trust model of
   comparable bridge tools (e.g. ACE Studio's bridge) and is accepted for this version.
-- Mitigations: random high port, per-user discovery directory, no cross-machine path.
-- Caveat: do not run OpenUtau in multi-user shared sessions.
+- Mitigations: random high port, owner-only discovery directory (on Unix the discovery
+  directory is tightened to mode 0700 before scanning and publishing, and a directory this
+  user does not own is refused outright), published files carry mode 0600, no cross-machine path.
+- Caveat: on a shared-`/tmp` Linux system, a file planted in the discovery directory *before*
+  OpenUtau first tightens it could still be scanned. Do not run OpenUtau in multi-user shared
+  sessions.
 
 ## 12. Error Handling
 

--- a/OpenUtau.Core/DawIntegration/API.md
+++ b/OpenUtau.Core/DawIntegration/API.md
@@ -1,0 +1,501 @@
+# OpenUtau DAW Integration API
+
+**Version 1.2 — Specification**
+
+This document specifies the integration contract between OpenUtau and digital audio
+workstation (DAW) plugins. It allows an OpenUtau project to be rendered into one or more
+DAW tracks in real time, with project, track and audio state synchronized incrementally
+and the DAW's transport reflected back into OpenUtau.
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are to be
+interpreted as described in RFC 2119.
+
+| | |
+|---|---|
+| Current version | `1.2` |
+| Transport | TCP, loopback only |
+| Control plane | newline-delimited JSON over UTF-8 |
+| Data plane | length-prefixed raw binary frames |
+| Audio format | raw `float32` PCM, 44.1 kHz, stereo, interleaved, little-endian |
+| Reference client | `OpenUtau.Core/DawIntegration/` (this repository) |
+| Reference plugin | [KakaruHayate/openutau-vst-bridge](https://github.com/KakaruHayate/openutau-vst-bridge) (VST3/CLAP) |
+
+---
+
+## 1. Scope and Goals
+
+The API synchronizes three kinds of state from OpenUtau into a DAW plugin — the project
+document, track configuration, and rendered part audio — and carries transport feedback
+(position, playing state, tempo) from the DAW back to OpenUtau.
+
+Design principles:
+
+- **Minimal surface in OpenUtau.** OpenUtau exposes a small, stable local API. Everything
+  plugin- or UI-shaped lives in the plugin project.
+- **Two-tier framing.** A JSON control plane that stays text-debuggable, and a binary data
+  plane for audio. **Audio never travels inside JSON** — no base64, no embedded encoding.
+- **Incremental by default.** Only changed state is pushed; audio is transferred on demand
+  by content hash.
+- **Pull-based audio.** The plugin requests audio it is missing; the request/response shape
+  gives the plugin backpressure.
+- **Localhost trust only.** No authentication; anything running as the same user may connect.
+
+Non-goals in this version:
+
+- Remote or cross-machine connections.
+- ARA (Audio Random Access) tempo-map integration.
+- Bidirectional tempo-map synchronization.
+- **Audio format negotiation.** 44.1 kHz stereo is a hard limit of OpenUtau's engine
+  (`WaveFormat.CreateIeeeFloatWaveFormat(44100, 2)` in `PlaybackManager`); the wire format
+  is fixed to match and is not negotiated.
+- MIDI input into OpenUtau (reserved for a future version, §6.3).
+
+## 2. Roles and Topology
+
+| Role | Process | Responsibility |
+|---|---|---|
+| **Server** | DAW plugin (VST3, AU, CLAP, …) | Listens on `127.0.0.1:<port>`, publishes a discovery file, answers requests, renders received audio into the DAW track |
+| **Client** | OpenUtau | Scans for discovery files, connects, pushes project/track/audio state |
+
+Connection direction is **plugin = TCP server, OpenUtau = TCP client**. OpenUtau never
+listens; the plugin never connects. One active connection per plugin instance.
+
+This inversion is deliberate: a plugin instance discovered through its own listening port
+maps one-to-one onto a DAW track the user has just added, with no pairing UI on either
+side.
+
+## 3. Transport
+
+- **Protocol:** TCP, loopback only (`127.0.0.1`).
+- **Port:** dynamic, chosen by the plugin at bind time.
+- **Framing:** two planes share one socket, distinguished on receive by the first bytes of
+  a line (§5).
+- **Ordering:** TCP ordering, plus a client-side write mutex. The protocol defines no
+  sequence numbers; a sender MUST serialize its own writes per connection.
+
+### 3.1 Timing Constants
+
+| Item | Value | Owner |
+|---|---|---|
+| `init` handshake timeout | 5 s | OpenUtau |
+| Control-plane request timeout | 10 s | OpenUtau |
+| Heartbeat send interval | 5 s | Plugin |
+| Heartbeat liveness check | every 2 s | OpenUtau |
+| Heartbeat dead threshold | 15 s without any message | OpenUtau |
+| Reconnect backoff | 500 ms, 1 s, 2 s, then give up | OpenUtau |
+
+## 4. Service Discovery and Version Negotiation
+
+### 4.1 Discovery File
+
+The plugin publishes one JSON file per instance:
+
+- **Path:** `%TEMP%/OpenUtau/PluginServers/<name>.json` (the per-user temporary directory
+  on every supported OS).
+- **Schema:**
+
+```json
+{
+  "port": 52341,
+  "name": "OpenUtau Bridge (Track 1)",
+  "apiVersion": "1.2"
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `port` | integer | The TCP port the instance listens on |
+| `name` | string | Human-readable instance name (shown in OpenUtau's UI) |
+| `apiVersion` | string | Protocol version the instance implements, `"major.minor"` |
+
+Rules:
+
+- The plugin **MUST** (re)write the file whenever it binds or re-binds its port, and
+  **MUST** delete it on shutdown.
+- File names **MUST** be unique per instance (e.g. `<plugin name> <port>.json`) so that
+  concurrent instances do not collide.
+- OpenUtau **MUST** scan the directory for `*.json`, probe each advertised port by
+  attempting `bind(127.0.0.1:<port>)` — if the bind succeeds, the advertised server is
+  gone — and delete stale files whose probes succeed.
+
+### 4.2 Version Negotiation
+
+- `apiVersion` is carried in the discovery file **and** echoed in the `init` response
+  (§6.1), so an implementation that advertises one version and speaks another is caught.
+- **Major mismatch** → OpenUtau **MUST** refuse the connection and inform the user that
+  the plugin is incompatible and needs updating.
+- **Minor skew** → connect. The newer side **MUST** restrict itself to messages and
+  fields present in the older minor (§10).
+
+## 5. Message Framing
+
+### 5.1 Control Plane (Line-Based JSON)
+
+Every control message is one line: UTF-8 `<header> <json>\n`. The JSON payload may be
+empty (the header is still followed by one space and an empty JSON document, e.g. `{}`).
+
+| Header | Direction | Meaning |
+|---|---|---|
+| `request:<uuid>:<kind>` | OpenUtau → Plugin | A request; the plugin **MUST** reply with `response:<uuid>` |
+| `response:<uuid>` | Plugin → OpenUtau | The reply to a request |
+| `notification:<kind>` | either | Fire-and-forget; no reply exists |
+| `close` | OpenUtau → Plugin | Bare string, no payload; clean teardown |
+
+Every response carries a `DawResult` envelope:
+
+```json
+{ "success": true, "data": { }, "error": null }
+```
+
+- On success `data` holds the response payload defined per message.
+- On failure `success` is `false`, `error` carries a human-readable string, and `data` is
+  `null`.
+
+A receiver **MUST** answer an unknown `request:` kind or malformed JSON with a failed
+envelope rather than dropping the connection, and **MUST** log-and-ignore an unknown
+`notification:` kind.
+
+### 5.2 Data Plane (Binary Audio Frames)
+
+```
+audio <hash> <length>\n
+<length bytes of raw audio>
+```
+
+- `hash` — the XXH64 hash of the payload bytes, **serialized as a decimal string**
+  (e.g. `13507256038857166760`). 64-bit hashes **MUST NOT** be serialized as JSON numbers
+  anywhere in the protocol: values above 2^53 exceed the safe-integer range of
+  `double`-based JSON parsers. In a data-plane frame header the hash appears unquoted, as
+  plain text outside JSON.
+- `length` — decimal byte count. The receiver **MUST** read exactly `length` bytes after
+  the header line; the frame does not end at the line break. A length above **268 435 456**
+  (256 MiB, ≈ 12.7 minutes of 44.1 kHz stereo `float32`) **MUST** be refused as a protocol
+  error, never allocated: the length is peer-controlled. Senders **MUST NOT** emit frames
+  above this bound.
+- Plane discrimination on receive: a line starting with `audio ` is a data-frame header;
+  any other line is a control line.
+
+## 6. Message Reference
+
+All JSON payloads below show the inner document that follows the header. `<uuid>` values
+are opaque correlation strings.
+
+### 6.1 OpenUtau → Plugin
+
+#### `init` (request)
+
+```json
+{ "ustx": "<full USTX project document>" }
+```
+
+- Sent exactly once, immediately after connecting; the full project is the baseline for
+  all later incremental updates.
+- `ustx` is OpenUtau's native USTX document, which is YAML — byte-identical to what
+  OpenUtau writes into a `.ustx` file. A plugin may persist it or re-parse it with any
+  YAML reader. It is deliberately **not** a JSON projection of the in-memory project
+  object, which would be lossy.
+- **Response `data`:** `{ "apiVersion": "1.2" }` — the version the plugin implements.
+- OpenUtau is the sole owner of the project: the baseline travels outward only and is
+  never echoed back.
+
+#### `updateUstx` (notification)
+
+```json
+{ "ustx": "<full USTX project document>" }
+```
+
+- The whole USTX document, resent per change (debounced, §7). Atomic replacement: the
+  receiver **MUST** discard its previous project state on receipt.
+
+#### `updatePartLayout` (request)
+
+```json
+{
+  "parts": [
+    { "trackNo": 0, "startMs": 1200.0, "endMs": 8400.0,
+      "audioHash": "13507256038857166760" }
+  ]
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `trackNo` | integer | Zero-based index into the last `updateTracks` list |
+| `startMs` | number | Part start on the shared timeline, milliseconds |
+| `endMs` | number | Part end, same coordinate system |
+| `audioHash` | string | XXH64 (decimal) of that part's rendered audio |
+
+- The receiver deduplicates against audio it already holds. It **SHOULD** additionally
+  verify a received frame's `length` against its own hash computation as a cheap
+  integrity cross-check.
+- **Response `data`:** `{ "missingAudios": ["13507256038857166760", …] }` — the hashes the
+  receiver still needs, each a decimal string. An empty array means everything is cached.
+
+#### `updateTracks` (notification)
+
+```json
+{ "tracks": [
+    { "name": "Singer 1", "volume": 0.0, "pan": 0.0, "muted": false,
+      "singer": "Kikyo", "engine": "DIFFSINGER" }
+] }
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | string | Track name |
+| `volume` | number | Track volume in **decibels**, `0` = unity, as stored by OpenUtau |
+| `pan` | number | Track pan in OpenUtau's scale, **-100…+100**, `0` = centre |
+| `muted` | bool | The **effective** mute — solo already resolved against the project |
+| `singer` | string | **v1.2** — track singer's display name; empty string when none assigned |
+| `engine` | string | **v1.2** — render engine key (`CLASSIC`, `WORLDLINE-R`, `DIFFSINGER`, `ENUNU`, `VOGEN`, `VOICEVOX`, …); empty string when no usable renderer |
+
+Notes:
+
+- `volume`, `pan` and `muted` are passed through **unconverted**, for peers that want
+  OpenUtau's mixer state. They do **not** govern the audio on the wire (§8): the audio is
+  pre-fader, and the DAW owns gain, pan, mute and solo. A muted track still renders and
+  ships part audio; `muted` is never a request to omit audio.
+- `singer` and `engine` are informational (track pickers, info windows). They do not
+  affect audio, and receivers that do not care may ignore them. Both were added in 1.2;
+  1.1 receivers ignore them implicitly (§10).
+
+#### `updateProjectInfo` (notification) — since 1.1
+
+```json
+{ "name": "my song", "saved": true }
+```
+
+- What a plugin's UI may show about the project. `name` is the project file's stem; an
+  unsaved project reports `saved` `false` and an empty `name`.
+- Carries no state the mixer or renderer needs; a plugin may ignore it.
+
+### 6.2 Plugin → OpenUtau
+
+#### `getAudio` (request) — audio pull
+
+```json
+{ "hash": "13507256038857166760" }
+```
+
+- Requests the rendered audio for a hash advertised in `updatePartLayout`.
+- **The response is a data-plane frame**, not a JSON envelope:
+
+```
+audio 13507256038857166760 3528000\n<3528000 raw bytes>
+```
+
+- Payload encoding (fixed, engine-bound): **raw `float32` PCM, 44.1 kHz, stereo,
+  interleaved, little-endian**. No compression, no base64. Mono mixes are upmixed to
+  stereo by OpenUtau before transmission.
+- The plugin **SHOULD** pull missing hashes sequentially; this version allows **one
+  outstanding `getAudio` per connection**.
+- The plugin is the requester by design: pulling rather than being pushed to is what gives
+  the plugin backpressure over a slow DAW track.
+
+#### `ping` (notification)
+
+```json
+{}
+```
+
+- Sent every 5 s. Any message from the peer also counts as liveness; `ping` exists for
+  otherwise-idle connections.
+
+#### `playbackStarted` (notification)
+
+```json
+{}
+```
+
+- Sent on the DAW transport's play rising edge. OpenUtau flushes all pending debounced
+  updates (§7) before playback begins, so the plugin plays against current state.
+
+#### `playhead` (notification) — since 1.1
+
+```json
+{ "positionMs": 12500.0, "playing": false }
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `positionMs` | number | DAW transport position, absolute milliseconds on the shared timeline — the same coordinate system as `updatePartLayout`'s `startMs` |
+| `playing` | bool | DAW transport state |
+
+- **One-way towards OpenUtau.** The received position overwrites OpenUtau's playhead,
+  converted to ticks on the project's own time axis. There is no reverse direction, reply,
+  or acknowledgement.
+- Moves smaller than **5 ticks** at the destination are ignored as jitter.
+- Pacing is the sender's choice; receivers **MUST** tolerate any pacing. The reference
+  plugin sends state changes immediately, every 100 ms while playing, and only when a
+  parked playhead moves more than 50 ms.
+
+#### `bpm` (notification) — since 1.1
+
+```json
+{ "bpm": 137.5 }
+```
+
+- The DAW project's tempo, sent when it changes. OpenUtau uses this only as a guard —
+  warning the user, once per distinct value outside a **±0.5 BPM** tolerance, that bars
+  will misalign. It never retempo-maps the project (no tempo-map sync in this version).
+
+### 6.3 MIDI Input (Reserved — Not in This Version)
+
+A future message family (e.g. `notification:midiNotes`, `request:recordMidi`) is reserved.
+Implementations **MUST NOT** invent wire shapes for this direction under the v1 namespace.
+
+## 7. Synchronization Semantics
+
+- OpenUtau observes its project's command stream and pushes changes while connected.
+- **Debounce windows:**
+
+| Message group | Debounce |
+|---|---|
+| `updateUstx`, `updateTracks`, `updateProjectInfo` | 1 s |
+| `updatePartLayout` (+ the audio pulls it triggers) | 5 s |
+
+- **Playback flush:** on `playbackStarted`, all debounce queues flush before playback
+  begins.
+- **Full sync:** after every (re)connect, in this order, serialized so that one update is
+  in flight per connection:
+
+```
+updateUstx → updateTracks → updateProjectInfo → updatePartLayout (+ audio pulls)
+```
+
+## 8. Audio Path Contract
+
+- The wire audio is **pre-fader**: OpenUtau's `volume`, `pan` and `muted` fields are not
+  applied to it. The DAW owns gain, pan, mute and solo, so the dry signal entering its
+  effects chain stays stable while the vocal performance is edited.
+- Pre-fader output is scaled by a **constant output trim of √0.5 (≈ 0.7071, −3.01 dB) per
+  channel**. OpenUtau pans constant-power, so its own playback of a centred track puts
+  cos(π/4) on each channel; a receiver that bypassed panning without this trim would sit a
+  systematic 3 dB above the level the performance was tuned against. The trim is **not**
+  mixer state and never follows `volume`, `pan` or `muted`.
+- Receivers **MUST NOT** expect the mixer fields to describe the signal they receive.
+
+## 9. Connection Lifecycle
+
+```
+plugin binds :port, writes discovery file (with apiVersion)
+        │
+OpenUtau scans discovery dir → probe port → TCP connect
+        │
+request:init (5 s timeout) → full USTX baseline + version check
+        │
+steady state: debounced updates; audio pulled by hash on demand
+        │
+DAW plays   → notification:playbackStarted → flush pending updates
+DAW moves   → notification:playhead / notification:bpm
+        │
+disconnect (error) → backoff ×3 → re-init + full sync
+disconnect (user)  → optional final update → "close" → teardown
+```
+
+## 10. Compatibility and Versioning Policy
+
+- **Append-only.** New minor versions add messages, fields and kinds; they **MUST NOT**
+  change the meaning of existing fields.
+- **Kind namespaces.** A semantically changed message gets a new kind with a version
+  suffix (e.g. `updatePartLayoutV2`) rather than an in-place change.
+- **Unknown-field tolerance.** Receivers **MUST** ignore fields they do not know; this is
+  what makes minor skew safe (§4.2).
+- Version identification lives in the discovery file and the `init` response (§4.2).
+- **1.1 → 1.2:** `updateTracks` gained the optional per-track `singer` and `engine`
+  informational fields. Nothing else changed; 1.1 implementations interoperate unchanged.
+
+## 11. Security and Trust Model
+
+- Loopback only, dynamic port, no authentication. Any local process running as the same
+  user can read the project document and rendered audio. This matches the trust model of
+  comparable bridge tools (e.g. ACE Studio's bridge) and is accepted for this version.
+- Mitigations: random high port, per-user discovery directory, no cross-machine path.
+- Caveat: do not run OpenUtau in multi-user shared sessions.
+
+## 12. Error Handling
+
+| Condition | Required behavior |
+|---|---|
+| Control request timeout (10 s) | Treat the connection as dead: disconnect and reconnect |
+| Malformed control line | Log a warning; keep the connection |
+| Unknown `request:` kind | Failed `DawResult` envelope; keep the connection |
+| Unknown `notification:` kind | Log and ignore |
+| Data frame truncated (stream ends before `length` bytes) | Protocol error: disconnect |
+| Frame `length` above the 256 MiB bound | Protocol error: refuse, do not allocate |
+| Non-user-initiated disconnect | Reconnect with backoff 500 ms / 1 s / 2 s, then notify the user |
+| User-initiated disconnect | Optional final update, then the bare `close` line, then teardown |
+
+## 13. Implementation Checklist for Plugin Authors
+
+A conforming plugin:
+
+1. Binds a dynamic TCP port on `127.0.0.1` and publishes the discovery file (§4.1),
+   deleting it on shutdown.
+2. Implements the control-plane framing and the `DawResult` envelope (§5.1), answering
+   unknown requests with a failed envelope instead of dropping the connection.
+3. Implements the data-plane framing (§5.2), including the decimal-string hash rule and
+   the 256 MiB length bound, and answers `getAudio` with a frame, not an envelope (§6.2).
+4. Handles `init` (version echo), `updateUstx` (atomic replacement), `updatePartLayout`
+   (hash dedup + `missingAudios`), and tolerates `updateTracks`/`updateProjectInfo`.
+5. Sends `ping` every 5 s; sends `playbackStarted` on the DAW's play edge; optionally
+   sends `playhead` and `bpm`.
+6. Treats the wire audio as pre-fader 44.1 kHz stereo `float32` already trimmed by √0.5
+   per channel (§8).
+7. Handles reconnection gracefully: any non-user-initiated disconnect is followed by
+   OpenUtau's re-`init` and a full sync (§9).
+8. Cleans up its discovery file when the host unloads it.
+
+## 14. Conformance Testing
+
+- **OpenUtau side (unit + conformance):** framing, request/response/timeout, heartbeat and
+  debounce-flush are covered by `OpenUtau.Test/Core/DawIntegration/`. A loopback test
+  plugin (`DawTestPlugin`) plays the plugin half over the shipping transport code, and a
+  conformance suite drives `init → updateTracks → updateProjectInfo → updatePartLayout →
+  getAudio → playbackStarted` (plus the 1.1 `playhead`/`bpm`) against the real manager
+  through a real discovery directory.
+- **Plugin side:** an independent test client that replays recorded transcripts —
+  including binary frames — against the plugin and asserts responses. Once the two sides
+  share no code, the transcript harness is the only honest contract test, and plugin
+  authors are encouraged to build one.
+
+## Appendix A — Constants Summary
+
+| Constant | Value | Where defined |
+|---|---|---|
+| Audio sample format | `float32`, interleaved, little-endian | §5.2, §6.2 |
+| Sample rate | 44 100 Hz (fixed, not negotiated) | §1 |
+| Channels | 2 (mono mixes upmixed) | §6.2 |
+| Output trim | √0.5 per channel (−3.01 dB), constant | §8 |
+| Hash function | XXH64, serialized as a decimal string | §5.2 |
+| Maximum frame length | 268 435 456 bytes (256 MiB) | §5.2 |
+| Discovery directory | `%TEMP%/OpenUtau/PluginServers/` | §4.1 |
+| `init` timeout | 5 s | §3.1 |
+| Request timeout | 10 s | §3.1 |
+| Heartbeat interval | 5 s | §3.1 |
+| Liveness check | every 2 s | §3.1 |
+| Dead threshold | 15 s | §3.1 |
+| Reconnect backoff | 500 ms, 1 s, 2 s | §3.1 |
+| Playhead jitter floor | 5 ticks | §6.2 |
+| BPM mismatch tolerance | ±0.5 | §6.2 |
+| Protocol version | `1.2` | §4.2 |
+
+## Appendix B — Design Notes
+
+For reviewers evaluating the shape of the API; not part of the conformance contract.
+
+- **Audio never travels in JSON.** A base64-in-JSON encoding costs +33 % before any
+  compression, compresses poorly on PCM, and forces the whole message to be materialized
+  in memory. The length-prefixed binary plane keeps the control plane readable and the
+  audio path streaming-friendly, with a fixed, engine-bound format instead of a
+  negotiation.
+- **Pull-based audio.** Making the plugin request audio by hash gives it backpressure: a
+  slow DAW track simply pulls slower, instead of OpenUtau flooding a socket ahead of the
+  consumer.
+- **XXH64, as decimal strings.** Fast enough to hash every rendered frame, and collisions
+  are negligible; the decimal-string rule exists because 64-bit values overflow the
+  2^53 safe-integer range of `double`-based JSON parsers. The receiver's `length`
+  cross-check is a deliberately cheap integrity backstop.
+- **Plugin as server.** An instance that listens and advertises itself maps one-to-one
+  onto a DAW track the user just added — no pairing step, no broker process, and OpenUtau
+  stays a pure client with no listening surface of its own.

--- a/OpenUtau.Core/DawIntegration/DawAudio.cs
+++ b/OpenUtau.Core/DawIntegration/DawAudio.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Text;
+using K4os.Hash.xxHash;
+using OpenUtau.Core.Ustx;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>
+    /// Data-plane helpers: part audio extraction, XXH64 hashing and binary frame framing.
+    /// See PROTOCOL.md §5.2 and §6.1 (<c>getAudio</c>).
+    /// </summary>
+    public static class DawAudio {
+        /// <summary>Hard engine limit, mirrors <c>PlaybackManager.cs:35</c>. Never negotiated (PROTOCOL.md §1).</summary>
+        public const int SampleRate = 44100;
+        public const int Channels = 2;
+
+        /// <summary>Data-plane frame header prefix. A received line starting with this is binary, not control.</summary>
+        public const string FramePrefix = "audio ";
+
+        /// <summary>
+        /// Upper bound on a single data-plane frame payload (256 MiB = 44.1 kHz stereo float32,
+        /// roughly 12.7 minutes of audio). Frames are length-prefixed by the peer, so before this
+        /// bound a hostile or corrupted header could make the receiver allocate up to 2 GiB
+        /// (PROTOCOL.md §6.1). Parts larger than this cannot be shipped over the wire in v1.
+        /// </summary>
+        public const int MaxFrameBytes = 1 << 28;
+
+        /// <summary>
+        /// Converts project time to an index into OpenUtau's interleaved stereo sample space.
+        /// The signal chain is addressed in absolute project samples, two floats per frame
+        /// (see <c>WaveSource.offset</c>).
+        /// </summary>
+        public static int MsToInterleavedIndex(double ms) {
+            if (ms <= 0) {
+                return 0;
+            }
+            return (int)(ms * SampleRate / 1000) * Channels;
+        }
+
+        /// <summary>
+        /// Extracts the rendered audio covering a part's own tick range.
+        /// </summary>
+        /// <remarks>
+        /// Voice parts only. <see cref="UWavePart"/> audio is out of v1 scope: it is user-supplied
+        /// material the DAW can import directly, and its source is produced by
+        /// <c>UWavePart.TrimSamples</c> rather than the render pipeline.
+        /// </remarks>
+        /// <returns>
+        /// False when the part carries no mix yet, or when the renderer has not finished the
+        /// window. Callers must skip such parts rather than shipping partial audio, because
+        /// <see cref="SignalChain.ISignalSource.Mix"/> would leave the gap silent and the
+        /// resulting hash would be wrong for the finished audio.
+        /// </returns>
+        public static bool TryExtractPart(UProject project, UVoicePart part, out float[] samples) {
+            samples = Array.Empty<float>();
+            var mix = part.Mix;
+            if (mix == null) {
+                return false;
+            }
+            int start = MsToInterleavedIndex(project.timeAxis.TickPosToMsPos(part.position));
+            int end = MsToInterleavedIndex(project.timeAxis.TickPosToMsPos(part.End));
+            int count = end - start;
+            if (count <= 0) {
+                return false;
+            }
+            if (!mix.IsReady(start, count)) {
+                return false;
+            }
+            // ISignalSource.Mix adds into the buffer, so it must start zeroed.
+            var buffer = new float[count];
+            mix.Mix(start, buffer, 0, count);
+            // §6.1 pre-fader output trim: OpenUtau pans constant-power, so a mix that
+            // bypasses panning sits a systematic 3 dB above what the performance was tuned
+            // against. Scale by cos(π/4) before hashing and serving; the trim is not mixer
+            // state and never follows volume, pan or muted.
+            float trim = MathF.Sqrt(0.5f);
+            for (int i = 0; i < count; i++) {
+                buffer[i] *= trim;
+            }
+            samples = buffer;
+            return true;
+        }
+
+        /// <summary>Serializes samples as raw little-endian float32, the fixed wire payload (PROTOCOL.md §6.1).</summary>
+        public static byte[] ToPcmBytes(float[] samples) {
+            var bytes = new byte[samples.Length * sizeof(float)];
+            if (BitConverter.IsLittleEndian) {
+                Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
+            } else {
+                for (int i = 0; i < samples.Length; i++) {
+                    BinaryPrimitives.WriteSingleLittleEndian(bytes.AsSpan(i * sizeof(float)), samples[i]);
+                }
+            }
+            return bytes;
+        }
+
+        /// <summary>Reads raw little-endian float32 back into samples. Used by tests and conformance tooling.</summary>
+        public static float[] FromPcmBytes(byte[] bytes) {
+            if (bytes.Length % sizeof(float) != 0) {
+                throw new DawProtocolException($"PCM payload of {bytes.Length} bytes is not a whole number of float32 samples.");
+            }
+            var samples = new float[bytes.Length / sizeof(float)];
+            if (BitConverter.IsLittleEndian) {
+                Buffer.BlockCopy(bytes, 0, samples, 0, bytes.Length);
+            } else {
+                for (int i = 0; i < samples.Length; i++) {
+                    samples[i] = BinaryPrimitives.ReadSingleLittleEndian(bytes.AsSpan(i * sizeof(float)));
+                }
+            }
+            return samples;
+        }
+
+        public static ulong Hash(byte[] pcm) => XXH64.DigestOf(pcm);
+
+        /// <summary>
+        /// Hashes are always decimal strings on the wire — a 64-bit value exceeds the 2^53
+        /// safe-integer range of JSON number parsers (PROTOCOL.md §5.2).
+        /// </summary>
+        public static string FormatHash(ulong hash) => hash.ToString(CultureInfo.InvariantCulture);
+
+        public static bool TryParseHash(string? text, out ulong hash) {
+            return ulong.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out hash);
+        }
+
+        /// <summary>Builds the <c>audio &lt;hash&gt; &lt;length&gt;\n</c> header. The payload follows verbatim.</summary>
+        public static byte[] BuildFrameHeader(string hash, int length) {
+            return Encoding.UTF8.GetBytes($"{FramePrefix}{hash} {length.ToString(CultureInfo.InvariantCulture)}\n");
+        }
+
+        public static bool IsFrameHeader(string line) => line.StartsWith(FramePrefix, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Parses a data-plane header line (without the trailing newline). Rejects negative,
+        /// unparseable or oversized lengths so a malformed header cannot desynchronize the stream
+        /// and a hostile length cannot drive the receiver into a huge allocation (§8).
+        /// </summary>
+        public static bool TryParseFrameHeader(string line, out string hash, out int length) {
+            hash = string.Empty;
+            length = 0;
+            if (!IsFrameHeader(line)) {
+                return false;
+            }
+            var parts = line.Substring(FramePrefix.Length).Split(' ');
+            if (parts.Length != 2) {
+                return false;
+            }
+            if (!TryParseHash(parts[0], out _)) {
+                return false;
+            }
+            if (!int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out length)) {
+                return false;
+            }
+            if (length > MaxFrameBytes) {
+                return false;
+            }
+            hash = parts[0];
+            return true;
+        }
+    }
+}

--- a/OpenUtau.Core/DawIntegration/DawManager.cs
+++ b/OpenUtau.Core/DawIntegration/DawManager.cs
@@ -244,6 +244,9 @@ namespace OpenUtau.Core.DawIntegration {
             public DawTransport? Transport;
             public bool ClosingLocally;
             public bool Reconnecting;
+            /// <summary>The init answer's minor (§4.2). Defaults to this build's own, so a
+            /// connection that has not finished its handshake is treated as fully capable.</summary>
+            public int NegotiatedMinor = DawApiVersion.Current.Minor;
         }
 
         private readonly DawSyncScheduler scheduler;
@@ -367,6 +370,11 @@ namespace OpenUtau.Core.DawIntegration {
                     connections.Remove(conn);
                 }
                 RecomputeState();
+                // OpenConnectionAsync may already have subscribed and started the pump before a
+                // post-init sync failed; a failed connect must not leave either behind (matching
+                // CloseConnectionAsync and the reconnect ladder's teardown).
+                StopPumpIfIdle();
+                UnsubscribeIfIdle();
                 throw;
             }
         }
@@ -399,6 +407,9 @@ namespace OpenUtau.Core.DawIntegration {
                     throw new DawProtocolException(
                         $"Plugin answered init with api '{response.ApiVersion}', " +
                         $"which this build cannot speak.");
+                }
+                lock (stateLock) {
+                    conn.NegotiatedMinor = version.Minor;
                 }
                 Subscribe();
                 RecomputeState();
@@ -453,7 +464,9 @@ namespace OpenUtau.Core.DawIntegration {
 
         private void Subscribe() {
             lock (stateLock) {
-                if (subscribed) {
+                // A reconnect handshake can complete after Dispose ran: without this check the
+                // disposed manager would re-register on DocManager for the process lifetime.
+                if (subscribed || Volatile.Read(ref disposed) != 0) {
                     return;
                 }
                 DocManager.Inst.AddSubscriber(this);
@@ -473,6 +486,10 @@ namespace OpenUtau.Core.DawIntegration {
 
         private void RecomputeState() {
             DawConnectionState next;
+            bool changed;
+            // One atomic scope: concurrent callers (the transport read loop, reconnects, user
+            // connects) would otherwise interleave between computing and assigning, and a later
+            // caller could publish an older value.
             lock (stateLock) {
                 if (connections.Any(c => c.Transport?.IsConnected == true)) {
                     next = DawConnectionState.Connected;
@@ -483,9 +500,6 @@ namespace OpenUtau.Core.DawIntegration {
                 } else {
                     next = DawConnectionState.Disconnected;
                 }
-            }
-            bool changed;
-            lock (stateLock) {
                 changed = State != next;
                 State = next;
             }
@@ -621,7 +635,9 @@ namespace OpenUtau.Core.DawIntegration {
                     break;
                 }
                 case DawSyncKind.Tracks: {
-                    var payload = await BuildTracksAsync();
+                    // §10: the v1.2 informational fields are omitted for peers that negotiated a
+                    // lower minor, so the payload carries the minimum across the targets.
+                    var payload = await BuildTracksAsync(MinNegotiatedMinor(live));
                     await BroadcastAsync(live, (conn, token) =>
                         conn.Transport!.SendNotificationAsync(DawMessageKind.UpdateTracks, payload, token),
                         cancellation);
@@ -654,8 +670,8 @@ namespace OpenUtau.Core.DawIntegration {
         }
 
         /// <summary>
-        /// Sends one pre-built payload to every live connection. A request timeout drops only
-        /// the connection it happened on (§8); the others stay synced.
+        /// Sends one pre-built payload to every live connection. Any failure a connection raises
+        /// drops only that connection (§8); the others still receive the payload.
         /// </summary>
         private async Task BroadcastAsync(List<Connection> targets,
                 Func<Connection, CancellationToken, Task> send, CancellationToken cancellation) {
@@ -666,8 +682,12 @@ namespace OpenUtau.Core.DawIntegration {
                 }
                 try {
                     await send(conn, cancellation);
-                } catch (TimeoutException e) {
-                    Log.Warning(e, $"DAW: sync to '{conn.Server.Name}' timed out; dropping it.");
+                } catch (OperationCanceledException) {
+                    throw;
+                } catch (Exception e) {
+                    // Not only timeouts: a protocol fault or socket error on one connection must
+                    // not leave the remaining targets stale until the next edit re-arms the stream.
+                    Log.Warning(e, $"DAW: sync to '{conn.Server.Name}' failed; dropping it.");
                     await DropConnectionAsync(conn);
                 }
             }
@@ -688,7 +708,8 @@ namespace OpenUtau.Core.DawIntegration {
                     break;
                 case DawSyncKind.Tracks:
                     await live.SendNotificationAsync(
-                        DawMessageKind.UpdateTracks, await BuildTracksAsync(), cancellation);
+                        DawMessageKind.UpdateTracks,
+                        await BuildTracksAsync(minor: GetNegotiatedMinor(conn)), cancellation);
                     break;
                 case DawSyncKind.ProjectInfo:
                     await live.SendNotificationAsync(
@@ -700,7 +721,21 @@ namespace OpenUtau.Core.DawIntegration {
             }
         }
 
-        private Task<UpdateTracksNotification> BuildTracksAsync() {
+        /// <summary>The lowest minor any of the targets negotiated, so a shared payload is safe for all of them.</summary>
+        private int MinNegotiatedMinor(List<Connection> targets) {
+            lock (stateLock) {
+                return targets.Aggregate(DawApiVersion.Current.Minor, (min, conn) => Math.Min(min, conn.NegotiatedMinor));
+            }
+        }
+
+        private int GetNegotiatedMinor(Connection conn) {
+            lock (stateLock) {
+                return conn.NegotiatedMinor;
+            }
+        }
+
+        private Task<UpdateTracksNotification> BuildTracksAsync(int minor) {
+            bool emitV12Fields = minor >= 2;
             return OnDocumentThreadAsync(() => new UpdateTracksNotification {
                 Tracks = ProjectSource().tracks
                     .Select(track => new DawTrackInfo {
@@ -712,9 +747,9 @@ namespace OpenUtau.Core.DawIntegration {
                         Muted = track.Muted,
                         // v1.2: informational fields for the plugin's GUI. Singer changes and
                         // renderer changes are TrackCommands, so the same Tracks sync keeps
-                        // these fresh without new triggers.
-                        Singer = track.Singer?.Name ?? string.Empty,
-                        Engine = track.RendererSettings.renderer ?? string.Empty,
+                        // these fresh without new triggers. Omitted for lower minors (§10).
+                        Singer = emitV12Fields ? track.Singer?.Name ?? string.Empty : null,
+                        Engine = emitV12Fields ? track.RendererSettings.renderer ?? string.Empty : null,
                     })
                     .ToList(),
             });
@@ -848,6 +883,14 @@ namespace OpenUtau.Core.DawIntegration {
             }
             if (!TryResolveAudio(hash, out byte[] pcm)) {
                 await request.RespondAsync(DawResult.Fail($"No audio for hash {hash}."));
+                return;
+            }
+            if (pcm.Length > DawAudio.MaxFrameBytes) {
+                // A frame above the bound would make the receiver refuse the header and stop the
+                // transport (§6.1, §8); refuse here with an envelope instead of wedging the peer.
+                await request.RespondAsync(DawResult.Fail(
+                    $"Audio for hash {hash} is {pcm.Length} bytes, above the " +
+                    $"{DawAudio.MaxFrameBytes}-byte data-plane bound."));
                 return;
             }
             await request.RespondWithAudioAsync(hash, pcm);
@@ -1112,9 +1155,13 @@ namespace OpenUtau.Core.DawIntegration {
                 conn.Transport?.Dispose();
                 conn.Transport = null;
             }
-            if (subscribed) {
-                DocManager.Inst.RemoveSubscriber(this);
-                subscribed = false;
+            // Same lock discipline as Subscribe/UnsubscribeIfIdle: a reconnect handshake racing
+            // the dispose must not re-add the subscriber after it is removed here.
+            lock (stateLock) {
+                if (subscribed) {
+                    DocManager.Inst.RemoveSubscriber(this);
+                    subscribed = false;
+                }
             }
             scheduler.Clear();
             audioCache.Clear();

--- a/OpenUtau.Core/DawIntegration/DawManager.cs
+++ b/OpenUtau.Core/DawIntegration/DawManager.cs
@@ -1,0 +1,1129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+using Serilog;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>What a pending sync covers. Values are ordered as PROTOCOL.md §7 requires them sent.</summary>
+    public enum DawSyncKind {
+        Ustx = 0,
+        Tracks = 1,
+        PartLayout = 2,
+        ProjectInfo = 3,
+    }
+
+    /// <summary>
+    /// Trailing-edge debounce for the sync streams (PROTOCOL.md §7): 1 s for
+    /// <c>updateUstx</c>/<c>updateTracks</c>/<c>updateProjectInfo</c>, 5 s for
+    /// <c>updatePartLayout</c> and its audio.
+    /// </summary>
+    /// <remarks>
+    /// Time is passed in rather than read from the clock, so the pump can be a timer in
+    /// production and a plain loop in tests without any sleeping.
+    /// </remarks>
+    public sealed class DawSyncScheduler {
+        public static readonly TimeSpan DefaultFastDebounce = TimeSpan.FromSeconds(1);
+        public static readonly TimeSpan DefaultSlowDebounce = TimeSpan.FromSeconds(5);
+
+        private readonly TimeSpan fast;
+        private readonly TimeSpan slow;
+        private readonly object lockObj = new object();
+        private readonly Dictionary<DawSyncKind, DateTime> due = new Dictionary<DawSyncKind, DateTime>();
+
+        public DawSyncScheduler(TimeSpan? fastDebounce = null, TimeSpan? slowDebounce = null) {
+            fast = fastDebounce ?? DefaultFastDebounce;
+            slow = slowDebounce ?? DefaultSlowDebounce;
+        }
+
+        public TimeSpan DebounceFor(DawSyncKind kind) =>
+            kind == DawSyncKind.PartLayout ? slow : fast;
+
+        public bool HasPending {
+            get {
+                lock (lockObj) {
+                    return due.Count > 0;
+                }
+            }
+        }
+
+        /// <summary>Marks a stream dirty, pushing its due time out to a full debounce from now.</summary>
+        public void Touch(DawSyncKind kind, DateTime now) {
+            lock (lockObj) {
+                due[kind] = now + DebounceFor(kind);
+            }
+        }
+
+        /// <summary>Makes every pending stream due immediately — the <c>playbackStarted</c> flush (§7).</summary>
+        public void FlushPending(DateTime now) {
+            lock (lockObj) {
+                foreach (var kind in due.Keys.ToList()) {
+                    due[kind] = now;
+                }
+            }
+        }
+
+        /// <summary>Marks one stream dirty and immediately due, bypassing its debounce.</summary>
+        public void MakeDue(DawSyncKind kind, DateTime now) {
+            lock (lockObj) {
+                due[kind] = now;
+            }
+        }
+
+        /// <summary>Marks every stream dirty and immediately due. Used for the post-(re)connect full sync.</summary>
+        public void RequestFullSync(DateTime now) {
+            lock (lockObj) {
+                foreach (DawSyncKind kind in Enum.GetValues<DawSyncKind>()) {
+                    due[kind] = now;
+                }
+            }
+        }
+
+        public void Clear() {
+            lock (lockObj) {
+                due.Clear();
+            }
+        }
+
+        /// <summary>Takes the streams whose debounce has elapsed, in §7 send order.</summary>
+        public DawSyncKind[] TryTake(DateTime now) {
+            lock (lockObj) {
+                var ready = due
+                    .Where(entry => entry.Value <= now)
+                    .Select(entry => entry.Key)
+                    .OrderBy(kind => (int)kind)
+                    .ToArray();
+                foreach (var kind in ready) {
+                    due.Remove(kind);
+                }
+                return ready;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Bounded hash → PCM store. <c>updatePartLayout</c> advertises hashes and the plugin pulls
+    /// them later with <c>getAudio</c> (PROTOCOL.md §6.2), so the bytes have to outlive the
+    /// message that named them.
+    /// </summary>
+    /// <remarks>
+    /// A three-minute stereo part is roughly 63 MB of float32, so the store is capped and evicts
+    /// least-recently-used entries. A miss is recoverable: <see cref="DawManager"/> re-extracts
+    /// the audio from the part that owns the hash.
+    /// </remarks>
+    public sealed class DawAudioCache {
+        public const long DefaultCapacityBytes = 256L * 1024 * 1024;
+
+        private sealed class Entry {
+            public byte[] Pcm = Array.Empty<byte>();
+            public long Stamp;
+        }
+
+        private readonly long capacity;
+        private readonly object lockObj = new object();
+        private readonly Dictionary<string, Entry> entries = new Dictionary<string, Entry>();
+        private long stamp;
+        private long sizeBytes;
+
+        public DawAudioCache(long capacityBytes = DefaultCapacityBytes) {
+            capacity = Math.Max(1, capacityBytes);
+        }
+
+        public long SizeBytes { get { lock (lockObj) { return sizeBytes; } } }
+        public int Count { get { lock (lockObj) { return entries.Count; } } }
+
+        public void Put(string hash, byte[] pcm) {
+            lock (lockObj) {
+                if (entries.TryGetValue(hash, out var previous)) {
+                    sizeBytes -= previous.Pcm.Length;
+                }
+                entries[hash] = new Entry { Pcm = pcm, Stamp = ++stamp };
+                sizeBytes += pcm.Length;
+                Evict();
+            }
+        }
+
+        public bool TryGet(string hash, out byte[] pcm) {
+            lock (lockObj) {
+                if (entries.TryGetValue(hash, out var entry)) {
+                    entry.Stamp = ++stamp;
+                    pcm = entry.Pcm;
+                    return true;
+                }
+            }
+            pcm = Array.Empty<byte>();
+            return false;
+        }
+
+        /// <summary>Drops every hash the current layout no longer advertises.</summary>
+        public void Retain(ICollection<string> keep) {
+            lock (lockObj) {
+                foreach (string hash in entries.Keys.Where(hash => !keep.Contains(hash)).ToList()) {
+                    sizeBytes -= entries[hash].Pcm.Length;
+                    entries.Remove(hash);
+                }
+            }
+        }
+
+        public void Clear() {
+            lock (lockObj) {
+                entries.Clear();
+                sizeBytes = 0;
+            }
+        }
+
+        /// <summary>Keeps one entry whatever its size, so an oversized part can still be served.</summary>
+        private void Evict() {
+            while (sizeBytes > capacity && entries.Count > 1) {
+                string oldest = entries.OrderBy(entry => entry.Value.Stamp).First().Key;
+                sizeBytes -= entries[oldest].Pcm.Length;
+                entries.Remove(oldest);
+            }
+        }
+    }
+
+    /// <summary>Connection state, surfaced to the UI.</summary>
+    public enum DawConnectionState {
+        Disconnected,
+        Connecting,
+        Connected,
+        Reconnecting,
+    }
+
+    /// <summary>One plugin connection, as the connection list shows it.</summary>
+    public sealed class DawConnectionInfo {
+        public int Port { get; }
+        public string Name { get; }
+        public DawConnectionState State { get; }
+
+        public DawConnectionInfo(int port, string name, DawConnectionState state) {
+            Port = port;
+            Name = name;
+            State = state;
+        }
+    }
+
+    /// <summary>
+    /// Drives every plugin connection: the <see cref="ICmdSubscriber"/> subscription that marks
+    /// streams dirty, the debounced sync pump broadcast to all connections, audio serving and
+    /// per-connection reconnect backoff (PROTOCOL.md §7, §9).
+    /// </summary>
+    /// <remarks>
+    /// Each plugin instance in the DAW binds one OpenUtau track, so several instances are
+    /// expected to be connected at once. Project state (the debounce scheduler, the audio
+    /// cache, the hash owners) is shared; connection state (transport, reconnect ladder) is
+    /// per connection.
+    /// </remarks>
+    public sealed class DawManager : SingletonBase<DawManager>, ICmdSubscriber, IDisposable {
+        /// <summary>§3: 500 ms, 1 s, 2 s, then give up and tell the user.</summary>
+        public static readonly TimeSpan[] DefaultReconnectBackoff = {
+            TimeSpan.FromMilliseconds(500),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2),
+        };
+
+        /// <summary>§3: the init handshake gets 5 s, not the ordinary 10 s request budget.</summary>
+        public static readonly TimeSpan InitTimeout = TimeSpan.FromSeconds(5);
+
+        /// <summary>Pump period. Well under the 1 s fast debounce, so it never dominates latency.</summary>
+        public static readonly TimeSpan DefaultPumpInterval = TimeSpan.FromMilliseconds(200);
+
+        /// <summary>
+        /// Playhead updates smaller than this are not forwarded to the document, so a parked
+        /// DAW transport does not re-seek OpenUtau on every notification.
+        /// </summary>
+        public const int PlayheadEpsilonTicks = 5;
+
+        /// <summary>Per-connection state. Guarded by <see cref="stateLock"/>.</summary>
+        private sealed class Connection {
+            public DawServer Server = null!;
+            public DawTransport? Transport;
+            public bool ClosingLocally;
+            public bool Reconnecting;
+        }
+
+        private readonly DawSyncScheduler scheduler;
+        private readonly DawAudioCache audioCache;
+        private readonly TimeSpan[] reconnectBackoff;
+        private readonly SemaphoreSlim syncGate = new SemaphoreSlim(1, 1);
+        private readonly object stateLock = new object();
+
+        /// <summary>Advertised hash → the part that produced it, so a cache miss can be re-extracted.</summary>
+        private readonly Dictionary<string, UVoicePart> hashOwners = new Dictionary<string, UVoicePart>();
+
+        private readonly List<Connection> connections = new List<Connection>();
+        private Timer? pump;
+        private bool subscribed;
+        private int disposed;
+
+        // BPM-mismatch reporting state (document thread only).
+        private double lastDawBpm = double.NaN;
+        private double lastWarnedProjectBpm = double.NaN;
+
+        public DawManager() : this(null) { }
+
+        public DawManager(
+            DawSyncScheduler? syncScheduler,
+            DawAudioCache? cache = null,
+            TimeSpan[]? backoff = null) {
+            scheduler = syncScheduler ?? new DawSyncScheduler();
+            audioCache = cache ?? new DawAudioCache();
+            reconnectBackoff = backoff ?? DefaultReconnectBackoff;
+        }
+
+        public DawConnectionState State { get; private set; } = DawConnectionState.Disconnected;
+        public bool IsConnected => LiveConnections().Any();
+        public string ServerName {
+            get {
+                lock (stateLock) {
+                    return connections.FirstOrDefault(c => c.Transport?.IsConnected == true)
+                        ?.Server.Name ?? string.Empty;
+                }
+            }
+        }
+        public DawSyncScheduler Scheduler => scheduler;
+        public DawAudioCache AudioCache => audioCache;
+
+        /// <summary>Injectable clock, so debounce tests never sleep.</summary>
+        public Func<DateTime> NowUtc { get; set; } = () => DateTime.UtcNow;
+
+        /// <summary>
+        /// The project being synced. Defaults to the open document; injectable so tests can drive
+        /// a hand-built project without standing up <see cref="DocManager"/>'s UI thread.
+        /// </summary>
+        public Func<UProject> ProjectSource { get; set; } = () => DocManager.Inst.Project;
+
+        public DawTransportOptions TransportOptions { get; set; } = DawTransportOptions.Default;
+
+        /// <summary>Set to false in tests, which drive <see cref="PumpOnceAsync"/> by hand.</summary>
+        public bool UseTimerPump { get; set; } = true;
+
+        public event Action<DawConnectionState>? StateChanged;
+
+        /// <summary>Raised whenever a connection is added, dropped or changes state.</summary>
+        public event Action? ConnectionsChanged;
+
+        /// <summary>Raised when reconnection is exhausted. The UI turns this into a visible error.</summary>
+        public event Action<string>? ConnectionLost;
+
+        /// <summary>The connections currently held, in connect order, for the UI list.</summary>
+        public IReadOnlyList<DawConnectionInfo> Connections {
+            get {
+                lock (stateLock) {
+                    return connections
+                        .Select(c => new DawConnectionInfo(c.Server.Port, c.Server.Name, StateOf(c)))
+                        .ToList();
+                }
+            }
+        }
+
+        private static DawConnectionState StateOf(Connection c) {
+            if (c.Transport?.IsConnected == true) {
+                return DawConnectionState.Connected;
+            }
+            return c.Reconnecting ? DawConnectionState.Reconnecting : DawConnectionState.Connecting;
+        }
+
+        private List<Connection> LiveConnections() {
+            lock (stateLock) {
+                return connections.Where(c => c.Transport?.IsConnected == true).ToList();
+            }
+        }
+
+        /// <summary>
+        /// Connects to a discovered plugin, performs the init handshake and starts syncing.
+        /// Several plugins may be connected at once, one per DAW plugin instance; connecting a
+        /// port that is already connected replaces that connection.
+        /// </summary>
+        /// <exception cref="DawProtocolException">
+        /// The advertisement, or the plugin's own init answer, is an api major this build cannot speak (§4).
+        /// </exception>
+        public async Task ConnectAsync(DawServer target, CancellationToken cancellation = default) {
+            if (!target.IsCompatible) {
+                throw new DawProtocolException(
+                    $"Plugin '{target.Name}' speaks api '{target.Info.ApiVersion}', " +
+                    $"this build speaks {DawApiVersion.CurrentString}.");
+            }
+            Connection? replaced;
+            lock (stateLock) {
+                replaced = connections.FirstOrDefault(c => c.Server.Port == target.Port);
+            }
+            if (replaced != null) {
+                await CloseConnectionAsync(replaced, finalSync: false);
+            }
+            var conn = new Connection { Server = target };
+            lock (stateLock) {
+                connections.Add(conn);
+            }
+            RecomputeState();
+            try {
+                await OpenConnectionAsync(conn, cancellation);
+            } catch {
+                lock (stateLock) {
+                    connections.Remove(conn);
+                }
+                RecomputeState();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The per-connection half of the old OpenAsync: transport, init handshake, then the
+        /// streams §9 still owes the plugin (tracks, layout, project info — init already
+        /// carried the USTX baseline).
+        /// </summary>
+        private async Task OpenConnectionAsync(Connection conn, CancellationToken cancellation) {
+            var opened = await DawTransport.ConnectAsync(
+                conn.Server.Port, TransportOptions, NowUtc, cancellation);
+            Action<string, JsonElement?> onNotification =
+                (kind, payload) => OnPluginNotification(conn, kind, payload);
+            Action<DawDisconnectReason, string> onDisconnected =
+                (reason, detail) => OnTransportDisconnected(conn, reason, detail);
+            opened.Notification += onNotification;
+            opened.Disconnected += onDisconnected;
+            opened.RequestHandler = ServeRequestAsync;
+            lock (stateLock) {
+                conn.Transport = opened;
+            }
+            try {
+                // §6.1 as decided: init carries the USTX baseline and the answer is the api version.
+                string ustx = await SerializeProjectAsync();
+                var response = await opened.SendRequestAsync<InitResponse>(
+                    DawMessageKind.Init, new InitRequest { Ustx = ustx }, InitTimeout, cancellation);
+                if (!DawApiVersion.TryParse(response.ApiVersion, out var version)
+                    || !version.IsCompatibleWith(DawApiVersion.Current)) {
+                    throw new DawProtocolException(
+                        $"Plugin answered init with api '{response.ApiVersion}', " +
+                        $"which this build cannot speak.");
+                }
+                Subscribe();
+                RecomputeState();
+                StartPump();
+                // init already delivered the USTX, so only tracks, layout and project info are
+                // outstanding (§7, §9). These go to this connection alone: the others already hold
+                // the same state.
+                await SyncConnectionAsync(conn, DawSyncKind.Tracks, cancellation);
+                await SyncConnectionAsync(conn, DawSyncKind.ProjectInfo, cancellation);
+                await SyncConnectionAsync(conn, DawSyncKind.PartLayout, cancellation);
+            } catch {
+                // A failed open must not leave a wired, connected transport behind: if the peer
+                // later dropped it, the disconnected callback would start a second reconnect
+                // ladder while the caller is still unwinding this one. Detach before disposing
+                // so the synchronous callback never fires. The whole open — init, subscription,
+                // pump and the initial per-connection syncs — is covered, so a post-init
+                // failure (a layout request timing out, an unsaved project) cannot leave a
+                // live transport behind either.
+                opened.Disconnected -= onDisconnected;
+                bool stillCurrent;
+                lock (stateLock) {
+                    stillCurrent = ReferenceEquals(conn.Transport, opened);
+                    if (stillCurrent) {
+                        conn.Transport = null;
+                    }
+                }
+                opened.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Serializes the open project to USTX YAML — byte-identical to what <c>Ustx.Save</c>
+        /// writes. <see cref="DawUstx.Serialize"/> runs <c>BeforeSave</c>/<c>AfterSave</c>, which
+        /// mutate the project, so it has to happen on the document thread.
+        /// </summary>
+        private Task<string> SerializeProjectAsync() {
+            return OnDocumentThreadAsync(() => DawUstx.Serialize(ProjectSource()));
+        }
+
+        /// <summary>
+        /// Runs work on the document thread. <see cref="DocManager.MainScheduler"/> is null until
+        /// the UI calls <c>Initialize</c>, which is the case in tests; then the work runs inline.
+        /// </summary>
+        private Task<T> OnDocumentThreadAsync<T>(Func<T> work) {
+            var docScheduler = DocManager.Inst.MainScheduler;
+            if (docScheduler == null) {
+                return Task.FromResult(work());
+            }
+            return Task.Factory.StartNew(work, CancellationToken.None, TaskCreationOptions.None, docScheduler);
+        }
+
+        private void Subscribe() {
+            lock (stateLock) {
+                if (subscribed) {
+                    return;
+                }
+                DocManager.Inst.AddSubscriber(this);
+                subscribed = true;
+            }
+        }
+
+        private void UnsubscribeIfIdle() {
+            lock (stateLock) {
+                if (!subscribed || connections.Count > 0) {
+                    return;
+                }
+                DocManager.Inst.RemoveSubscriber(this);
+                subscribed = false;
+            }
+        }
+
+        private void RecomputeState() {
+            DawConnectionState next;
+            lock (stateLock) {
+                if (connections.Any(c => c.Transport?.IsConnected == true)) {
+                    next = DawConnectionState.Connected;
+                } else if (connections.Any(c => c.Reconnecting)) {
+                    next = DawConnectionState.Reconnecting;
+                } else if (connections.Count > 0) {
+                    next = DawConnectionState.Connecting;
+                } else {
+                    next = DawConnectionState.Disconnected;
+                }
+            }
+            bool changed;
+            lock (stateLock) {
+                changed = State != next;
+                State = next;
+            }
+            if (changed) {
+                StateChanged?.Invoke(next);
+            }
+            ConnectionsChanged?.Invoke();
+        }
+
+        private void StartPump() {
+            if (!UseTimerPump) {
+                return;
+            }
+            lock (stateLock) {
+                pump?.Dispose();
+                pump = new Timer(
+                    _ => PumpOnceAsync(CancellationToken.None).ContinueWith(
+                        task => Log.Error(task.Exception!, "DAW: sync pump failed."),
+                        TaskContinuationOptions.OnlyOnFaulted),
+                    null,
+                    DefaultPumpInterval,
+                    DefaultPumpInterval);
+            }
+        }
+
+        private void StopPumpIfIdle() {
+            lock (stateLock) {
+                if (connections.Count > 0) {
+                    return;
+                }
+                pump?.Dispose();
+                pump = null;
+            }
+        }
+
+        /// <summary>
+        /// The document command stream. Runs on the document thread for every single edit, so it
+        /// only ever sets flags — the pump does the work (§7).
+        /// </summary>
+        public void OnNext(UCommand cmd, bool isUndo) {
+            if (!IsConnected) {
+                return;
+            }
+            var now = NowUtc();
+            switch (cmd) {
+                case VolumeChangeNotification:
+                case PanChangeNotification:
+                case SoloTrackNotification:
+                    scheduler.Touch(DawSyncKind.Tracks, now);
+                    break;
+                case PartRenderedNotification:
+                    scheduler.Touch(DawSyncKind.PartLayout, now);
+                    break;
+                case LoadProjectNotification:
+                    // A different project: nothing any plugin holds is valid any more.
+                    audioCache.Clear();
+                    lock (stateLock) {
+                        hashOwners.Clear();
+                    }
+                    scheduler.RequestFullSync(now);
+                    break;
+                case SaveProjectNotification:
+                    // Saving for the first time is what turns an unsaved project syncable, and
+                    // the file name is what the plugins' info windows show.
+                    scheduler.Touch(DawSyncKind.ProjectInfo, now);
+                    break;
+                case UNotification:
+                    // Transient UI state — play position, selection, progress. Not project data.
+                    break;
+                case TrackCommand:
+                    // Adding, removing or renaming a track moves parts between track numbers too.
+                    scheduler.Touch(DawSyncKind.Tracks, now);
+                    scheduler.Touch(DawSyncKind.Ustx, now);
+                    scheduler.Touch(DawSyncKind.PartLayout, now);
+                    break;
+                default:
+                    // A real edit. The audio follows once the renderer reports back.
+                    scheduler.Touch(DawSyncKind.Ustx, now);
+                    scheduler.Touch(DawSyncKind.PartLayout, now);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Sends whatever the debounce has made due, in §7 order, to every live connection. A
+        /// gate serializes ticks so a slow layout sync can never overlap the next one.
+        /// </summary>
+        public async Task PumpOnceAsync(CancellationToken cancellation = default) {
+            if (!IsConnected || !scheduler.HasPending) {
+                return;
+            }
+            if (!await syncGate.WaitAsync(0, cancellation)) {
+                // Already syncing. Whatever is due simply waits for the next tick.
+                return;
+            }
+            try {
+                foreach (var kind in scheduler.TryTake(NowUtc())) {
+                    if (!IsConnected) {
+                        break;
+                    }
+                    await SyncAsync(kind, cancellation);
+                }
+            } catch (OperationCanceledException) {
+                // Shutting down.
+            } catch (Exception e) {
+                // A refused envelope or a serialization fault leaves the stream coherent, so the
+                // connection survives and the stream is retried on the next edit.
+                Log.Error(e, "DAW: sync failed.");
+            } finally {
+                syncGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Sends one stream to every live connection. Shared payloads (the USTX YAML, the
+        /// track list, the part layout and its hashes) are built once, not once per
+        /// connection; only the sends are per connection. A request timeout drops only the
+        /// connection it happened on (§8); the others stay synced.
+        /// </summary>
+        public async Task SyncAsync(DawSyncKind kind, CancellationToken cancellation = default) {
+            var live = LiveConnections();
+            if (live.Count == 0) {
+                return;
+            }
+            switch (kind) {
+                case DawSyncKind.Ustx: {
+                    // Serialize once: BeforeSave/AfterSave mutate the project's serialization
+                    // views, so N connections must not mean N mutation round trips.
+                    var payload = new UpdateUstxNotification { Ustx = await SerializeProjectAsync() };
+                    await BroadcastAsync(live, (conn, token) =>
+                        conn.Transport!.SendNotificationAsync(DawMessageKind.UpdateUstx, payload, token),
+                        cancellation);
+                    break;
+                }
+                case DawSyncKind.Tracks: {
+                    var payload = await BuildTracksAsync();
+                    await BroadcastAsync(live, (conn, token) =>
+                        conn.Transport!.SendNotificationAsync(DawMessageKind.UpdateTracks, payload, token),
+                        cancellation);
+                    break;
+                }
+                case DawSyncKind.ProjectInfo: {
+                    var payload = await BuildProjectInfoAsync();
+                    await BroadcastAsync(live, (conn, token) =>
+                        conn.Transport!.SendNotificationAsync(DawMessageKind.UpdateProjectInfo, payload, token),
+                        cancellation);
+                    break;
+                }
+                case DawSyncKind.PartLayout: {
+                    var layout = await BuildPartLayoutAsync();
+                    await BroadcastAsync(live, async (conn, token) => {
+                        var response = await conn.Transport!.SendRequestAsync<UpdatePartLayoutResponse>(
+                            DawMessageKind.UpdatePartLayout,
+                            new UpdatePartLayoutRequest { Parts = layout },
+                            cancellation: token);
+                        if (response.MissingAudios.Count > 0) {
+                            // The plugin pulls each one itself with getAudio (§6.2); we just keep them warm.
+                            Log.Information(
+                                $"DAW: plugin '{conn.Server.Name}' is missing " +
+                                $"{response.MissingAudios.Count} of {layout.Count} part audios.");
+                        }
+                    }, cancellation);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sends one pre-built payload to every live connection. A request timeout drops only
+        /// the connection it happened on (§8); the others stay synced.
+        /// </summary>
+        private async Task BroadcastAsync(List<Connection> targets,
+                Func<Connection, CancellationToken, Task> send, CancellationToken cancellation) {
+            foreach (var conn in targets) {
+                var t = conn.Transport;
+                if (t == null || !t.IsConnected) {
+                    continue;
+                }
+                try {
+                    await send(conn, cancellation);
+                } catch (TimeoutException e) {
+                    Log.Warning(e, $"DAW: sync to '{conn.Server.Name}' timed out; dropping it.");
+                    await DropConnectionAsync(conn);
+                }
+            }
+        }
+
+        /// <summary>Sends one stream to one connection. Public-per-kind so tests can force a sync.</summary>
+        private async Task SyncConnectionAsync(Connection conn, DawSyncKind kind, CancellationToken cancellation) {
+            var live = conn.Transport;
+            if (live == null || !live.IsConnected) {
+                return;
+            }
+            switch (kind) {
+                case DawSyncKind.Ustx:
+                    await live.SendNotificationAsync(
+                        DawMessageKind.UpdateUstx,
+                        new UpdateUstxNotification { Ustx = await SerializeProjectAsync() },
+                        cancellation);
+                    break;
+                case DawSyncKind.Tracks:
+                    await live.SendNotificationAsync(
+                        DawMessageKind.UpdateTracks, await BuildTracksAsync(), cancellation);
+                    break;
+                case DawSyncKind.ProjectInfo:
+                    await live.SendNotificationAsync(
+                        DawMessageKind.UpdateProjectInfo, await BuildProjectInfoAsync(), cancellation);
+                    break;
+                case DawSyncKind.PartLayout:
+                    await SyncPartLayoutAsync(conn, live, cancellation);
+                    break;
+            }
+        }
+
+        private Task<UpdateTracksNotification> BuildTracksAsync() {
+            return OnDocumentThreadAsync(() => new UpdateTracksNotification {
+                Tracks = ProjectSource().tracks
+                    .Select(track => new DawTrackInfo {
+                        Name = track.TrackName,
+                        Volume = track.Volume,
+                        Pan = track.Pan,
+                        // Kept on the wire for compatibility, but the bridge sends pre-fader
+                        // audio and leaves gain, pan, mute and solo to the DAW mixer.
+                        Muted = track.Muted,
+                        // v1.2: informational fields for the plugin's GUI. Singer changes and
+                        // renderer changes are TrackCommands, so the same Tracks sync keeps
+                        // these fresh without new triggers.
+                        Singer = track.Singer?.Name ?? string.Empty,
+                        Engine = track.RendererSettings.renderer ?? string.Empty,
+                    })
+                    .ToList(),
+            });
+        }
+
+        private Task<UpdateProjectInfoNotification> BuildProjectInfoAsync() {
+            return OnDocumentThreadAsync(() => {
+                var project = ProjectSource();
+                bool saved = !string.IsNullOrEmpty(project.FilePath);
+                return new UpdateProjectInfoNotification {
+                    Saved = saved,
+                    Name = saved
+                        ? System.IO.Path.GetFileNameWithoutExtension(project.FilePath)
+                        : string.Empty,
+                };
+            });
+        }
+
+        /// <summary>A part's layout plus the signal it was mixed into, captured on the document thread.</summary>
+        private sealed class PartSnapshot {
+            public UProject Project = null!;
+            public UVoicePart Part = null!;
+            public int TrackNo;
+            public double StartMs;
+            public double EndMs;
+        }
+
+        private Task<List<PartSnapshot>> SnapshotPartsAsync() {
+            return OnDocumentThreadAsync(() => {
+                var project = ProjectSource();
+                return project.parts
+                    .OfType<UVoicePart>()
+                    .Select(part => new PartSnapshot {
+                        Project = project,
+                        Part = part,
+                        TrackNo = part.trackNo,
+                        StartMs = project.timeAxis.TickPosToMsPos(part.position),
+                        EndMs = project.timeAxis.TickPosToMsPos(part.End),
+                    })
+                    .ToList();
+            });
+        }
+
+        /// <summary>
+        /// Reports the layout, hashing each part's rendered audio on the way.
+        /// </summary>
+        /// <remarks>
+        /// Parts whose render is unfinished are left out entirely rather than advertised with a
+        /// placeholder hash, because <see cref="DawAudio.TryExtractPart"/> can only produce a
+        /// correct hash for finished audio. <c>PartRenderedNotification</c> marks the stream dirty
+        /// again, so they appear in a later sync. The hash owner map and the audio cache are
+        /// shared between connections: every plugin is offered every track, and chooses its own
+        /// (PROTOCOL.md §6.1).
+        /// </remarks>
+        private async Task SyncPartLayoutAsync(Connection conn, DawTransport live, CancellationToken cancellation) {
+            var layout = await BuildPartLayoutAsync();
+            var response = await live.SendRequestAsync<UpdatePartLayoutResponse>(
+                DawMessageKind.UpdatePartLayout,
+                new UpdatePartLayoutRequest { Parts = layout },
+                cancellation: cancellation);
+            if (response.MissingAudios.Count > 0) {
+                // The plugin pulls each one itself with getAudio (§6.2); we just keep them warm.
+                Log.Information(
+                    $"DAW: plugin '{conn.Server.Name}' is missing " +
+                    $"{response.MissingAudios.Count} of {layout.Count} part audios.");
+            }
+        }
+
+        /// <summary>
+        /// Builds the part layout payload — extracting, hashing and caching every rendered
+        /// part — and updates the shared hash owner map. Done once per sync, never once per
+        /// connection: a part can be tens of megabytes.
+        /// </summary>
+        private async Task<List<DawPartLayout>> BuildPartLayoutAsync() {
+            var snapshot = await SnapshotPartsAsync();
+            var layout = new List<DawPartLayout>(snapshot.Count);
+            var owners = new Dictionary<string, UVoicePart>();
+            foreach (var entry in snapshot) {
+                if (!TryHashPart(entry, out string hash, out byte[] pcm)) {
+                    continue;
+                }
+                owners[hash] = entry.Part;
+                audioCache.Put(hash, pcm);
+                layout.Add(new DawPartLayout {
+                    TrackNo = entry.TrackNo,
+                    StartMs = entry.StartMs,
+                    EndMs = entry.EndMs,
+                    AudioHash = hash,
+                });
+            }
+            lock (stateLock) {
+                hashOwners.Clear();
+                foreach (var pair in owners) {
+                    hashOwners[pair.Key] = pair.Value;
+                }
+            }
+            audioCache.Retain(owners.Keys);
+            return layout;
+        }
+
+        /// <summary>
+        /// Extracts and hashes one part. Runs off the document thread on purpose: a part can be
+        /// tens of megabytes, and concurrent reads of a part's mix are what playback already does.
+        /// </summary>
+        private static bool TryHashPart(PartSnapshot entry, out string hash, out byte[] pcm) {
+            hash = string.Empty;
+            pcm = Array.Empty<byte>();
+            if (!DawAudio.TryExtractPart(entry.Project, entry.Part, out var samples)) {
+                return false;
+            }
+            pcm = DawAudio.ToPcmBytes(samples);
+            hash = DawAudio.FormatHash(DawAudio.Hash(pcm));
+            return true;
+        }
+
+        /// <summary>
+        /// Serves a plugin's requests. Only <c>getAudio</c> is inbound in v1 (§6.2), and it is
+        /// answered with a data-plane frame rather than an envelope.
+        /// </summary>
+        private async Task ServeRequestAsync(DawInboundRequest request) {
+            if (request.Kind != DawMessageKind.GetAudio) {
+                await request.RespondAsync(DawResult.Fail($"Unsupported request '{request.Kind}'."));
+                return;
+            }
+            string hash;
+            try {
+                hash = request.ReadPayload<GetAudioRequest>().Hash;
+            } catch (Exception e) {
+                await request.RespondAsync(DawResult.Fail(e.Message));
+                return;
+            }
+            if (!TryResolveAudio(hash, out byte[] pcm)) {
+                await request.RespondAsync(DawResult.Fail($"No audio for hash {hash}."));
+                return;
+            }
+            await request.RespondWithAudioAsync(hash, pcm);
+        }
+
+        /// <summary>
+        /// Finds the audio behind an advertised hash: the cache first, then a re-extraction from
+        /// the part that produced it. The re-extracted bytes still have to hash to the requested
+        /// value — if they do not, the part was re-rendered and the plugin is asking about audio
+        /// that no longer exists, which the next layout sync will correct.
+        /// </summary>
+        private bool TryResolveAudio(string hash, out byte[] pcm) {
+            if (audioCache.TryGet(hash, out pcm)) {
+                return true;
+            }
+            UVoicePart? part;
+            lock (stateLock) {
+                hashOwners.TryGetValue(hash, out part);
+            }
+            if (part == null) {
+                return false;
+            }
+            var entry = new PartSnapshot { Project = ProjectSource(), Part = part };
+            if (!TryHashPart(entry, out string actual, out var bytes) || actual != hash) {
+                return false;
+            }
+            audioCache.Put(hash, bytes);
+            pcm = bytes;
+            return true;
+        }
+
+        private void OnPluginNotification(Connection conn, string kind, JsonElement? payload) {
+            switch (kind) {
+                case DawMessageKind.Ping:
+                    // Liveness only — the transport already refreshed its heartbeat clock (§3).
+                    break;
+                case DawMessageKind.PlaybackStarted:
+                    // §7: the DAW is about to play, so everything pending goes out now.
+                    scheduler.FlushPending(NowUtc());
+                    FireAndForget(PumpOnceAsync(), "playbackStarted flush");
+                    break;
+                case DawMessageKind.Playhead:
+                    if (payload.HasValue) {
+                        var note = payload.Value.Deserialize<PlayheadNotification>(DawJson.Options);
+                        if (note != null) {
+                            HandlePlayhead(note);
+                        }
+                    }
+                    break;
+                case DawMessageKind.Bpm:
+                    if (payload.HasValue) {
+                        var note = payload.Value.Deserialize<BpmNotification>(DawJson.Options);
+                        if (note != null) {
+                            HandleBpm(note.Bpm);
+                        }
+                    }
+                    break;
+                default:
+                    Log.Information($"DAW: ignoring unknown notification '{kind}'.");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// v1.1 one-way playhead sync: the DAW's position simply overwrites OpenUtau's. The
+        /// reverse direction does not exist — OpenUtau never reports its own position.
+        /// </summary>
+        private void HandlePlayhead(PlayheadNotification note) {
+            FireAndForget(OnDocumentThreadAsync(() => {
+                var project = ProjectSource();
+                int tick = Math.Max(0, project.timeAxis.MsPosToTickPos(note.PositionMs));
+                if (Math.Abs(tick - DocManager.Inst.playPosTick) < PlayheadEpsilonTicks) {
+                    return 0;
+                }
+                DocManager.Inst.ExecuteCmd(new SeekPlayPosTickNotification(tick));
+                return 0;
+            }), "playhead sync");
+        }
+
+        /// <summary>
+        /// v1.1 tempo guard: without ARA there is no tempo-map sync, so a DAW tempo that does
+        /// not match the project's first tempo is reported once per distinct mismatch instead
+        /// of silently misaligning bars.
+        /// </summary>
+        private void HandleBpm(double dawBpm) {
+            FireAndForget(OnDocumentThreadAsync(() => {
+                var project = ProjectSource();
+                double projectBpm = project.tempos.Count > 0 ? project.tempos[0].bpm : 120.0;
+                if (Math.Abs(dawBpm - projectBpm) < 0.5) {
+                    return 0;
+                }
+                if (dawBpm == lastDawBpm && projectBpm == lastWarnedProjectBpm) {
+                    // Already told the user about exactly this mismatch.
+                    return 0;
+                }
+                lastDawBpm = dawBpm;
+                lastWarnedProjectBpm = projectBpm;
+                string detail = $"DAW: {dawBpm:0.##} / OpenUtau: {projectBpm:0.##}";
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(
+                    new MessageCustomizableException(
+                        $"The DAW project's tempo ({dawBpm:0.##} BPM) does not match this " +
+                        $"project's tempo ({projectBpm:0.##} BPM). Align them, or the DAW " +
+                        $"timeline and OpenUtau's will only agree in seconds, not in bars.",
+                        $"<translate:dawintegration.bpmmismatch> ({detail})",
+                        new InvalidOperationException(), false)));
+                return 0;
+            }), "bpm check");
+        }
+
+        /// <summary>
+        /// End of one connection. A close we asked for stays closed; anything else climbs the
+        /// §3 backoff ladder for that connection alone.
+        /// </summary>
+        private void OnTransportDisconnected(Connection conn, DawDisconnectReason reason, string detail) {
+            if (conn.ClosingLocally) {
+                return;
+            }
+            lock (stateLock) {
+                // The dead transport is left to the GC, as before the multi-instance split:
+                // disposing it from inside its own read-loop callback risks a self-join.
+                conn.Transport = null;
+                conn.Reconnecting = true;
+            }
+            RecomputeState();
+            FireAndForget(ReconnectAsync(conn, reason, detail), "reconnect");
+        }
+
+        /// <summary>
+        /// Retries the same port on the §3 ladder — 500 ms, 1 s, 2 s. A plugin that really
+        /// exited never answers, so the ladder ends and the user is told once.
+        /// </summary>
+        private async Task ReconnectAsync(Connection conn, DawDisconnectReason reason, string detail) {
+            for (int attempt = 0; attempt < reconnectBackoff.Length; attempt++) {
+                await Task.Delay(reconnectBackoff[attempt]);
+                bool cancelled;
+                lock (stateLock) {
+                    cancelled = conn.ClosingLocally || !connections.Contains(conn);
+                }
+                if (cancelled || Volatile.Read(ref disposed) != 0) {
+                    return;
+                }
+                try {
+                    await OpenConnectionAsync(conn, CancellationToken.None);
+                    lock (stateLock) {
+                        conn.Reconnecting = false;
+                    }
+                    RecomputeState();
+                    Log.Information(
+                        $"DAW: reconnected to '{conn.Server.Name}' on attempt {attempt + 1}.");
+                    return;
+                } catch (Exception e) {
+                    Log.Warning(e, $"DAW: reconnect attempt {attempt + 1} of {reconnectBackoff.Length} failed.");
+                }
+            }
+            lock (stateLock) {
+                connections.Remove(conn);
+            }
+            RecomputeState();
+            StopPumpIfIdle();
+            UnsubscribeIfIdle();
+            ConnectionLost?.Invoke($"{conn.Server.Name}: {reason}: {detail}");
+        }
+
+        /// <summary>
+        /// Drops one connection after a protocol-level failure, letting its disconnect handler
+        /// start the reconnect ladder.
+        /// </summary>
+        private async Task DropConnectionAsync(Connection conn) {
+            var live = conn.Transport;
+            if (live == null) {
+                return;
+            }
+            try {
+                await live.CloseAsync();
+            } catch (Exception e) {
+                Log.Warning(e, "DAW: closing the transport failed.");
+            }
+        }
+
+        /// <summary>
+        /// User-initiated teardown of every connection: flush what is pending so the DAW is
+        /// left holding the final state, then send the bare <c>close</c> (§9).
+        /// </summary>
+        public async Task DisconnectAsync() {
+            List<Connection> snapshot;
+            lock (stateLock) {
+                snapshot = connections.ToList();
+            }
+            foreach (var conn in snapshot) {
+                await CloseConnectionAsync(conn, finalSync: true);
+            }
+        }
+
+        /// <summary>User-initiated teardown of the connection on one port, if it exists.</summary>
+        public async Task DisconnectAsync(int port) {
+            Connection? conn;
+            lock (stateLock) {
+                conn = connections.FirstOrDefault(c => c.Server.Port == port);
+            }
+            if (conn != null) {
+                await CloseConnectionAsync(conn, finalSync: true);
+            }
+        }
+
+        private async Task CloseConnectionAsync(Connection conn, bool finalSync) {
+            conn.ClosingLocally = true;
+            var live = conn.Transport;
+            if (finalSync && live != null && live.IsConnected) {
+                // Flush and drain the pending streams, so the due entries are consumed rather
+                // than replayed by the next pump tick (§9: the DAW keeps the final state).
+                scheduler.FlushPending(NowUtc());
+                try {
+                    foreach (var kind in scheduler.TryTake(NowUtc())) {
+                        await SyncAsync(kind);
+                    }
+                } catch (Exception e) {
+                    Log.Warning(e, "DAW: the final sync before closing failed.");
+                }
+            }
+            if (live != null) {
+                try {
+                    await live.CloseAsync();
+                } catch (Exception e) {
+                    Log.Warning(e, "DAW: closing the transport failed.");
+                }
+                live.Dispose();
+            }
+            lock (stateLock) {
+                conn.Transport = null;
+                connections.Remove(conn);
+            }
+            RecomputeState();
+            StopPumpIfIdle();
+            UnsubscribeIfIdle();
+        }
+
+        private static void FireAndForget(Task task, string what) {
+            task.ContinueWith(
+                faulted => Log.Error(faulted.Exception!, $"DAW: {what} failed."),
+                TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        /// <summary>
+        /// Drops every connection without a final sync. Deliberately does no blocking wait:
+        /// dispose runs on application shutdown, and a final sync needs the document thread,
+        /// which would deadlock if that thread is the one disposing.
+        /// </summary>
+        public void Dispose() {
+            if (Interlocked.Exchange(ref disposed, 1) != 0) {
+                return;
+            }
+            List<Connection> snapshot;
+            lock (stateLock) {
+                snapshot = connections.ToList();
+                connections.Clear();
+                pump?.Dispose();
+                pump = null;
+                hashOwners.Clear();
+            }
+            foreach (var conn in snapshot) {
+                conn.ClosingLocally = true;
+                conn.Transport?.Dispose();
+                conn.Transport = null;
+            }
+            if (subscribed) {
+                DocManager.Inst.RemoveSubscriber(this);
+                subscribed = false;
+            }
+            scheduler.Clear();
+            audioCache.Clear();
+            // Deliberately not disposing syncGate: StopPump does not join an in-flight timer
+            // callback, and notifications start PumpOnceAsync without awaiting it, so a pump
+            // can still enter WaitAsync/Release after this point. A SemaphoreSlim holds no
+            // unmanaged state, so leaving it to the GC is safe; disposing it here could throw
+            // ObjectDisposedException into an awaited DisconnectAsync on the UI thread.
+            State = DawConnectionState.Disconnected;
+        }
+    }
+}

--- a/OpenUtau.Core/DawIntegration/DawMessages.cs
+++ b/OpenUtau.Core/DawIntegration/DawMessages.cs
@@ -220,16 +220,22 @@ namespace OpenUtau.Core.DawIntegration {
         /// <summary>
         /// v1.2: the track's singer display name (<see cref="Ustx.UTrack.Singer"/>), or the
         /// empty string when the track has none yet. Informational — the plugin's GUI shows
-        /// it next to the track name; it does not affect the audio.
+        /// it next to the track name; it does not affect the audio. Omitted on the wire when
+        /// the peer negotiated a minor below 2 (§10: the newer side omits fields the older
+        /// minor does not know).
         /// </summary>
-        [JsonPropertyName("singer")] public string Singer { get; set; } = string.Empty;
+        [JsonPropertyName("singer")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Singer { get; set; } = string.Empty;
 
         /// <summary>
         /// v1.2: the track's render engine key (<see cref="Ustx.URenderSettings.renderer"/>,
         /// e.g. CLASSIC, WORLDLINE-R, DIFFSINGER), or the empty string when the track has no
-        /// usable singer/renderer yet. Informational only.
+        /// usable singer/renderer yet. Informational only; version-gated like <see cref="Singer"/>.
         /// </summary>
-        [JsonPropertyName("engine")] public string Engine { get; set; } = string.Empty;
+        [JsonPropertyName("engine")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Engine { get; set; } = string.Empty;
     }
 
     /// <summary><c>updateTracks</c> notification payload (PROTOCOL.md §6.1).</summary>

--- a/OpenUtau.Core/DawIntegration/DawMessages.cs
+++ b/OpenUtau.Core/DawIntegration/DawMessages.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>
+    /// Control-plane message kinds. See PROTOCOL.md §6.
+    /// </summary>
+    public static class DawMessageKind {
+        // OpenUtau -> plugin
+        public const string Init = "init";
+        public const string UpdateUstx = "updateUstx";
+        public const string UpdatePartLayout = "updatePartLayout";
+        public const string GetAudio = "getAudio";
+        public const string UpdateTracks = "updateTracks";
+        public const string UpdateProjectInfo = "updateProjectInfo";
+        // plugin -> OpenUtau
+        public const string Ping = "ping";
+        public const string PlaybackStarted = "playbackStarted";
+        public const string Playhead = "playhead";
+        public const string Bpm = "bpm";
+    }
+
+    /// <summary>
+    /// Protocol version carried by the discovery file and echoed in the init response
+    /// (PROTOCOL.md §4). Major mismatch refuses the connection; minor skew connects.
+    /// </summary>
+    public readonly struct DawApiVersion : IEquatable<DawApiVersion> {
+        public const string CurrentString = "1.2";
+        public static DawApiVersion Current => new DawApiVersion(1, 2);
+
+        public readonly int Major;
+        public readonly int Minor;
+
+        public DawApiVersion(int major, int minor) {
+            Major = major;
+            Minor = minor;
+        }
+
+        public static bool TryParse(string? text, out DawApiVersion version) {
+            version = default;
+            if (string.IsNullOrWhiteSpace(text)) {
+                return false;
+            }
+            var parts = text.Split('.');
+            if (parts.Length != 2) {
+                return false;
+            }
+            if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int major) ||
+                !int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out int minor)) {
+                return false;
+            }
+            version = new DawApiVersion(major, minor);
+            return true;
+        }
+
+        /// <summary>Only the major component gates compatibility (PROTOCOL.md §4, §10).</summary>
+        public bool IsCompatibleWith(DawApiVersion other) => Major == other.Major;
+
+        public bool Equals(DawApiVersion other) => Major == other.Major && Minor == other.Minor;
+        public override bool Equals(object? obj) => obj is DawApiVersion other && Equals(other);
+        public override int GetHashCode() => (Major * 397) ^ Minor;
+        public override string ToString() => $"{Major}.{Minor}";
+    }
+
+    /// <summary>
+    /// Response envelope for <c>response:&lt;uuid&gt;</c> lines (PROTOCOL.md §5.1):
+    /// <c>{ "success": true, "data": { }, "error": null }</c>.
+    /// </summary>
+    public class DawResult {
+        [JsonPropertyName("success")] public bool Success { get; set; }
+        [JsonPropertyName("data")] public JsonElement? Data { get; set; }
+        [JsonPropertyName("error")] public string? Error { get; set; }
+
+        public static DawResult Ok() => new DawResult { Success = true };
+
+        /// <summary>
+        /// Wraps a payload as the envelope's <c>data</c>. Round-tripping through
+        /// <see cref="JsonElement"/> keeps <see cref="Data"/> a single type regardless of whether
+        /// the envelope was built locally or read off the wire.
+        /// </summary>
+        public static DawResult Ok<T>(T data) => new DawResult {
+            Success = true,
+            Data = JsonSerializer.SerializeToElement(data, DawJson.Options),
+        };
+
+        public static DawResult Fail(string error) => new DawResult { Success = false, Error = error };
+
+        /// <summary>
+        /// Deserializes <see cref="Data"/> into <typeparamref name="T"/>. Throws
+        /// <see cref="DawProtocolException"/> when the envelope reported failure or the
+        /// payload is absent, so callers never silently observe a default value.
+        /// </summary>
+        public T Unwrap<T>() {
+            if (!Success) {
+                throw new DawProtocolException($"Plugin returned an error: {Error ?? "(none)"}");
+            }
+            if (Data == null) {
+                throw new DawProtocolException("Plugin returned a successful response with no data.");
+            }
+            var value = Data.Value.Deserialize<T>(DawJson.Options);
+            if (value == null) {
+                throw new DawProtocolException($"Plugin response data could not be read as {typeof(T).Name}.");
+            }
+            return value;
+        }
+    }
+
+    /// <summary>Raised on any framing / envelope violation that must drop the connection (PROTOCOL.md §8).</summary>
+    public class DawProtocolException : Exception {
+        public DawProtocolException(string message) : base(message) { }
+        public DawProtocolException(string message, Exception inner) : base(message, inner) { }
+    }
+
+    /// <summary>Shared serializer settings. Keys are explicit on every DTO, so no naming policy is applied.</summary>
+    public static class DawJson {
+        public static readonly JsonSerializerOptions Options = new JsonSerializerOptions {
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
+        };
+
+        public static string Serialize<T>(T value) => JsonSerializer.Serialize(value, Options);
+    }
+
+    /// <summary>
+    /// Produces the <c>ustx</c> string field carried by <c>init</c> and <c>updateUstx</c>.
+    /// USTX is OpenUtau's native YAML document — byte-identical to what <c>Ustx.Save</c> writes
+    /// to a <c>.ustx</c> file — so the plugin can persist it or re-parse it with any YAML reader.
+    /// </summary>
+    /// <remarks>
+    /// Must run on the document thread: <c>UProject.BeforeSave</c> mutates the project's
+    /// serialization views (<c>voiceParts</c>/<c>waveParts</c>), so concurrent edits would race.
+    /// </remarks>
+    public static class DawUstx {
+        /// <summary>
+        /// Serializes the open project to USTX YAML. An unsaved project has no
+        /// <c>FilePath</c>, and <c>UWavePart.BeforeSave</c> builds paths relative to it, so
+        /// serializing one dies inside <c>Path.GetRelativePath</c> with a null-argument
+        /// exception that tells the user nothing. That case is reported here instead, in the
+        /// same shape as the renderer's friendly errors.
+        /// </summary>
+        public static string Serialize(Ustx.UProject project) {
+            if (string.IsNullOrEmpty(project.FilePath)) {
+                throw new MessageCustomizableException(
+                    "The project has not been saved. Save it before connecting a DAW plugin.",
+                    "<translate:dawintegration.unsavedproject>", new InvalidOperationException(), false);
+            }
+            project.ustxVersion = Format.Ustx.kUstxVersion;
+            project.BeforeSave();
+            try {
+                return Yaml.DefaultSerializer.Serialize(project);
+            } finally {
+                project.AfterSave();
+            }
+        }
+    }
+
+    /// <summary>Payload for kinds that carry no fields: <c>ping</c> and <c>playbackStarted</c>.</summary>
+    public class DawEmptyPayload {
+        public static readonly DawEmptyPayload Instance = new DawEmptyPayload();
+    }
+
+    /// <summary>
+    /// <c>init</c> request payload (PROTOCOL.md §6.1): the full-project baseline, pushed once
+    /// per connection. OpenUtau is the sole owner of the project, so the baseline only ever
+    /// travels outward and is never echoed back.
+    /// </summary>
+    public class InitRequest {
+        [JsonPropertyName("ustx")] public string Ustx { get; set; } = string.Empty;
+    }
+
+    /// <summary><c>init</c> response data: the plugin's protocol version, for the §4 major check.</summary>
+    public class InitResponse {
+        [JsonPropertyName("apiVersion")] public string ApiVersion { get; set; } = DawApiVersion.CurrentString;
+    }
+
+    /// <summary><c>updateUstx</c> notification payload (PROTOCOL.md §6.1).</summary>
+    public class UpdateUstxNotification {
+        [JsonPropertyName("ustx")] public string Ustx { get; set; } = string.Empty;
+    }
+
+    /// <summary>One entry of <c>updatePartLayout</c>. <see cref="AudioHash"/> is a decimal XXH64 string.</summary>
+    public class DawPartLayout {
+        [JsonPropertyName("trackNo")] public int TrackNo { get; set; }
+        [JsonPropertyName("startMs")] public double StartMs { get; set; }
+        [JsonPropertyName("endMs")] public double EndMs { get; set; }
+        [JsonPropertyName("audioHash")] public string AudioHash { get; set; } = string.Empty;
+    }
+
+    /// <summary><c>updatePartLayout</c> request payload (PROTOCOL.md §6.1).</summary>
+    public class UpdatePartLayoutRequest {
+        [JsonPropertyName("parts")] public List<DawPartLayout> Parts { get; set; } = new List<DawPartLayout>();
+    }
+
+    /// <summary><c>updatePartLayout</c> response data: hashes the plugin does not hold yet.</summary>
+    public class UpdatePartLayoutResponse {
+        [JsonPropertyName("missingAudios")] public List<string> MissingAudios { get; set; } = new List<string>();
+    }
+
+    /// <summary><c>getAudio</c> request payload. The response is a data-plane frame, not an envelope.</summary>
+    public class GetAudioRequest {
+        [JsonPropertyName("hash")] public string Hash { get; set; } = string.Empty;
+    }
+
+    /// <summary>One entry of <c>updateTracks</c>, in OpenUtau's internal scale (<c>UTrack.Volume</c> dB, <c>UTrack.Pan</c>).</summary>
+    public class DawTrackInfo {
+        [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("volume")] public double Volume { get; set; }
+        [JsonPropertyName("pan")] public double Pan { get; set; }
+
+        /// <summary>
+        /// The effective mute, i.e. <see cref="Ustx.UTrack.Muted"/> — mute with solo already
+        /// resolved against the rest of the project. Part audio travels pre-fader, so without
+        /// this the plugin has no way to reproduce a mute or a solo.
+        /// </summary>
+        [JsonPropertyName("muted")] public bool Muted { get; set; }
+
+        /// <summary>
+        /// v1.2: the track's singer display name (<see cref="Ustx.UTrack.Singer"/>), or the
+        /// empty string when the track has none yet. Informational — the plugin's GUI shows
+        /// it next to the track name; it does not affect the audio.
+        /// </summary>
+        [JsonPropertyName("singer")] public string Singer { get; set; } = string.Empty;
+
+        /// <summary>
+        /// v1.2: the track's render engine key (<see cref="Ustx.URenderSettings.renderer"/>,
+        /// e.g. CLASSIC, WORLDLINE-R, DIFFSINGER), or the empty string when the track has no
+        /// usable singer/renderer yet. Informational only.
+        /// </summary>
+        [JsonPropertyName("engine")] public string Engine { get; set; } = string.Empty;
+    }
+
+    /// <summary><c>updateTracks</c> notification payload (PROTOCOL.md §6.1).</summary>
+    public class UpdateTracksNotification {
+        [JsonPropertyName("tracks")] public List<DawTrackInfo> Tracks { get; set; } = new List<DawTrackInfo>();
+    }
+
+    /// <summary>
+    /// <c>updateProjectInfo</c> notification payload (v1.1): what a plugin's info window shows
+    /// about the project. The name is the file stem; an unsaved project reports
+    /// <see cref="Saved"/> false and an empty name.
+    /// </summary>
+    public class UpdateProjectInfoNotification {
+        [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("saved")] public bool Saved { get; set; }
+    }
+
+    /// <summary>
+    /// <c>playhead</c> notification payload (v1.1): the DAW's transport position, one-way
+    /// towards OpenUtau. <see cref="PositionMs"/> is absolute milliseconds on the shared
+    /// timeline — the same coordinate <see cref="DawPartLayout.StartMs"/> uses.
+    /// </summary>
+    public class PlayheadNotification {
+        [JsonPropertyName("positionMs")] public double PositionMs { get; set; }
+        [JsonPropertyName("playing")] public bool Playing { get; set; }
+    }
+
+    /// <summary><c>bpm</c> notification payload (v1.1): the DAW project's tempo.</summary>
+    public class BpmNotification {
+        [JsonPropertyName("bpm")] public double Bpm { get; set; }
+    }
+}

--- a/OpenUtau.Core/DawIntegration/DawServerFinder.cs
+++ b/OpenUtau.Core/DawIntegration/DawServerFinder.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Serilog;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>Discovery file contents (PROTOCOL.md §4).</summary>
+    public class DawServerInfo {
+        [JsonPropertyName("port")] public int Port { get; set; }
+        [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("apiVersion")] public string ApiVersion { get; set; } = string.Empty;
+    }
+
+    /// <summary>A discovered plugin instance: its advertisement plus the version verdict.</summary>
+    public class DawServer {
+        public string FilePath { get; }
+        public DawServerInfo Info { get; }
+
+        /// <summary>Parsed <c>apiVersion</c>. Default when the field was missing or unparseable.</summary>
+        public DawApiVersion Version { get; }
+
+        /// <summary>False when <c>apiVersion</c> is unreadable or its major differs (§4).</summary>
+        public bool IsCompatible { get; }
+
+        public int Port => Info.Port;
+        public string Name => string.IsNullOrWhiteSpace(Info.Name) ? Path.GetFileNameWithoutExtension(FilePath) : Info.Name;
+
+        public DawServer(string filePath, DawServerInfo info) {
+            FilePath = filePath;
+            Info = info;
+            bool parsed = DawApiVersion.TryParse(info.ApiVersion, out var version);
+            Version = version;
+            IsCompatible = parsed && version.IsCompatibleWith(DawApiVersion.Current);
+        }
+
+        public override string ToString() => $"{Name} (port {Port}, api {Info.ApiVersion})";
+    }
+
+    /// <summary>
+    /// Finds plugin servers through the discovery directory, drops stale advertisements and
+    /// reports version compatibility (PROTOCOL.md §4). The directory is injectable so tests
+    /// never touch the real per-user temp path.
+    /// </summary>
+    public sealed class DawServerFinder {
+        /// <summary>The protocol path: <c>%TEMP%/OpenUtau/PluginServers</c>, per-user on every OS.</summary>
+        public static string DefaultDirectory => Path.Combine(Path.GetTempPath(), "OpenUtau", "PluginServers");
+
+        public static DawServerFinder Default { get; } = new DawServerFinder(DefaultDirectory);
+
+        public string Directory { get; }
+
+        public DawServerFinder(string directory) {
+            Directory = directory;
+        }
+
+        /// <summary>
+        /// Reads every advertisement in the directory. Files whose port no longer answers are
+        /// deleted when <paramref name="removeStale"/> is set, which is how the directory stays
+        /// clean after a DAW crash.
+        /// </summary>
+        public List<DawServer> Scan(bool removeStale = true) {
+            var servers = new List<DawServer>();
+            if (!System.IO.Directory.Exists(Directory)) {
+                return servers;
+            }
+            foreach (string path in System.IO.Directory.GetFiles(Directory, "*.json")) {
+                DawServerInfo? info;
+                try {
+                    info = JsonSerializer.Deserialize<DawServerInfo>(
+                        File.ReadAllText(path, Encoding.UTF8), DawJson.Options);
+                } catch (Exception e) {
+                    // A half-written file is normal if we scan while a plugin is starting.
+                    Log.Warning(e, $"DAW: unreadable discovery file '{path}', skipped.");
+                    continue;
+                }
+                if (info == null || info.Port <= 0 || info.Port > 65535) {
+                    Log.Warning($"DAW: discovery file '{path}' has no usable port, skipped.");
+                    continue;
+                }
+                if (!IsPortAlive(info.Port)) {
+                    Log.Information($"DAW: discovery file '{path}' is stale (port {info.Port} is free).");
+                    if (removeStale) {
+                        TryDelete(path);
+                    }
+                    continue;
+                }
+                servers.Add(new DawServer(path, info));
+            }
+            return servers;
+        }
+
+        /// <summary>
+        /// Liveness probe from §4: if we can bind the port ourselves, nothing is listening.
+        /// <see cref="Socket.ExclusiveAddressUse"/> must be set — without it Windows allows a
+        /// second bind through SO_REUSEADDR and every live server would look stale.
+        /// </summary>
+        public static bool IsPortAlive(int port) {
+            try {
+                using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                socket.ExclusiveAddressUse = true;
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, port));
+                return false;
+            } catch (SocketException) {
+                return true;
+            } catch (Exception e) {
+                // Unexpected failures must not delete a possibly-live advertisement.
+                Log.Warning(e, $"DAW: could not probe port {port}; assuming it is alive.");
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Writes an advertisement. Production plugins publish their own file; this exists for the
+        /// conformance harness and tests, which play the plugin side.
+        /// </summary>
+        public string Publish(string name, int port, string apiVersion = DawApiVersion.CurrentString) {
+            System.IO.Directory.CreateDirectory(Directory);
+            string path = Path.Combine(Directory, name + ".json");
+            var info = new DawServerInfo { Port = port, Name = name, ApiVersion = apiVersion };
+            File.WriteAllText(path, DawJson.Serialize(info), Encoding.UTF8);
+            return path;
+        }
+
+        public void Remove(string path) => TryDelete(path);
+
+        private static void TryDelete(string path) {
+            try {
+                File.Delete(path);
+            } catch (Exception e) {
+                Log.Warning(e, $"DAW: could not delete discovery file '{path}'.");
+            }
+        }
+    }
+}

--- a/OpenUtau.Core/DawIntegration/DawServerFinder.cs
+++ b/OpenUtau.Core/DawIntegration/DawServerFinder.cs
@@ -46,8 +46,15 @@ namespace OpenUtau.Core.DawIntegration {
     /// reports version compatibility (PROTOCOL.md §4). The directory is injectable so tests
     /// never touch the real per-user temp path.
     /// </summary>
+    /// <remarks>
+    /// Trust boundary (§11): on Windows <c>%TEMP%</c> is already private to the user. On Unix a
+    /// shared <c>TMPDIR</c> would let another local user plant an advertisement whose port they
+    /// listen on, so the directory is tightened to owner-only permissions before scanning or
+    /// publishing; a directory this user does not own is refused outright.
+    /// </remarks>
     public sealed class DawServerFinder {
-        /// <summary>The protocol path: <c>%TEMP%/OpenUtau/PluginServers</c>, per-user on every OS.</summary>
+        /// <summary>The protocol path: <c>%TEMP%/OpenUtau/PluginServers</c>, per-user on Windows
+        /// and macOS; on Unix the owner-only enforcement below closes the shared-<c>TMPDIR</c> case.</summary>
         public static string DefaultDirectory => Path.Combine(Path.GetTempPath(), "OpenUtau", "PluginServers");
 
         public static DawServerFinder Default { get; } = new DawServerFinder(DefaultDirectory);
@@ -66,6 +73,9 @@ namespace OpenUtau.Core.DawIntegration {
         public List<DawServer> Scan(bool removeStale = true) {
             var servers = new List<DawServer>();
             if (!System.IO.Directory.Exists(Directory)) {
+                return servers;
+            }
+            if (!EnsureOwnerPrivateDirectory()) {
                 return servers;
             }
             foreach (string path in System.IO.Directory.GetFiles(Directory, "*.json")) {
@@ -118,15 +128,51 @@ namespace OpenUtau.Core.DawIntegration {
         /// Writes an advertisement. Production plugins publish their own file; this exists for the
         /// conformance harness and tests, which play the plugin side.
         /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The discovery directory is not owner-private and could not be tightened (Unix).
+        /// </exception>
         public string Publish(string name, int port, string apiVersion = DawApiVersion.CurrentString) {
             System.IO.Directory.CreateDirectory(Directory);
+            if (!EnsureOwnerPrivateDirectory()) {
+                throw new InvalidOperationException(
+                    $"Discovery directory '{Directory}' is not user-private; refusing to publish.");
+            }
             string path = Path.Combine(Directory, name + ".json");
             var info = new DawServerInfo { Port = port, Name = name, ApiVersion = apiVersion };
             File.WriteAllText(path, DawJson.Serialize(info), Encoding.UTF8);
+            if (!OperatingSystem.IsWindows()) {
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
             return path;
         }
 
         public void Remove(string path) => TryDelete(path);
+
+        /// <summary>
+        /// Tightens the discovery directory to owner-only (mode 0700) on Unix. False when the
+        /// directory is shared and not ours — its contents were not placed by this user, so
+        /// neither scanning nor publishing may trust them.
+        /// </summary>
+        private bool EnsureOwnerPrivateDirectory() {
+            if (OperatingSystem.IsWindows()) {
+                return true;
+            }
+            try {
+                var mode = File.GetUnixFileMode(Directory);
+                const UnixFileMode shared =
+                    UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+                if ((mode & shared) != 0) {
+                    File.SetUnixFileMode(Directory, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+                }
+                return true;
+            } catch (Exception e) {
+                Log.Warning(e,
+                    $"DAW: discovery directory '{Directory}' is not user-private and could not be " +
+                    $"tightened; refusing to touch it (§11).");
+                return false;
+            }
+        }
 
         private static void TryDelete(string path) {
             try {

--- a/OpenUtau.Core/DawIntegration/DawTransport.cs
+++ b/OpenUtau.Core/DawIntegration/DawTransport.cs
@@ -1,0 +1,544 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>Why a <see cref="DawTransport"/> stopped. Drives the reconnect decision (PROTOCOL.md §8).</summary>
+    public enum DawDisconnectReason {
+        /// <summary>The plugin sent a bare <c>close</c>.</summary>
+        PluginClosed,
+        /// <summary>Nothing arrived within the heartbeat dead threshold.</summary>
+        HeartbeatTimeout,
+        /// <summary>Framing violation. Never retried without a fresh handshake.</summary>
+        ProtocolError,
+        /// <summary>Socket ended or faulted.</summary>
+        StreamClosed,
+        /// <summary>We asked to close.</summary>
+        LocalClose,
+    }
+
+    /// <summary>Tunable protocol timings. Defaults are the PROTOCOL.md §3 values; tests shorten them.</summary>
+    public sealed class DawTransportOptions {
+        public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(10);
+        public TimeSpan HeartbeatPollInterval { get; init; } = TimeSpan.FromSeconds(2);
+        public TimeSpan HeartbeatDeadThreshold { get; init; } = TimeSpan.FromSeconds(15);
+        public static DawTransportOptions Default { get; } = new DawTransportOptions();
+    }
+
+    /// <summary>
+    /// Reads the two planes off one socket: LF-terminated UTF-8 control lines and
+    /// exact-length binary payloads, sharing a single buffer so a data frame that is
+    /// partially buffered behind its header is not lost (PROTOCOL.md §5).
+    /// </summary>
+    internal sealed class DawFrameReader {
+        /// <summary>Guards against a peer that never sends a newline. USTX lines are legitimately multi-MB.</summary>
+        private const int MaxLineBytes = 256 * 1024 * 1024;
+
+        private readonly Stream stream;
+        private byte[] buffer = new byte[16 * 1024];
+        private int start;
+        private int end;
+
+        public DawFrameReader(Stream stream) {
+            this.stream = stream;
+        }
+
+        /// <summary>Returns the next control line, or null at a clean end of stream.</summary>
+        public async Task<string?> ReadLineAsync(CancellationToken cancellation) {
+            while (true) {
+                int newline = Array.IndexOf(buffer, (byte)'\n', start, end - start);
+                if (newline >= 0) {
+                    int length = newline - start;
+                    // Tolerate CRLF from hand-written or Windows-side test peers.
+                    if (length > 0 && buffer[start + length - 1] == (byte)'\r') {
+                        length--;
+                    }
+                    var line = Encoding.UTF8.GetString(buffer, start, length);
+                    start = newline + 1;
+                    return line;
+                }
+                if (end - start >= MaxLineBytes) {
+                    throw new DawProtocolException($"Control line exceeded {MaxLineBytes} bytes without a newline.");
+                }
+                if (!await FillAsync(cancellation)) {
+                    if (end > start) {
+                        throw new DawProtocolException($"Stream ended mid-line with {end - start} bytes buffered.");
+                    }
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>Reads exactly <paramref name="count"/> bytes of a data-plane payload.</summary>
+        public async Task<byte[]> ReadExactlyAsync(int count, CancellationToken cancellation) {
+            var result = new byte[count];
+            int copied = 0;
+            while (copied < count) {
+                int available = Math.Min(end - start, count - copied);
+                if (available > 0) {
+                    Buffer.BlockCopy(buffer, start, result, copied, available);
+                    start += available;
+                    copied += available;
+                    continue;
+                }
+                if (!await FillAsync(cancellation)) {
+                    throw new DawProtocolException(
+                        $"Stream ended after {copied} of {count} payload bytes.");
+                }
+            }
+            return result;
+        }
+
+        private async Task<bool> FillAsync(CancellationToken cancellation) {
+            if (start == end) {
+                start = 0;
+                end = 0;
+            } else if (end == buffer.Length) {
+                if (start > 0) {
+                    Buffer.BlockCopy(buffer, start, buffer, 0, end - start);
+                    end -= start;
+                    start = 0;
+                } else {
+                    Array.Resize(ref buffer, buffer.Length * 2);
+                }
+            }
+            int read = await stream.ReadAsync(buffer.AsMemory(end, buffer.Length - end), cancellation);
+            if (read <= 0) {
+                return false;
+            }
+            end += read;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// An inbound <c>request:&lt;uuid&gt;:&lt;kind&gt;</c>. Exactly one of the respond methods must be
+    /// called: <c>getAudio</c> answers with a data-plane frame, every other kind with an envelope
+    /// (PROTOCOL.md §5.1, §6.1).
+    /// </summary>
+    public sealed class DawInboundRequest {
+        private readonly DawTransport transport;
+        private int answered;
+
+        public string Uuid { get; }
+        public string Kind { get; }
+        public JsonElement? Payload { get; }
+
+        internal DawInboundRequest(DawTransport transport, string uuid, string kind, JsonElement? payload) {
+            this.transport = transport;
+            Uuid = uuid;
+            Kind = kind;
+            Payload = payload;
+        }
+
+        internal bool IsAnswered => Volatile.Read(ref answered) != 0;
+
+        public Task RespondAsync(DawResult result, CancellationToken cancellation = default) {
+            Claim();
+            return transport.SendLineAsync($"response:{Uuid} {DawJson.Serialize(result)}", cancellation);
+        }
+
+        /// <summary>Answers with the binary frame that <c>getAudio</c> expects instead of an envelope.</summary>
+        public Task RespondWithAudioAsync(string hash, byte[] pcm, CancellationToken cancellation = default) {
+            Claim();
+            return transport.SendAudioFrameAsync(hash, pcm, cancellation);
+        }
+
+        public T ReadPayload<T>() {
+            if (Payload == null) {
+                throw new DawProtocolException($"Request '{Kind}' carried no payload.");
+            }
+            return Payload.Value.Deserialize<T>(DawJson.Options)
+                ?? throw new DawProtocolException($"Request '{Kind}' payload could not be read as {typeof(T).Name}.");
+        }
+
+        private void Claim() {
+            if (Interlocked.Exchange(ref answered, 1) != 0) {
+                throw new InvalidOperationException($"Request {Uuid} ({Kind}) was already answered.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// One plugin connection: read loop, request correlation, write mutex and heartbeat
+    /// liveness (PROTOCOL.md §3, §5). Symmetric on purpose — both OpenUtau and a test peer
+    /// playing the plugin drive the same class, so the framing can only be implemented once.
+    /// </summary>
+    public sealed class DawTransport : IDisposable {
+        /// <summary>Every inbound notification, including kinds this version does not know (§5.1).</summary>
+        public event Action<string, JsonElement?>? Notification;
+
+        /// <summary>Raised once when the connection ends, whatever the cause.</summary>
+        public event Action<DawDisconnectReason, string>? Disconnected;
+
+        /// <summary>Serves inbound requests. Unset means every request is refused with a failed envelope.</summary>
+        public Func<DawInboundRequest, Task>? RequestHandler { get; set; }
+
+        public DawTransportOptions Options { get; }
+        public bool IsConnected => Volatile.Read(ref stopped) == 0;
+
+        private readonly TcpClient client;
+        private readonly Stream stream;
+        private readonly DawFrameReader reader;
+        private readonly SemaphoreSlim writeLock = new SemaphoreSlim(1, 1);
+        private readonly ConcurrentDictionary<string, TaskCompletionSource<DawResult>> pendingRequests
+            = new ConcurrentDictionary<string, TaskCompletionSource<DawResult>>();
+        private readonly ConcurrentDictionary<string, TaskCompletionSource<byte[]>> pendingAudio
+            = new ConcurrentDictionary<string, TaskCompletionSource<byte[]>>();
+        private readonly CancellationTokenSource shutdown = new CancellationTokenSource();
+        private readonly Func<DateTime> nowUtc;
+        private long lastMessageUtcTicks;
+        private int stopped;
+        private int disposed;
+
+        private DawTransport(TcpClient client, DawTransportOptions options, Func<DateTime>? nowUtc) {
+            this.client = client;
+            this.nowUtc = nowUtc ?? (() => DateTime.UtcNow);
+            Options = options;
+            stream = client.GetStream();
+            reader = new DawFrameReader(stream);
+            lastMessageUtcTicks = this.nowUtc().Ticks;
+        }
+
+        /// <summary>Connects to a plugin listening on loopback and starts the read + heartbeat loops.</summary>
+        public static async Task<DawTransport> ConnectAsync(
+            int port,
+            DawTransportOptions? options = null,
+            Func<DateTime>? nowUtc = null,
+            CancellationToken cancellation = default) {
+            var client = new TcpClient();
+            try {
+                client.NoDelay = true;
+                await client.ConnectAsync(IPAddress.Loopback, port, cancellation);
+            } catch {
+                client.Dispose();
+                throw;
+            }
+            return Adopt(client, options, nowUtc);
+        }
+
+        /// <summary>Wraps an already-accepted socket. Used by the peer side in tests and conformance tooling.</summary>
+        public static DawTransport Adopt(
+            TcpClient client,
+            DawTransportOptions? options = null,
+            Func<DateTime>? nowUtc = null) {
+            client.NoDelay = true;
+            var transport = new DawTransport(client, options ?? DawTransportOptions.Default, nowUtc);
+            transport.Start();
+            return transport;
+        }
+
+        private void Start() {
+            _ = Task.Run(() => ReadLoopAsync(shutdown.Token));
+            _ = Task.Run(() => HeartbeatLoopAsync(shutdown.Token));
+        }
+
+        private async Task ReadLoopAsync(CancellationToken cancellation) {
+            try {
+                while (!cancellation.IsCancellationRequested) {
+                    string? line = await reader.ReadLineAsync(cancellation);
+                    if (line == null) {
+                        Stop(DawDisconnectReason.StreamClosed, "Peer closed the socket.");
+                        return;
+                    }
+                    Volatile.Write(ref lastMessageUtcTicks, nowUtc().Ticks);
+                    if (DawAudio.IsFrameHeader(line)) {
+                        await ReadAudioFrameAsync(line, cancellation);
+                    } else {
+                        DispatchControl(line);
+                    }
+                }
+            } catch (OperationCanceledException) {
+                // Local shutdown.
+            } catch (DawProtocolException e) {
+                Stop(DawDisconnectReason.ProtocolError, e.Message);
+            } catch (Exception e) {
+                Stop(DawDisconnectReason.StreamClosed, e.Message);
+            }
+        }
+
+        private async Task ReadAudioFrameAsync(string header, CancellationToken cancellation) {
+            if (!DawAudio.TryParseFrameHeader(header, out string hash, out int length)) {
+                throw new DawProtocolException($"Malformed audio frame header: '{header}'.");
+            }
+            // A short read here is unrecoverable: the stream position is lost (§8).
+            byte[] payload = await reader.ReadExactlyAsync(length, cancellation);
+            if (pendingAudio.TryRemove(hash, out var waiter)) {
+                waiter.TrySetResult(payload);
+                return;
+            }
+            Log.Warning($"DAW: unsolicited audio frame for hash {hash} ({payload.Length} bytes), dropped.");
+        }
+
+        private void DispatchControl(string line) {
+            if (line == "close") {
+                Stop(DawDisconnectReason.PluginClosed, "Peer sent close.");
+                return;
+            }
+            int space = line.IndexOf(' ');
+            string header = space < 0 ? line : line.Substring(0, space);
+            string payload = space < 0 ? string.Empty : line.Substring(space + 1);
+            if (header.StartsWith("response:", StringComparison.Ordinal)) {
+                CompleteResponse(header.Substring("response:".Length), payload);
+            } else if (header.StartsWith("notification:", StringComparison.Ordinal)) {
+                RaiseNotification(header.Substring("notification:".Length), payload);
+            } else if (header.StartsWith("request:", StringComparison.Ordinal)) {
+                _ = ServeRequestAsync(header, payload);
+            } else {
+                // Malformed control lines are logged and survived, never fatal (§8).
+                Log.Warning($"DAW: unrecognized control header '{header}', ignored.");
+            }
+        }
+
+        private void CompleteResponse(string uuid, string payload) {
+            if (!pendingRequests.TryRemove(uuid, out var waiter)) {
+                Log.Warning($"DAW: response for unknown request {uuid}, ignored.");
+                return;
+            }
+            try {
+                var result = JsonSerializer.Deserialize<DawResult>(payload, DawJson.Options);
+                if (result == null) {
+                    throw new DawProtocolException($"Empty response envelope for request {uuid}.");
+                }
+                waiter.TrySetResult(result);
+            } catch (JsonException e) {
+                waiter.TrySetException(new DawProtocolException($"Malformed response envelope for request {uuid}.", e));
+            }
+        }
+
+        private void RaiseNotification(string kind, string payload) {
+            var data = TryParsePayload(kind, payload);
+            try {
+                Notification?.Invoke(kind, data);
+            } catch (Exception e) {
+                Log.Error(e, $"DAW: handler for notification:{kind} threw.");
+            }
+        }
+
+        private async Task ServeRequestAsync(string header, string payload) {
+            // request:<uuid>:<kind> — the kind may itself contain ':', so split only twice.
+            var parts = header.Split(':', 3);
+            if (parts.Length < 3 || parts[1].Length == 0 || parts[2].Length == 0) {
+                Log.Warning($"DAW: malformed request header '{header}', ignored.");
+                return;
+            }
+            var request = new DawInboundRequest(this, parts[1], parts[2], TryParsePayload(parts[2], payload));
+            try {
+                if (RequestHandler == null) {
+                    await request.RespondAsync(DawResult.Fail($"Unsupported request kind: {request.Kind}"));
+                    return;
+                }
+                await RequestHandler(request);
+                if (!request.IsAnswered) {
+                    // A handler that returns without answering would hang the peer until its timeout.
+                    await request.RespondAsync(DawResult.Fail($"Request '{request.Kind}' produced no response."));
+                }
+            } catch (Exception e) {
+                Log.Error(e, $"DAW: serving request '{request.Kind}' failed.");
+                if (!request.IsAnswered) {
+                    try {
+                        await request.RespondAsync(DawResult.Fail(e.Message));
+                    } catch (Exception sendError) {
+                        Log.Warning(sendError, $"DAW: could not report failure of '{request.Kind}'.");
+                    }
+                }
+            }
+        }
+
+        private static JsonElement? TryParsePayload(string kind, string payload) {
+            if (string.IsNullOrWhiteSpace(payload)) {
+                return null;
+            }
+            try {
+                using var document = JsonDocument.Parse(payload);
+                return document.RootElement.Clone();
+            } catch (JsonException e) {
+                Log.Warning(e, $"DAW: malformed JSON payload on '{kind}', treated as empty.");
+                return null;
+            }
+        }
+
+        private async Task HeartbeatLoopAsync(CancellationToken cancellation) {
+            try {
+                while (!cancellation.IsCancellationRequested) {
+                    await Task.Delay(Options.HeartbeatPollInterval, cancellation);
+                    var last = new DateTime(Volatile.Read(ref lastMessageUtcTicks), DateTimeKind.Utc);
+                    var silence = nowUtc() - last;
+                    if (silence >= Options.HeartbeatDeadThreshold) {
+                        Stop(DawDisconnectReason.HeartbeatTimeout,
+                            $"No message from peer for {silence.TotalSeconds:F1}s.");
+                        return;
+                    }
+                }
+            } catch (OperationCanceledException) {
+                // Local shutdown.
+            }
+        }
+
+        /// <summary>Sends a request and awaits its envelope. A timeout means the connection is dead (§8).</summary>
+        public async Task<DawResult> SendRequestAsync(
+            string kind,
+            object payload,
+            TimeSpan? timeout = null,
+            CancellationToken cancellation = default) {
+            string uuid = Guid.NewGuid().ToString();
+            var waiter = new TaskCompletionSource<DawResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            pendingRequests[uuid] = waiter;
+            try {
+                await SendLineAsync($"request:{uuid}:{kind} {DawJson.Serialize(payload)}", cancellation);
+                return await AwaitAsync(waiter.Task, timeout ?? Options.RequestTimeout, $"{kind} request", cancellation);
+            } finally {
+                pendingRequests.TryRemove(uuid, out _);
+            }
+        }
+
+        /// <summary>Sends a request and unwraps its <c>data</c> payload, throwing on a failed envelope.</summary>
+        public async Task<T> SendRequestAsync<T>(
+            string kind,
+            object payload,
+            TimeSpan? timeout = null,
+            CancellationToken cancellation = default) {
+            var result = await SendRequestAsync(kind, payload, timeout, cancellation);
+            return result.Unwrap<T>();
+        }
+
+        public Task SendNotificationAsync(string kind, object payload, CancellationToken cancellation = default) {
+            return SendLineAsync($"notification:{kind} {DawJson.Serialize(payload)}", cancellation);
+        }
+
+        /// <summary>
+        /// Pulls one audio payload by hash. The reply is a data-plane frame, so it is correlated
+        /// by hash rather than uuid; a failed envelope on the same uuid also completes the wait,
+        /// so a refusing peer costs nothing instead of a full timeout.
+        /// </summary>
+        public async Task<byte[]> GetAudioAsync(
+            string hash,
+            TimeSpan? timeout = null,
+            CancellationToken cancellation = default) {
+            string uuid = Guid.NewGuid().ToString();
+            var frame = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var envelope = new TaskCompletionSource<DawResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!pendingAudio.TryAdd(hash, frame)) {
+                throw new InvalidOperationException($"An audio pull for hash {hash} is already outstanding.");
+            }
+            pendingRequests[uuid] = envelope;
+            try {
+                var request = new GetAudioRequest { Hash = hash };
+                await SendLineAsync(
+                    $"request:{uuid}:{DawMessageKind.GetAudio} {DawJson.Serialize(request)}", cancellation);
+                var winner = await AwaitAsync(
+                    Task.WhenAny(frame.Task, envelope.Task), timeout ?? Options.RequestTimeout, "getAudio", cancellation);
+                if (winner == envelope.Task) {
+                    var result = await envelope.Task;
+                    throw new DawProtocolException(
+                        $"Peer refused getAudio for {hash}: {result.Error ?? "(no error given)"}");
+                }
+                return await frame.Task;
+            } finally {
+                pendingAudio.TryRemove(hash, out _);
+                pendingRequests.TryRemove(uuid, out _);
+            }
+        }
+
+        /// <summary>
+        /// Writes a data-plane frame: header line then exactly <c>pcm.Length</c> bytes, under the
+        /// same write mutex so no control line can interleave into the payload (§5.2).
+        /// </summary>
+        public async Task SendAudioFrameAsync(string hash, byte[] pcm, CancellationToken cancellation = default) {
+            var header = DawAudio.BuildFrameHeader(hash, pcm.Length);
+            var frame = new byte[header.Length + pcm.Length];
+            Buffer.BlockCopy(header, 0, frame, 0, header.Length);
+            Buffer.BlockCopy(pcm, 0, frame, header.Length, pcm.Length);
+            await WriteAsync(frame, cancellation);
+        }
+
+        /// <summary>User-initiated teardown: bare <c>close</c>, then stop (§5.1, §9).</summary>
+        public async Task CloseAsync() {
+            if (IsConnected) {
+                try {
+                    await SendLineAsync("close");
+                } catch (Exception e) {
+                    Log.Warning(e, "DAW: could not send close; tearing down anyway.");
+                }
+            }
+            Stop(DawDisconnectReason.LocalClose, "Closed locally.");
+        }
+
+        internal Task SendLineAsync(string line, CancellationToken cancellation = default) {
+            return WriteAsync(Encoding.UTF8.GetBytes(line + "\n"), cancellation);
+        }
+
+        private async Task WriteAsync(byte[] bytes, CancellationToken cancellation) {
+            if (!IsConnected) {
+                throw new DawProtocolException("Connection is closed.");
+            }
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellation, shutdown.Token);
+            await writeLock.WaitAsync(linked.Token);
+            try {
+                await stream.WriteAsync(bytes, linked.Token);
+                await stream.FlushAsync(linked.Token);
+            } finally {
+                writeLock.Release();
+            }
+        }
+
+        private async Task<T> AwaitAsync<T>(Task<T> task, TimeSpan timeout, string what, CancellationToken cancellation) {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellation, shutdown.Token);
+            try {
+                return await task.WaitAsync(timeout, linked.Token);
+            } catch (TimeoutException) {
+                throw new TimeoutException($"{what} timed out after {timeout.TotalSeconds:F1}s.");
+            } catch (OperationCanceledException) when (shutdown.IsCancellationRequested && !cancellation.IsCancellationRequested) {
+                throw new DawProtocolException($"Connection closed while waiting for {what}.");
+            }
+        }
+
+        /// <summary>Ends the connection once and fails every outstanding wait so no caller hangs.</summary>
+        private void Stop(DawDisconnectReason reason, string detail) {
+            if (Interlocked.Exchange(ref stopped, 1) != 0) {
+                return;
+            }
+            Log.Information($"DAW: disconnected ({reason}): {detail}");
+            shutdown.Cancel();
+            var error = new DawProtocolException($"Connection ended ({reason}): {detail}");
+            foreach (var uuid in pendingRequests.Keys) {
+                if (pendingRequests.TryRemove(uuid, out var waiter)) {
+                    waiter.TrySetException(error);
+                }
+            }
+            foreach (var hash in pendingAudio.Keys) {
+                if (pendingAudio.TryRemove(hash, out var waiter)) {
+                    waiter.TrySetException(error);
+                }
+            }
+            try {
+                client.Close();
+            } catch (Exception e) {
+                Log.Warning(e, "DAW: closing the socket failed.");
+            }
+            try {
+                Disconnected?.Invoke(reason, detail);
+            } catch (Exception e) {
+                Log.Error(e, "DAW: Disconnected handler threw.");
+            }
+        }
+
+        public void Dispose() {
+            if (Interlocked.Exchange(ref disposed, 1) != 0) {
+                return;
+            }
+            Stop(DawDisconnectReason.LocalClose, "Disposed.");
+            shutdown.Dispose();
+            writeLock.Dispose();
+            client.Dispose();
+        }
+    }
+}

--- a/OpenUtau.Core/DawIntegration/DawTransport.cs
+++ b/OpenUtau.Core/DawIntegration/DawTransport.cs
@@ -19,6 +19,8 @@ namespace OpenUtau.Core.DawIntegration {
         HeartbeatTimeout,
         /// <summary>Framing violation. Never retried without a fresh handshake.</summary>
         ProtocolError,
+        /// <summary>A control request outlived its timeout budget, so the peer is wedged (§8).</summary>
+        RequestTimeout,
         /// <summary>Socket ended or faulted.</summary>
         StreamClosed,
         /// <summary>We asked to close.</summary>
@@ -271,6 +273,12 @@ namespace OpenUtau.Core.DawIntegration {
             }
             // A short read here is unrecoverable: the stream position is lost (§8).
             byte[] payload = await reader.ReadExactlyAsync(length, cancellation);
+            // §5.2: the header names the hash of the payload that follows. A peer that labels
+            // unrelated bytes with the requested hash would otherwise be served as a cache hit,
+            // so the payload is verified before any waiter is completed.
+            if (!string.Equals(DawAudio.FormatHash(DawAudio.Hash(payload)), hash, StringComparison.Ordinal)) {
+                throw new DawProtocolException($"Audio payload does not match its declared hash {hash}.");
+            }
             if (pendingAudio.TryRemove(hash, out var waiter)) {
                 waiter.TrySetResult(payload);
                 return;
@@ -450,14 +458,29 @@ namespace OpenUtau.Core.DawIntegration {
 
         /// <summary>
         /// Writes a data-plane frame: header line then exactly <c>pcm.Length</c> bytes, under the
-        /// same write mutex so no control line can interleave into the payload (§5.2).
+        /// same write mutex so no control line can interleave into the payload (§5.2). The two
+        /// writes are separate: copying header and payload into one buffer would double the peak
+        /// memory of a legal 256 MiB frame.
         /// </summary>
+        /// <exception cref="DawProtocolException">The payload exceeds the data-plane bound (§6.1).</exception>
         public async Task SendAudioFrameAsync(string hash, byte[] pcm, CancellationToken cancellation = default) {
+            if (pcm.Length > DawAudio.MaxFrameBytes) {
+                throw new DawProtocolException(
+                    $"Audio frame of {pcm.Length} bytes exceeds the {DawAudio.MaxFrameBytes}-byte data-plane bound.");
+            }
             var header = DawAudio.BuildFrameHeader(hash, pcm.Length);
-            var frame = new byte[header.Length + pcm.Length];
-            Buffer.BlockCopy(header, 0, frame, 0, header.Length);
-            Buffer.BlockCopy(pcm, 0, frame, header.Length, pcm.Length);
-            await WriteAsync(frame, cancellation);
+            if (!IsConnected) {
+                throw new DawProtocolException("Connection is closed.");
+            }
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellation, shutdown.Token);
+            await writeLock.WaitAsync(linked.Token);
+            try {
+                await stream.WriteAsync(header, linked.Token);
+                await stream.WriteAsync(pcm, linked.Token);
+                await stream.FlushAsync(linked.Token);
+            } finally {
+                writeLock.Release();
+            }
         }
 
         /// <summary>User-initiated teardown: bare <c>close</c>, then stop (§5.1, §9).</summary>
@@ -495,6 +518,10 @@ namespace OpenUtau.Core.DawIntegration {
             try {
                 return await task.WaitAsync(timeout, linked.Token);
             } catch (TimeoutException) {
+                // §8: a peer that never answers is wedged — it can keep pinging forever without
+                // ever answering a request. Stop the transport so the heartbeat cannot mask the
+                // wedge and reconnect handling starts now, then report the timeout to the caller.
+                Stop(DawDisconnectReason.RequestTimeout, $"{what} timed out after {timeout.TotalSeconds:F1}s.");
                 throw new TimeoutException($"{what} timed out after {timeout.TotalSeconds:F1}s.");
             } catch (OperationCanceledException) when (shutdown.IsCancellationRequested && !cancellation.IsCancellationRequested) {
                 throw new DawProtocolException($"Connection closed while waiting for {what}.");

--- a/OpenUtau.Test/Core/DawIntegration/DawAudioTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawAudioTest.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Linq;
+using OpenUtau.Core.SignalChain;
+using OpenUtau.Core.Ustx;
+using Xunit;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>Data-plane contract: index space, PCM encoding, hashing and frame headers (§5.2, §6.1).</summary>
+    [Collection(DawIntegrationCollection.Name)]
+    public class DawAudioTest {
+        /// <summary>Writes each slot's absolute sample index, so any extracted window describes itself.</summary>
+        private sealed class RampSource : ISignalSource {
+            public bool Ready = true;
+
+            public bool IsReady(int position, int count) => Ready;
+
+            public int Mix(int position, float[] buffer, int index, int count) {
+                for (int i = 0; i < count; i++) {
+                    buffer[index + i] += position + i;
+                }
+                return position + count;
+            }
+        }
+
+        private static UProject NewProject() {
+            // Defaults are 4/4 at 120 bpm with 480 ticks per beat, so 480 ticks is exactly 500 ms.
+            var project = new UProject();
+            project.timeAxis.BuildSegments(project);
+            return project;
+        }
+
+        [Fact]
+        public void EngineFormatIsFixed() {
+            // PROTOCOL.md §1: never negotiated, mirrors PlaybackManager.
+            Assert.Equal(44100, DawAudio.SampleRate);
+            Assert.Equal(2, DawAudio.Channels);
+        }
+
+        [Fact]
+        public void MsMapsToInterleavedStereoIndex() {
+            Assert.Equal(0, DawAudio.MsToInterleavedIndex(0));
+            Assert.Equal(0, DawAudio.MsToInterleavedIndex(-25));
+            Assert.Equal(88200, DawAudio.MsToInterleavedIndex(1000));
+            Assert.Equal(44100, DawAudio.MsToInterleavedIndex(500));
+        }
+
+        [Fact]
+        public void IndexIsAlwaysFrameAligned() {
+            // An odd index would put the left channel in the right channel's slot.
+            for (double ms = 0; ms < 5; ms += 0.017) {
+                Assert.Equal(0, DawAudio.MsToInterleavedIndex(ms) % DawAudio.Channels);
+            }
+        }
+
+        [Fact]
+        public void PcmRoundTrips() {
+            var samples = new[] { 0f, 1f, -1f, 0.5f, -0.25f, float.Epsilon };
+
+            byte[] pcm = DawAudio.ToPcmBytes(samples);
+
+            Assert.Equal(samples.Length * sizeof(float), pcm.Length);
+            Assert.Equal(samples, DawAudio.FromPcmBytes(pcm));
+        }
+
+        [Fact]
+        public void PartialFloatIsRejected() {
+            Assert.Throws<DawProtocolException>(() => DawAudio.FromPcmBytes(new byte[7]));
+        }
+
+        [Fact]
+        public void HashIsStableAndContentAddressed() {
+            byte[] one = DawAudio.ToPcmBytes(new[] { 1f, 2f, 3f });
+            byte[] same = DawAudio.ToPcmBytes(new[] { 1f, 2f, 3f });
+            byte[] other = DawAudio.ToPcmBytes(new[] { 1f, 2f, 4f });
+
+            Assert.Equal(DawAudio.Hash(one), DawAudio.Hash(same));
+            Assert.NotEqual(DawAudio.Hash(one), DawAudio.Hash(other));
+        }
+
+        [Fact]
+        public void HashMatchesTheReferenceVectorForEmptyInput() {
+            // Pins this side to standard XXH64 with seed 0 — the published vector, not something
+            // K4os.Hash.xxHash agrees with only because it computed both numbers. The plugin
+            // hashes with its own library; if either stops being the reference algorithm, every
+            // part looks missing forever and nothing else in the protocol reports it.
+            Assert.Equal(0xEF46DB3751D8E999UL, DawAudio.Hash(Array.Empty<byte>()));
+        }
+
+        [Fact]
+        public void SharedPcmVectorHashesToTheValueThePluginExpects() {
+            // Interleaved little-endian float32 is the wire encoding (§6.1), so the bytes are
+            // spelled out rather than round-tripped: this is the one assertion that would catch a
+            // big-endian or non-IEEE encoding, which no same-side round trip can.
+            byte[] pcm = DawAudio.ToPcmBytes(new[] { 1f, -1f, 0.5f });
+
+            Assert.Equal(new byte[] {
+                0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x80, 0xBF, 0x00, 0x00, 0x00, 0x3F,
+            }, pcm);
+            // The plugin's tests/test_hash.cpp asserts this same constant against its own XXH64.
+            // Two suites, two libraries, one number: neither repository can drift alone.
+            Assert.Equal(12033956788804169010UL, DawAudio.Hash(pcm));
+            Assert.Equal("12033956788804169010", DawAudio.FormatHash(DawAudio.Hash(pcm)));
+        }
+
+        [Fact]
+        public void HashSerializesAsDecimalStringBeyondDoublePrecision() {
+            // §5.2: a JSON number would round this; the wire format is a string for that reason.
+            string text = DawAudio.FormatHash(ulong.MaxValue);
+
+            Assert.Equal("18446744073709551615", text);
+            Assert.True(DawAudio.TryParseHash(text, out ulong parsed));
+            Assert.Equal(ulong.MaxValue, parsed);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("-1")]
+        [InlineData("0x1f")]
+        [InlineData(" 12")]
+        [InlineData("18446744073709551616")]
+        public void MalformedHashesAreRefused(string? text) {
+            Assert.False(DawAudio.TryParseHash(text, out _));
+        }
+
+        [Fact]
+        public void FrameHeaderRoundTrips() {
+            byte[] header = DawAudio.BuildFrameHeader("13507256038857166760", 4096);
+
+            string line = System.Text.Encoding.UTF8.GetString(header);
+            Assert.Equal("audio 13507256038857166760 4096\n", line);
+
+            Assert.True(DawAudio.TryParseFrameHeader(line.TrimEnd('\n'), out string hash, out int length));
+            Assert.Equal("13507256038857166760", hash);
+            Assert.Equal(4096, length);
+        }
+
+        [Theory]
+        [InlineData("notaudio 1 2")]
+        [InlineData("audio 1")]
+        [InlineData("audio 1 2 3")]
+        [InlineData("audio abc 2")]
+        [InlineData("audio 1 -2")]
+        [InlineData("audio 1 abc")]
+        [InlineData("audio 1 268435457")] // MaxFrameBytes + 1: a hostile length must not drive allocation.
+        public void MalformedFrameHeadersAreRefused(string line) {
+            // A header we cannot trust would desynchronize the stream, so it must never parse.
+            Assert.False(DawAudio.TryParseFrameHeader(line, out _, out _));
+        }
+
+        [Fact]
+        public void FrameHeaderAcceptsTheLargestLegalLength() {
+            Assert.True(DawAudio.TryParseFrameHeader($"audio 1 {DawAudio.MaxFrameBytes}", out _, out int length));
+            Assert.Equal(DawAudio.MaxFrameBytes, length);
+        }
+
+        [Fact]
+        public void ControlLinesAreNotMistakenForFrames() {
+            Assert.False(DawAudio.IsFrameHeader("notification:ping {}"));
+            Assert.False(DawAudio.IsFrameHeader("close"));
+            Assert.True(DawAudio.IsFrameHeader("audio 1 2"));
+        }
+
+        [Fact]
+        public void ExtractionReadsThePartsOwnAbsoluteWindow() {
+            var project = NewProject();
+            var part = new UVoicePart { trackNo = 0, position = 480, duration = 480 };
+            part.SetMix(new RampSource());
+
+            Assert.True(DawAudio.TryExtractPart(project, part, out float[] samples));
+
+            // 480 ticks in, 480 ticks long: 500 ms to 1000 ms of the project timeline.
+            // §6.1: extraction applies the pre-fader output trim (√0.5), so the ramp values
+            // come out scaled.
+            float trim = MathF.Sqrt(0.5f);
+            int start = DawAudio.MsToInterleavedIndex(500);
+            Assert.Equal(DawAudio.MsToInterleavedIndex(1000) - start, samples.Length);
+            Assert.Equal(start * trim, samples[0]);
+            Assert.Equal((start + samples.Length - 1) * trim, samples[^1]);
+        }
+
+        [Fact]
+        public void ExtractionStartsFromAZeroedBuffer() {
+            // ISignalSource.Mix adds rather than assigns, so a reused buffer would double the signal.
+            var project = NewProject();
+            var part = new UVoicePart { trackNo = 0, position = 0, duration = 480 };
+            part.SetMix(new RampSource());
+
+            Assert.True(DawAudio.TryExtractPart(project, part, out float[] first));
+            Assert.True(DawAudio.TryExtractPart(project, part, out float[] second));
+
+            Assert.Equal(first, second);
+        }
+
+        [Fact]
+        public void UnrenderedPartsAreRefused() {
+            var project = NewProject();
+            var empty = new UVoicePart { trackNo = 0, position = 0, duration = 480 };
+            var unfinished = new UVoicePart { trackNo = 0, position = 0, duration = 480 };
+            unfinished.SetMix(new RampSource { Ready = false });
+            var zeroLength = new UVoicePart { trackNo = 0, position = 0, duration = 0 };
+            zeroLength.SetMix(new RampSource());
+
+            Assert.False(DawAudio.TryExtractPart(project, empty, out _));
+            Assert.False(DawAudio.TryExtractPart(project, unfinished, out _));
+            Assert.False(DawAudio.TryExtractPart(project, zeroLength, out _));
+        }
+
+        [Fact]
+        public void ExtractionMatchesTheEngineWaveSource() {
+            var project = NewProject();
+            var samples = Enumerable.Range(0, 44100 * 2).Select(i => i / 100000f).ToArray();
+            // WaveSource is what RenderEngine hands to a part, addressed in absolute project ms.
+            var source = new WaveSource(0, 500, 0, 2);
+            source.SetSamples(samples);
+            var part = new UVoicePart { trackNo = 0, position = 0, duration = 480 };
+            part.SetMix(source);
+
+            Assert.True(DawAudio.TryExtractPart(project, part, out float[] extracted));
+
+            Assert.Equal(DawAudio.MsToInterleavedIndex(500), extracted.Length);
+            // §6.1: extraction applies the pre-fader output trim (√0.5), so what is served
+            // matches the level OpenUtau's constant-power pan produces per channel.
+            float trim = MathF.Sqrt(0.5f);
+            Assert.Equal(samples.Take(extracted.Length).Select(s => s * trim), extracted);
+        }
+    }
+}

--- a/OpenUtau.Test/Core/DawIntegration/DawConformanceTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawConformanceTest.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OpenUtau.Core.SignalChain;
+using OpenUtau.Core.Ustx;
+using Xunit;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>
+    /// The end-to-end conformance run: a real plugin-side TCP server drives
+    /// <c>init → updateTracks → updatePartLayout → getAudio → playbackStarted</c> against the
+    /// shipping <see cref="DawManager"/>, over loopback, through the real discovery directory.
+    /// </summary>
+    [Collection(DawIntegrationCollection.Name)]
+    public class DawConformanceTest : IDisposable {
+        private static readonly DateTime T0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>A ladder short enough that reconnection is observed rather than waited out.</summary>
+        private static readonly TimeSpan[] FastBackoff = {
+            TimeSpan.FromMilliseconds(20),
+            TimeSpan.FromMilliseconds(20),
+            TimeSpan.FromMilliseconds(20),
+        };
+
+        private readonly string directory;
+        private readonly DawTestPlugin plugin;
+        private readonly UProject project;
+        private DawManager? manager;
+        private DateTime now = T0;
+
+        public DawConformanceTest() {
+            directory = Path.Combine(Path.GetTempPath(), "OpenUtauDawTest", Guid.NewGuid().ToString("N"));
+            plugin = DawTestPlugin.Start("ConformancePlugin", directory);
+            project = BuildProject();
+        }
+
+        public void Dispose() {
+            manager?.Dispose();
+            plugin.Dispose();
+            try {
+                if (Directory.Exists(directory)) {
+                    Directory.Delete(directory, recursive: true);
+                }
+            } catch (Exception) {
+                // A leftover temp directory is not worth failing a test over.
+            }
+        }
+
+        /// <summary>Writes each slot's absolute sample index, so a pulled window describes itself.</summary>
+        private sealed class RampSource : ISignalSource {
+            public bool IsReady(int position, int count) => true;
+
+            public int Mix(int position, float[] buffer, int index, int count) {
+                for (int i = 0; i < count; i++) {
+                    buffer[index + i] += position + i;
+                }
+                return position + count;
+            }
+        }
+
+        /// <summary>An edit that is not a notification, i.e. something that changed the document.</summary>
+        private sealed class FakeEdit : UCommand {
+            public override void Execute() { }
+            public override void Unexecute() { }
+            public override string ToString() => "fake edit";
+        }
+
+        /// <summary>
+        /// Two tracks and two rendered parts. Project defaults are 4/4 at 120 bpm with 480 ticks
+        /// per beat, so 480 ticks is exactly 500 ms.
+        /// </summary>
+        private static UProject BuildProject() {
+            var built = new UProject();
+            // v1.1 refuses to sync an unsaved project (the USTX serializer needs a FilePath
+            // for relative paths), so give the test project a plausible save location.
+            built.FilePath = Path.Combine(Path.GetTempPath(), "conformance-test.ustx");
+            built.tracks.Clear();
+            built.tracks.Add(new UTrack("Lead") { TrackNo = 0, Volume = -3, Pan = -20 });
+            // v1.2: the singer/engine informational fields travel on updateTracks. The values
+            // are read straight off the track, so plain assignments exercise the wire format
+            // without spinning up real voicebank or renderer infrastructure.
+            built.tracks[0].Singer = USinger.CreateMissing("Test Singer");
+            built.tracks[0].RendererSettings.renderer = "DIFFSINGER";
+            // Muted, so the effective-mute field is exercised rather than defaulted; the
+            // second track has no singer, so the empty-string defaults are exercised too.
+            built.tracks.Add(new UTrack("Harmony") { TrackNo = 1, Volume = 0, Pan = 15, Muted = true });
+            var lead = new UVoicePart { name = "Lead A", trackNo = 0, position = 0, duration = 480 };
+            lead.SetMix(new RampSource());
+            built.parts.Add(lead);
+            var harmony = new UVoicePart { name = "Harmony A", trackNo = 1, position = 480, duration = 960 };
+            harmony.SetMix(new RampSource());
+            built.parts.Add(harmony);
+            built.timeAxis.BuildSegments(built);
+            return built;
+        }
+
+        /// <summary>
+        /// A manager with the timer pump off and a frozen clock, so every sync in these tests is
+        /// either explicitly pumped or triggered by the protocol itself.
+        /// </summary>
+        private DawManager NewManager(TimeSpan[]? backoff = null) {
+            var created = new DawManager(null, null, backoff) {
+                UseTimerPump = false,
+                NowUtc = () => now,
+                ProjectSource = () => project,
+            };
+            manager = created;
+            return created;
+        }
+
+        /// <summary>
+        /// The completion criterion: discovery → <c>init</c> → <c>updateTracks</c> →
+        /// <c>updatePartLayout</c> → <c>getAudio</c> → <c>playbackStarted</c>, end to end.
+        /// </summary>
+        [Fact]
+        public async Task FullFlowFromDiscoveryToPlaybackFlush() {
+            var advertised = plugin.Advertisement;
+            Assert.True(advertised.IsCompatible);
+            var openutau = NewManager();
+
+            await openutau.ConnectAsync(advertised);
+
+            Assert.Equal(DawConnectionState.Connected, openutau.State);
+            Assert.Equal(plugin.Name, openutau.ServerName);
+            // §7: the connect handshake is init, then tracks, then layout, in that order.
+            Assert.Equal(
+                new[] { DawMessageKind.Init, DawMessageKind.UpdateTracks, DawMessageKind.UpdateProjectInfo, DawMessageKind.UpdatePartLayout },
+                plugin.Received.ToArray());
+
+            // The baseline is real USTX YAML, not a JSON projection of the project.
+            Assert.Equal(DawUstx.Serialize(project), plugin.Ustx);
+            Assert.Contains("ustx_version", plugin.Ustx);
+
+            // §6.1: the fader is applied downstream of the audio the plugin pulls, so mute has to
+            // travel as its own field or the plugin cannot reproduce it. v1.2 adds the singer and
+            // engine informational fields a plugin GUI shows next to the track name.
+            Assert.Collection(plugin.Tracks,
+                track => {
+                    Assert.Equal("Lead", track.Name);
+                    Assert.Equal(-3d, track.Volume);
+                    Assert.Equal(-20d, track.Pan);
+                    Assert.False(track.Muted);
+                    Assert.Equal("Test Singer", track.Singer);
+                    Assert.Equal("DIFFSINGER", track.Engine);
+                },
+                track => {
+                    Assert.Equal("Harmony", track.Name);
+                    Assert.Equal(0d, track.Volume);
+                    Assert.Equal(15d, track.Pan);
+                    Assert.True(track.Muted);
+                    Assert.Equal(string.Empty, track.Singer);
+                    Assert.Equal(string.Empty, track.Engine);
+                });
+
+            // 480 ticks is 500 ms at the project defaults, so the windows are 0-500 and 500-1500.
+            Assert.Collection(plugin.Layout,
+                part => {
+                    Assert.Equal(0, part.TrackNo);
+                    Assert.Equal(0d, part.StartMs, 3);
+                    Assert.Equal(500d, part.EndMs, 3);
+                },
+                part => {
+                    Assert.Equal(1, part.TrackNo);
+                    Assert.Equal(500d, part.StartMs, 3);
+                    Assert.Equal(1500d, part.EndMs, 3);
+                });
+            Assert.All(plugin.Layout, part => Assert.NotEmpty(part.AudioHash));
+            Assert.Equal(2, plugin.Layout.Select(part => part.AudioHash).Distinct().Count());
+
+            // §5.2/§6.2: the plugin pulls what it lacks, and every frame matches its header hash.
+            await plugin.PullLayoutAudioAsync();
+            var parts = project.parts.OfType<UVoicePart>().ToList();
+            AssertPulledMatchesPart(plugin.Layout[0], parts[0]);
+            AssertPulledMatchesPart(plugin.Layout[1], parts[1]);
+
+            // A real edit only arms the debounce; the clock is frozen, so nothing may go out yet.
+            openutau.OnNext(new FakeEdit(), false);
+            await openutau.PumpOnceAsync();
+
+            Assert.True(openutau.Scheduler.HasPending);
+            Assert.DoesNotContain(DawMessageKind.UpdateUstx, plugin.Received);
+
+            // §9: playbackStarted makes everything pending due at once, so the DAW never plays
+            // audio that OpenUtau has already superseded.
+            await plugin.SendPlaybackStartedAsync();
+            await plugin.WaitForAsync(DawMessageKind.UpdateUstx);
+            await plugin.WaitForCountAsync(DawMessageKind.UpdatePartLayout, 2);
+
+            Assert.Equal(DawUstx.Serialize(project), plugin.Ustx);
+
+            // An inbound heartbeat is absorbed and leaves the connection working.
+            await plugin.SendPingAsync();
+            await openutau.SyncAsync(DawSyncKind.Ustx);
+            await plugin.WaitForCountAsync(DawMessageKind.UpdateUstx, 2);
+
+            Assert.True(openutau.IsConnected);
+
+            await openutau.DisconnectAsync();
+
+            Assert.Equal(DawConnectionState.Disconnected, openutau.State);
+            Assert.False(openutau.IsConnected);
+        }
+
+        [Fact]
+        public async Task IncompatibleAdvertisementIsRefusedWithoutDialing() {
+            using var future = DawTestPlugin.Start("FuturePlugin", directory, "2.0");
+            var openutau = NewManager();
+
+            await Assert.ThrowsAsync<DawProtocolException>(
+                () => openutau.ConnectAsync(future.Advertisement));
+
+            // §4: the major mismatch is visible in the directory, so no socket is ever opened.
+            Assert.Equal(DawConnectionState.Disconnected, openutau.State);
+            Assert.Empty(future.Received);
+        }
+
+        [Fact]
+        public async Task IncompatibleInitAnswerDropsTheConnection() {
+            // Advertised 1.0 but answers 2.0, which the directory scan cannot catch.
+            plugin.ApiVersion = "2.0";
+            var openutau = NewManager();
+
+            await Assert.ThrowsAsync<DawProtocolException>(
+                () => openutau.ConnectAsync(plugin.Advertisement));
+
+            Assert.Contains(DawMessageKind.Init, plugin.Received);
+            Assert.DoesNotContain(DawMessageKind.UpdatePartLayout, plugin.Received);
+            Assert.Equal(DawConnectionState.Disconnected, openutau.State);
+            Assert.False(openutau.IsConnected);
+        }
+
+        [Fact]
+        public async Task DroppedConnectionIsRecoveredOnTheBackoffLadder() {
+            var openutau = NewManager(FastBackoff);
+            await openutau.ConnectAsync(plugin.Advertisement);
+            plugin.ExpectReconnect();
+
+            // §8: a plugin that vanishes without sending close.
+            plugin.DropConnection();
+
+            await plugin.WaitForConnectionAsync();
+            // The handshake re-runs in full, so the plugin gets a fresh baseline.
+            await plugin.WaitForCountAsync(DawMessageKind.Init, 2);
+            await plugin.WaitForCountAsync(DawMessageKind.UpdatePartLayout, 2);
+
+            Assert.Equal(DawConnectionState.Connected, openutau.State);
+            Assert.True(openutau.IsConnected);
+        }
+
+        [Fact]
+        public async Task ExhaustedBackoffGivesUpAndReports() {
+            var openutau = NewManager(FastBackoff);
+            var lost = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            openutau.ConnectionLost += reason => lost.TrySetResult(reason);
+            await openutau.ConnectAsync(plugin.Advertisement);
+
+            // Nothing is left to reconnect to: the port stops answering before the socket dies.
+            plugin.StopListening();
+            plugin.DropConnection();
+
+            Assert.NotEmpty(await lost.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.Equal(DawConnectionState.Disconnected, openutau.State);
+            Assert.False(openutau.IsConnected);
+        }
+
+        [Fact]
+        public async Task LocalDisconnectDoesNotReconnect() {
+            var openutau = NewManager(FastBackoff);
+            await openutau.ConnectAsync(plugin.Advertisement);
+            plugin.ExpectReconnect();
+
+            await openutau.DisconnectAsync();
+            await Task.Delay(250);
+
+            // §8: the ladder exists for failures, not for a disconnect the user asked for.
+            Assert.Equal(DawConnectionState.Disconnected, openutau.State);
+            Assert.Equal(1, plugin.Received.Count(kind => kind == DawMessageKind.Init));
+        }
+
+        private void AssertPulledMatchesPart(DawPartLayout advertised, UVoicePart part) {
+            Assert.True(DawAudio.TryExtractPart(project, part, out float[] expected));
+            Assert.Equal(expected, DawAudio.FromPcmBytes(plugin.Pulled[advertised.AudioHash]));
+        }
+    }
+}

--- a/OpenUtau.Test/Core/DawIntegration/DawRealPluginTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawRealPluginTest.cs
@@ -48,14 +48,14 @@ namespace OpenUtau.Core.DawIntegration {
         }
 
         private DawManager? manager;
-        private readonly Xunit.Abstractions.ITestOutputHelper output;
+        private readonly ITestOutputHelper output;
 
         /// <summary>
-        /// xUnit 2.x has no runtime skip API (that arrived in v3), so a missing
-        /// OPENUTAU_BRIDGE_DISCOVERY cannot mark the run skipped. It is reported through the test
-        /// output instead of silently passing, and the early return keeps CI unaffected.
+        /// xUnit v3 has a runtime skip API, but a missing OPENUTAU_BRIDGE_DISCOVERY is reported
+        /// through the test output instead of silently passing, and the early return keeps CI
+        /// unaffected either way.
         /// </summary>
-        public DawRealPluginTest(Xunit.Abstractions.ITestOutputHelper output) {
+        public DawRealPluginTest(ITestOutputHelper output) {
             this.output = output;
         }
 

--- a/OpenUtau.Test/Core/DawIntegration/DawRealPluginTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawRealPluginTest.cs
@@ -48,26 +48,21 @@ namespace OpenUtau.Core.DawIntegration {
         }
 
         private DawManager? manager;
-        private readonly ITestOutputHelper output;
 
-        /// <summary>
-        /// xUnit v3 has a runtime skip API, but a missing OPENUTAU_BRIDGE_DISCOVERY is reported
-        /// through the test output instead of silently passing, and the early return keeps CI
-        /// unaffected either way.
-        /// </summary>
-        public DawRealPluginTest(ITestOutputHelper output) {
-            this.output = output;
-        }
+        public DawRealPluginTest() { }
 
         public void Dispose() => manager?.Dispose();
 
         /// <summary>
         /// One track at unity and centre, one part from 2000 ms to 3000 ms. Project defaults are
         /// 4/4 at 120 bpm with 480 ticks per beat, so 480 ticks is 500 ms: the part sits at ticks
-        /// 1920..2880.
+        /// 1920..2880. <c>FilePath</c> is set because <c>DawManager.OpenConnectionAsync</c>
+        /// serializes the project for the init handshake, and the USTX serializer refuses an
+        /// unsaved project (see <c>DawConformanceTest.BuildProject</c>).
         /// </summary>
         private static UProject BuildProject() {
             var built = new UProject();
+            built.FilePath = Path.Combine(Path.GetTempPath(), "real-plugin-test.ustx");
             built.tracks.Clear();
             built.tracks.Add(new UTrack("Live") { TrackNo = 0, Volume = 0, Pan = 0 });
             var live = new UVoicePart { name = "Live A", trackNo = 0, position = 1920, duration = 960 };
@@ -82,11 +77,10 @@ namespace OpenUtau.Core.DawIntegration {
             string? directory = Environment.GetEnvironmentVariable("OPENUTAU_BRIDGE_DISCOVERY");
             if (string.IsNullOrEmpty(directory)) {
                 // Opt-in live test: needs a running bridge-host publishing its discovery file.
-                // xUnit v2 on this branch has no runtime skip, so report and return instead.
-                output.WriteLine(
-                    "SKIPPED (reported as pass): set OPENUTAU_BRIDGE_DISCOVERY to a running " +
-                    "bridge-host's discovery directory to run this live handshake test.");
-                return;
+                // xUnit v3's runtime skip keeps CI unaffected without disguising the skip as a pass.
+                Assert.Skip(
+                    "Set OPENUTAU_BRIDGE_DISCOVERY to a running bridge-host's discovery " +
+                    "directory to run this live handshake test.");
             }
             Assert.True(Directory.Exists(directory), $"No such directory: {directory}");
 

--- a/OpenUtau.Test/Core/DawIntegration/DawRealPluginTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawRealPluginTest.cs
@@ -1,0 +1,148 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OpenUtau.Core.SignalChain;
+using OpenUtau.Core.Ustx;
+using Xunit;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>
+    /// The one test that is not run against a stand-in. Everything else here drives
+    /// <see cref="DawManager"/> against <see cref="DawTestPlugin"/>, and the plugin repository's
+    /// tests drive its session against a fake OpenUtau — two implementations that each agree with
+    /// their own fake can still disagree with each other, and nothing else would notice.
+    ///
+    /// Opt-in, because it needs the C++ plugin built and running. Start its standalone host with a
+    /// scratch discovery directory, then point this at the same directory:
+    ///
+    /// <code>
+    /// bridge-host.exe --dir /tmp/bridge-live --rate 48000
+    /// OPENUTAU_BRIDGE_DISCOVERY=/tmp/bridge-live dotnet test --filter DawRealPluginTest
+    /// </code>
+    ///
+    /// Skipped when that variable is unset, so CI and everyday runs are unaffected.
+    /// </summary>
+    [Collection(DawIntegrationCollection.Name)]
+    public class DawRealPluginTest : IDisposable {
+        /// <summary>Bounded, unlike the ramp the other tests use: the plugin's peak meter is read
+        /// as a number here, so the signal has to mean something at the far end.</summary>
+        private const float Level = 0.25f;
+
+        private sealed class ConstantSource : ISignalSource {
+            public bool IsReady(int position, int count) => true;
+
+            public int Mix(int position, float[] buffer, int index, int count) {
+                for (int i = 0; i < count; i++) {
+                    buffer[index + i] += Level;
+                }
+                return position + count;
+            }
+        }
+
+        /// <summary>An edit that is not a notification, i.e. something that changed the document.</summary>
+        private sealed class FakeEdit : UCommand {
+            public override void Execute() { }
+            public override void Unexecute() { }
+            public override string ToString() => "fake edit";
+        }
+
+        private DawManager? manager;
+        private readonly Xunit.Abstractions.ITestOutputHelper output;
+
+        /// <summary>
+        /// xUnit 2.x has no runtime skip API (that arrived in v3), so a missing
+        /// OPENUTAU_BRIDGE_DISCOVERY cannot mark the run skipped. It is reported through the test
+        /// output instead of silently passing, and the early return keeps CI unaffected.
+        /// </summary>
+        public DawRealPluginTest(Xunit.Abstractions.ITestOutputHelper output) {
+            this.output = output;
+        }
+
+        public void Dispose() => manager?.Dispose();
+
+        /// <summary>
+        /// One track at unity and centre, one part from 2000 ms to 3000 ms. Project defaults are
+        /// 4/4 at 120 bpm with 480 ticks per beat, so 480 ticks is 500 ms: the part sits at ticks
+        /// 1920..2880.
+        /// </summary>
+        private static UProject BuildProject() {
+            var built = new UProject();
+            built.tracks.Clear();
+            built.tracks.Add(new UTrack("Live") { TrackNo = 0, Volume = 0, Pan = 0 });
+            var live = new UVoicePart { name = "Live A", trackNo = 0, position = 1920, duration = 960 };
+            live.SetMix(new ConstantSource());
+            built.parts.Add(live);
+            built.timeAxis.BuildSegments(built);
+            return built;
+        }
+
+        [Fact]
+        public async Task RealPluginCompletesTheHandshakeAndPullsAudio() {
+            string? directory = Environment.GetEnvironmentVariable("OPENUTAU_BRIDGE_DISCOVERY");
+            if (string.IsNullOrEmpty(directory)) {
+                // Opt-in live test: needs a running bridge-host publishing its discovery file.
+                // xUnit v2 on this branch has no runtime skip, so report and return instead.
+                output.WriteLine(
+                    "SKIPPED (reported as pass): set OPENUTAU_BRIDGE_DISCOVERY to a running " +
+                    "bridge-host's discovery directory to run this live handshake test.");
+                return;
+            }
+            Assert.True(Directory.Exists(directory), $"No such directory: {directory}");
+
+            // Discovery is exercised for real: the file was written by the C++ side, and this is
+            // the shipping scanner reading it rather than a fixture.
+            var servers = new DawServerFinder(directory!).Scan();
+            var server = Assert.Single(servers);
+            Assert.True(server.IsCompatible, $"Advertised api {server.Info.ApiVersion}.");
+
+            var project = BuildProject();
+            manager = new DawManager(null, null, null) {
+                UseTimerPump = false,
+                ProjectSource = () => project,
+            };
+
+            await manager.ConnectAsync(server);
+
+            Assert.Equal(DawConnectionState.Connected, manager.State);
+            Assert.True(manager.IsConnected);
+
+            // The plugin pulls what the layout named, on its own worker thread. Serving those
+            // requests is the manager's job, so the wait is for the pulls to stop arriving —
+            // there is no message that says "I have everything" (§6.2).
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            Assert.True(manager.IsConnected, "The plugin dropped the connection mid-run.");
+            Assert.Equal(DawConnectionState.Connected, manager.State);
+
+            // The last message of the flow, in the direction only the plugin can start it: an edit
+            // arms the debounce, and a looping bridge-host reports a fresh start every time the
+            // transport jumps back, which §7 says makes everything pending due at once.
+            manager.OnNext(new FakeEdit(), false);
+            await manager.PumpOnceAsync();
+            Assert.True(manager.Scheduler.HasPending, "The edit did not arm the debounce.");
+
+            Assert.True(await WaitUntilAsync(() => !manager!.Scheduler.HasPending),
+                "No playbackStarted arrived, so the pending sync was never flushed. " +
+                "Run bridge-host with --loop for this half of the flow.");
+
+            // Whether the audio actually landed is visible at the other end, in bridge-host's peak
+            // meter: one track at unity and centre, so the constant-power pan law puts
+            // 0.25 * 0.7071 = 0.1768 in each channel between 2 s and 3 s, and silence either side.
+            await manager.DisconnectAsync();
+
+            Assert.False(manager.IsConnected);
+        }
+
+        /// <summary>Polls a condition the plugin's own timing decides. False if it never held.</summary>
+        private static async Task<bool> WaitUntilAsync(Func<bool> ready) {
+            for (int i = 0; i < 100; i++) {
+                if (ready()) {
+                    return true;
+                }
+                await Task.Delay(100);
+            }
+            return false;
+        }
+    }
+}

--- a/OpenUtau.Test/Core/DawIntegration/DawServerFinderTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawServerFinderTest.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using Xunit;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>Discovery directory and version negotiation (PROTOCOL.md §4).</summary>
+    [Collection(DawIntegrationCollection.Name)]
+    public class DawServerFinderTest : IDisposable {
+        private readonly string directory;
+
+        public DawServerFinderTest() {
+            directory = Path.Combine(Path.GetTempPath(), "OpenUtauDawTest", Guid.NewGuid().ToString("N"));
+        }
+
+        public void Dispose() {
+            try {
+                if (Directory.Exists(directory)) {
+                    Directory.Delete(directory, recursive: true);
+                }
+            } catch (Exception) {
+                // A leftover temp directory is not worth failing a test over.
+            }
+        }
+
+        /// <summary>Binds a loopback port and keeps it bound for as long as the test needs it.</summary>
+        private static TcpListener Listen() {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            return listener;
+        }
+
+        private static int Port(TcpListener listener) => ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        /// <summary>A port that was bound and released, so nothing answers on it any more.</summary>
+        private static int FreePort() {
+            var listener = Listen();
+            int port = Port(listener);
+            listener.Stop();
+            return port;
+        }
+
+        [Fact]
+        public void DefaultDirectoryIsTheProtocolPath() {
+            Assert.Equal(
+                Path.Combine(Path.GetTempPath(), "OpenUtau", "PluginServers"),
+                DawServerFinder.DefaultDirectory);
+        }
+
+        [Fact]
+        public void MissingDirectoryScansEmpty() {
+            var finder = new DawServerFinder(directory);
+
+            Assert.Empty(finder.Scan());
+        }
+
+        [Fact]
+        public void LiveAdvertisementIsFound() {
+            using var listener = Listen();
+            var finder = new DawServerFinder(directory);
+            finder.Publish("TestPlugin", Port(listener));
+
+            var found = Assert.Single(finder.Scan());
+
+            Assert.Equal(Port(listener), found.Port);
+            Assert.Equal("TestPlugin", found.Name);
+            Assert.True(found.IsCompatible);
+        }
+
+        [Fact]
+        public void StaleAdvertisementIsDeleted() {
+            var finder = new DawServerFinder(directory);
+            string path = finder.Publish("CrashedPlugin", FreePort());
+
+            Assert.Empty(finder.Scan());
+
+            // §4: this is how the directory recovers from a DAW that died without cleaning up.
+            Assert.False(File.Exists(path));
+        }
+
+        [Fact]
+        public void StaleAdvertisementIsKeptWhenSweepingIsOff() {
+            var finder = new DawServerFinder(directory);
+            string path = finder.Publish("CrashedPlugin", FreePort());
+
+            Assert.Empty(finder.Scan(removeStale: false));
+
+            Assert.True(File.Exists(path));
+        }
+
+        [Fact]
+        public void UnreadableFileIsSkipped() {
+            using var listener = Listen();
+            Directory.CreateDirectory(directory);
+            // Half-written files are normal if a plugin is starting while we scan.
+            File.WriteAllText(Path.Combine(directory, "torn.json"), "{\"port\": ");
+            var finder = new DawServerFinder(directory);
+            finder.Publish("Good", Port(listener));
+
+            var found = Assert.Single(finder.Scan());
+
+            Assert.Equal("Good", found.Name);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(70000)]
+        public void UnusablePortIsSkipped(int port) {
+            var finder = new DawServerFinder(directory);
+            finder.Publish("Broken", port);
+
+            Assert.Empty(finder.Scan());
+        }
+
+        [Fact]
+        public void IncompatibleMajorIsListedButRefused() {
+            using var listener = Listen();
+            var finder = new DawServerFinder(directory);
+            finder.Publish("FuturePlugin", Port(listener), "2.0");
+
+            var found = Assert.Single(finder.Scan());
+
+            // Listed so the UI can explain itself, but not connectable.
+            Assert.False(found.IsCompatible);
+            Assert.Equal(2, found.Version.Major);
+        }
+
+        [Fact]
+        public void NewerMinorStillConnects() {
+            using var listener = Listen();
+            var finder = new DawServerFinder(directory);
+            finder.Publish("NewerPlugin", Port(listener), "1.7");
+
+            Assert.True(Assert.Single(finder.Scan()).IsCompatible);
+        }
+
+        [Fact]
+        public void UnparseableVersionIsRefused() {
+            using var listener = Listen();
+            var finder = new DawServerFinder(directory);
+            finder.Publish("MysteryPlugin", Port(listener), "not-a-version");
+
+            Assert.False(Assert.Single(finder.Scan()).IsCompatible);
+        }
+
+        [Fact]
+        public void NameFallsBackToTheFileName() {
+            using var listener = Listen();
+            var finder = new DawServerFinder(directory);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(
+                Path.Combine(directory, "AnonymousPlugin.json"),
+                DawJson.Serialize(new DawServerInfo { Port = Port(listener), ApiVersion = "1.0" }));
+
+            Assert.Equal("AnonymousPlugin", Assert.Single(finder.Scan()).Name);
+        }
+
+        [Fact]
+        public void PortProbeDistinguishesBoundFromFree() {
+            using var listener = Listen();
+
+            // ExclusiveAddressUse is what makes this reliable on Windows; without it a second bind
+            // would succeed through SO_REUSEADDR and every live server would look stale.
+            Assert.True(DawServerFinder.IsPortAlive(Port(listener)));
+            Assert.False(DawServerFinder.IsPortAlive(FreePort()));
+        }
+
+        [Fact]
+        public void RemoveDeletesTheAdvertisement() {
+            var finder = new DawServerFinder(directory);
+            string path = finder.Publish("Departing", 1);
+
+            finder.Remove(path);
+
+            Assert.False(File.Exists(path));
+        }
+
+        [Theory]
+        [InlineData("1.0", 1, 0, true)]
+        [InlineData("1.4", 1, 4, true)]
+        [InlineData("2.0", 2, 0, false)]
+        [InlineData("0.9", 0, 9, false)]
+        public void VersionCompatibilityIsMajorOnly(string text, int major, int minor, bool compatible) {
+            Assert.True(DawApiVersion.TryParse(text, out var version));
+
+            Assert.Equal(major, version.Major);
+            Assert.Equal(minor, version.Minor);
+            Assert.Equal(compatible, version.IsCompatibleWith(DawApiVersion.Current));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("1")]
+        [InlineData("1.x")]
+        [InlineData("x.0")]
+        public void MalformedVersionsDoNotParse(string text) {
+            Assert.False(DawApiVersion.TryParse(text, out _));
+        }
+    }
+}

--- a/OpenUtau.Test/Core/DawIntegration/DawSyncSchedulerTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawSyncSchedulerTest.cs
@@ -1,0 +1,135 @@
+using System;
+using Xunit;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>
+    /// The debounce contract from PROTOCOL.md §7. The scheduler takes time as an argument, so
+    /// none of this sleeps.
+    /// </summary>
+    [Collection(DawIntegrationCollection.Name)]
+    public class DawSyncSchedulerTest {
+        private static readonly DateTime T0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        [Fact]
+        public void FastStreamsWaitOneSecond() {
+            var scheduler = new DawSyncScheduler();
+
+            scheduler.Touch(DawSyncKind.Ustx, T0);
+
+            Assert.Empty(scheduler.TryTake(T0.AddMilliseconds(999)));
+            Assert.Equal(new[] { DawSyncKind.Ustx }, scheduler.TryTake(T0.AddSeconds(1)));
+        }
+
+        [Fact]
+        public void PartLayoutWaitsFiveSeconds() {
+            var scheduler = new DawSyncScheduler();
+
+            scheduler.Touch(DawSyncKind.PartLayout, T0);
+
+            Assert.Empty(scheduler.TryTake(T0.AddSeconds(4)));
+            Assert.Equal(new[] { DawSyncKind.PartLayout }, scheduler.TryTake(T0.AddSeconds(5)));
+        }
+
+        [Fact]
+        public void TakingAStreamClearsIt() {
+            var scheduler = new DawSyncScheduler();
+
+            scheduler.Touch(DawSyncKind.Tracks, T0);
+            Assert.Single(scheduler.TryTake(T0.AddSeconds(1)));
+
+            Assert.Empty(scheduler.TryTake(T0.AddSeconds(10)));
+            Assert.False(scheduler.HasPending);
+        }
+
+        [Fact]
+        public void EachEditPushesTheDueTimeOut() {
+            var scheduler = new DawSyncScheduler();
+
+            // A user editing continuously: the sync must land after they stop, not during.
+            scheduler.Touch(DawSyncKind.Ustx, T0);
+            scheduler.Touch(DawSyncKind.Ustx, T0.AddMilliseconds(500));
+            scheduler.Touch(DawSyncKind.Ustx, T0.AddMilliseconds(900));
+
+            Assert.Empty(scheduler.TryTake(T0.AddMilliseconds(1800)));
+            Assert.Single(scheduler.TryTake(T0.AddMilliseconds(1900)));
+        }
+
+        [Fact]
+        public void TakeIsOrderedUstxThenTracksThenLayout() {
+            var scheduler = new DawSyncScheduler();
+
+            scheduler.Touch(DawSyncKind.PartLayout, T0);
+            scheduler.Touch(DawSyncKind.Tracks, T0);
+            scheduler.Touch(DawSyncKind.Ustx, T0);
+
+            Assert.Equal(
+                new[] { DawSyncKind.Ustx, DawSyncKind.Tracks, DawSyncKind.PartLayout },
+                scheduler.TryTake(T0.AddSeconds(5)));
+        }
+
+        [Fact]
+        public void PlaybackFlushMakesPendingStreamsDueAtOnce() {
+            var scheduler = new DawSyncScheduler();
+            scheduler.Touch(DawSyncKind.Ustx, T0);
+            scheduler.Touch(DawSyncKind.PartLayout, T0);
+
+            // playbackStarted: the DAW is about to play, so it must not hear stale audio.
+            scheduler.FlushPending(T0.AddMilliseconds(10));
+
+            Assert.Equal(
+                new[] { DawSyncKind.Ustx, DawSyncKind.PartLayout },
+                scheduler.TryTake(T0.AddMilliseconds(10)));
+        }
+
+        [Fact]
+        public void PlaybackFlushInventsNothingWhenIdle() {
+            var scheduler = new DawSyncScheduler();
+
+            scheduler.FlushPending(T0);
+
+            Assert.False(scheduler.HasPending);
+            Assert.Empty(scheduler.TryTake(T0));
+        }
+
+        [Fact]
+        public void FullSyncMakesEveryStreamDue() {
+            var scheduler = new DawSyncScheduler();
+
+            scheduler.RequestFullSync(T0);
+
+            Assert.Equal(
+                new[] { DawSyncKind.Ustx, DawSyncKind.Tracks, DawSyncKind.PartLayout, DawSyncKind.ProjectInfo },
+                scheduler.TryTake(T0));
+        }
+
+        [Fact]
+        public void MakeDueBypassesTheDebounce() {
+            var scheduler = new DawSyncScheduler();
+
+            scheduler.MakeDue(DawSyncKind.PartLayout, T0);
+
+            Assert.Equal(new[] { DawSyncKind.PartLayout }, scheduler.TryTake(T0));
+        }
+
+        [Fact]
+        public void ClearDropsEverythingPending() {
+            var scheduler = new DawSyncScheduler();
+            scheduler.RequestFullSync(T0);
+
+            scheduler.Clear();
+
+            Assert.False(scheduler.HasPending);
+            Assert.Empty(scheduler.TryTake(T0.AddMinutes(1)));
+        }
+
+        [Fact]
+        public void DebounceWindowsAreInjectable() {
+            var scheduler = new DawSyncScheduler(
+                fastDebounce: TimeSpan.FromMilliseconds(10), slowDebounce: TimeSpan.FromMilliseconds(20));
+
+            Assert.Equal(TimeSpan.FromMilliseconds(10), scheduler.DebounceFor(DawSyncKind.Ustx));
+            Assert.Equal(TimeSpan.FromMilliseconds(10), scheduler.DebounceFor(DawSyncKind.Tracks));
+            Assert.Equal(TimeSpan.FromMilliseconds(20), scheduler.DebounceFor(DawSyncKind.PartLayout));
+        }
+    }
+}

--- a/OpenUtau.Test/Core/DawIntegration/DawTestBootstrap.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawTestBootstrap.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Xunit;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>
+    /// Puts every DawIntegration test class into one non-parallel collection. These tests run
+    /// real loopback sockets with real pumps and real second-scale timeouts; running them
+    /// concurrently with each other (xUnit's default is one collection per class) is what
+    /// showed up as random <c>init request timed out after 5.0s</c> failures on loaded CI
+    /// runners, where the pumps' thread-pool continuations queue behind the rest of the suite.
+    /// <c>DisableParallelization</c> keeps them off every other collection's threads, too.
+    /// </summary>
+    [CollectionDefinition(nameof(DawIntegrationCollection), DisableParallelization = true)]
+    public sealed class DawIntegrationCollection {
+        public const string Name = nameof(DawIntegrationCollection);
+    }
+
+    /// <summary>
+    /// Raises the thread-pool minimums before anything in this assembly runs. A test process
+    /// that mixes CPU-heavy suites with socket pumps that must answer inside 5 s starves the
+    /// pool by default: it grows by roughly one thread per half second, which is exactly the
+    /// shape of "passes locally, times out on CI". No test semantics are touched.
+    /// </summary>
+    internal static class DawTestBootstrap {
+        [ModuleInitializer]
+        internal static void Init() {
+            ThreadPool.SetMinThreads(workerThreads: 32, completionPortThreads: 32);
+        }
+    }
+}

--- a/OpenUtau.Test/Core/DawIntegration/DawTestPlugin.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawTestPlugin.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>
+    /// The plugin half of the protocol, for tests and conformance runs: a loopback TCP server that
+    /// publishes a discovery file, accepts one connection and answers on it.
+    /// </summary>
+    /// <remarks>
+    /// Built on the same <see cref="DawTransport"/> as the OpenUtau side on purpose. A second,
+    /// independent framing implementation here would only prove the two copies agree with each
+    /// other; sharing it means these tests exercise the code that ships.
+    /// </remarks>
+    public sealed class DawTestPlugin : IDisposable {
+        private readonly TcpListener listener;
+        private readonly DawServerFinder finder;
+        private TaskCompletionSource<DawTransport> connected =
+            new TaskCompletionSource<DawTransport>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Every control message received, in arrival order — the §7 ordering assertion.</summary>
+        public ConcurrentQueue<string> Received { get; } = new ConcurrentQueue<string>();
+
+        /// <summary>Hash → PCM for everything pulled with <c>getAudio</c>.</summary>
+        public Dictionary<string, byte[]> Pulled { get; } = new Dictionary<string, byte[]>();
+
+        /// <summary>The baseline from <c>init</c>, then whatever <c>updateUstx</c> last carried.</summary>
+        public string Ustx { get; private set; } = string.Empty;
+
+        public List<DawPartLayout> Layout { get; private set; } = new List<DawPartLayout>();
+        public List<DawTrackInfo> Tracks { get; private set; } = new List<DawTrackInfo>();
+
+        /// <summary>What this plugin answers <c>init</c> with. Set before connecting to test §4.</summary>
+        public string ApiVersion { get; set; } = DawApiVersion.CurrentString;
+
+        public string Name { get; }
+        public int Port { get; }
+        public string DiscoveryPath { get; }
+        public DawServerFinder Finder => finder;
+        public DawTransport? Transport { get; private set; }
+
+        private DawTestPlugin(TcpListener listener, DawServerFinder finder, string name, int port, string path) {
+            this.listener = listener;
+            this.finder = finder;
+            Name = name;
+            Port = port;
+            DiscoveryPath = path;
+        }
+
+        /// <summary>Binds an ephemeral loopback port, advertises it and starts accepting.</summary>
+        public static DawTestPlugin Start(
+            string name, string discoveryDirectory, string? advertisedApiVersion = null) {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var finder = new DawServerFinder(discoveryDirectory);
+            string path = finder.Publish(name, port, advertisedApiVersion ?? DawApiVersion.CurrentString);
+            var plugin = new DawTestPlugin(listener, finder, name, port, path) {
+                ApiVersion = advertisedApiVersion ?? DawApiVersion.CurrentString,
+            };
+            plugin.Accept();
+            return plugin;
+        }
+
+        /// <summary>This plugin as OpenUtau discovers it — through a real directory scan (§4).</summary>
+        public DawServer Advertisement =>
+            finder.Scan(removeStale: false).Single(server => server.Port == Port);
+
+        public Task<DawTransport> WaitForConnectionAsync(TimeSpan? timeout = null) =>
+            connected.Task.WaitAsync(timeout ?? TimeSpan.FromSeconds(10));
+
+        /// <summary>
+        /// Arms a fresh connection wait, so a reconnect can be awaited without racing the one that
+        /// is about to be dropped.
+        /// </summary>
+        public void ExpectReconnect() {
+            connected = new TaskCompletionSource<DawTransport>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        /// <summary>Kills the socket without a <c>close</c> — a wedged or crashed plugin.</summary>
+        public void DropConnection() {
+            Transport?.Dispose();
+            Transport = null;
+        }
+
+        /// <summary>Stops answering entirely, so reconnection cannot succeed.</summary>
+        public void StopListening() {
+            try {
+                listener.Stop();
+            } catch (Exception) {
+                // Already stopped.
+            }
+        }
+
+        private void Accept() {
+            _ = Task.Run(async () => {
+                while (true) {
+                    TcpClient client;
+                    try {
+                        client = await listener.AcceptTcpClientAsync();
+                    } catch (Exception) {
+                        // The listener was stopped; nothing more will connect.
+                        return;
+                    }
+                    var transport = DawTransport.Adopt(client);
+                    transport.RequestHandler = ServeAsync;
+                    transport.Notification += OnNotification;
+                    Transport = transport;
+                    connected.TrySetResult(transport);
+                }
+            });
+        }
+
+        private void OnNotification(string kind, JsonElement? payload) {
+            switch (kind) {
+                case DawMessageKind.UpdateUstx:
+                    Ustx = payload?.Deserialize<UpdateUstxNotification>(DawJson.Options)?.Ustx ?? string.Empty;
+                    break;
+                case DawMessageKind.UpdateTracks:
+                    Tracks = payload?.Deserialize<UpdateTracksNotification>(DawJson.Options)?.Tracks
+                        ?? new List<DawTrackInfo>();
+                    break;
+            }
+            Received.Enqueue(kind);
+        }
+
+        private async Task ServeAsync(DawInboundRequest request) {
+            switch (request.Kind) {
+                case DawMessageKind.Init:
+                    Ustx = request.ReadPayload<InitRequest>().Ustx;
+                    Received.Enqueue(request.Kind);
+                    await request.RespondAsync(DawResult.Ok(new InitResponse { ApiVersion = ApiVersion }));
+                    break;
+                case DawMessageKind.UpdatePartLayout:
+                    Layout = request.ReadPayload<UpdatePartLayoutRequest>().Parts;
+                    Received.Enqueue(request.Kind);
+                    await request.RespondAsync(DawResult.Ok(new UpdatePartLayoutResponse {
+                        MissingAudios = Layout
+                            .Select(part => part.AudioHash)
+                            .Where(hash => !Pulled.ContainsKey(hash))
+                            .Distinct()
+                            .ToList(),
+                    }));
+                    break;
+                default:
+                    Received.Enqueue(request.Kind);
+                    await request.RespondAsync(DawResult.Fail($"Unsupported request '{request.Kind}'."));
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Pulls every hash the last layout advertised and checks each frame against its header
+        /// hash, which is the whole point of the data plane (§5.2, §6.2).
+        /// </summary>
+        public async Task PullLayoutAudioAsync() {
+            var transport = Transport ?? throw new InvalidOperationException("Not connected yet.");
+            foreach (string hash in Layout.Select(part => part.AudioHash).Distinct().ToList()) {
+                byte[] pcm = await transport.GetAudioAsync(hash);
+                Assert.Equal(hash, DawAudio.FormatHash(DawAudio.Hash(pcm)));
+                Pulled[hash] = pcm;
+            }
+        }
+
+        public Task SendPlaybackStartedAsync() =>
+            Transport!.SendNotificationAsync(DawMessageKind.PlaybackStarted, new DawEmptyPayload());
+
+        public Task SendPingAsync() =>
+            Transport!.SendNotificationAsync(DawMessageKind.Ping, new DawEmptyPayload());
+
+        /// <summary>Waits for a control message of this kind, polling instead of guessing a sleep.</summary>
+        public Task WaitForAsync(string kind, TimeSpan? timeout = null) =>
+            WaitForCountAsync(kind, 1, timeout);
+
+        /// <summary>
+        /// Waits until this kind has arrived at least <paramref name="count"/> times, which is how
+        /// a *second* update is distinguished from the one the connect handshake already sent.
+        /// </summary>
+        public async Task WaitForCountAsync(string kind, int count, TimeSpan? timeout = null) {
+            var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(10));
+            while (DateTime.UtcNow < deadline) {
+                if (Received.Count(seen => seen == kind) >= count) {
+                    return;
+                }
+                await Task.Delay(20);
+            }
+            throw new TimeoutException(
+                $"Plugin saw '{kind}' {Received.Count(seen => seen == kind)} time(s), wanted {count}. " +
+                $"Saw: {string.Join(", ", Received)}");
+        }
+
+        public void Dispose() {
+            Transport?.Dispose();
+            try {
+                listener.Stop();
+            } catch (Exception) {
+                // Already torn down.
+            }
+            finder.Remove(DiscoveryPath);
+        }
+    }
+}

--- a/OpenUtau.Test/Core/DawIntegration/DawTransportTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawTransportTest.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenUtau.Core.DawIntegration {
+    /// <summary>
+    /// Framing, correlation, timeout and heartbeat behaviour over a real loopback socket
+    /// (PROTOCOL.md §3, §5, §8).
+    /// </summary>
+    [Collection(DawIntegrationCollection.Name)]
+    public class DawTransportTest : IDisposable {
+        private static readonly DateTime T0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        private readonly List<IDisposable> owned = new List<IDisposable>();
+
+        /// <summary>A mutable clock, so heartbeat death is provoked without waiting 15 s.</summary>
+        private sealed class Clock {
+            public DateTime Now;
+
+            public Clock(DateTime now) {
+                Now = now;
+            }
+
+            public DateTime Read() => Now;
+        }
+
+        /// <summary>
+        /// A connected pair: <c>openutau</c> is the side that dials, <c>plugin</c> the side that
+        /// listens. Both are the shipping transport, so the framing is only implemented once.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="pluginOptions"/> exists because only OpenUtau watches its peer's pings
+        /// (§3). A heartbeat test that tightened the threshold on both ends would have the plugin
+        /// declare OpenUtau dead first and close the socket from the wrong side.
+        /// </remarks>
+        private async Task<(DawTransport openutau, DawTransport plugin)> PairAsync(
+            DawTransportOptions? options = null,
+            Func<DateTime>? nowUtc = null,
+            DawTransportOptions? pluginOptions = null) {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            try {
+                int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+                var accepting = listener.AcceptTcpClientAsync();
+                var openutau = await DawTransport.ConnectAsync(port, options, nowUtc);
+                var plugin = DawTransport.Adopt(await accepting, pluginOptions ?? options, nowUtc);
+                owned.Add(openutau);
+                owned.Add(plugin);
+                return (openutau, plugin);
+            } finally {
+                listener.Stop();
+            }
+        }
+
+        public void Dispose() {
+            foreach (var item in owned) {
+                item.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task RequestIsCorrelatedWithItsResponse() {
+            var (openutau, plugin) = await PairAsync();
+            plugin.RequestHandler = request => request.RespondAsync(
+                DawResult.Ok(new InitResponse { ApiVersion = "1.0" }));
+
+            var response = await openutau.SendRequestAsync<InitResponse>(
+                DawMessageKind.Init, new InitRequest { Ustx = "name: test" });
+
+            Assert.Equal("1.0", response.ApiVersion);
+        }
+
+        [Fact]
+        public async Task ConcurrentRequestsDoNotCrossOver() {
+            var (openutau, plugin) = await PairAsync();
+            plugin.RequestHandler = async request => {
+                // Answer slowly and out of order, so uuid correlation is what makes this work.
+                var payload = request.ReadPayload<UpdateUstxNotification>();
+                await Task.Delay(payload.Ustx == "slow" ? 120 : 10);
+                await request.RespondAsync(DawResult.Ok(new UpdateUstxNotification { Ustx = payload.Ustx }));
+            };
+
+            var slow = openutau.SendRequestAsync<UpdateUstxNotification>(
+                DawMessageKind.UpdateUstx, new UpdateUstxNotification { Ustx = "slow" });
+            var fast = openutau.SendRequestAsync<UpdateUstxNotification>(
+                DawMessageKind.UpdateUstx, new UpdateUstxNotification { Ustx = "fast" });
+
+            Assert.Equal("slow", (await slow).Ustx);
+            Assert.Equal("fast", (await fast).Ustx);
+        }
+
+        [Fact]
+        public async Task NotificationsArriveWithTheirPayload() {
+            var (openutau, plugin) = await PairAsync();
+            var seen = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            plugin.Notification += (kind, payload) => seen.TrySetResult(
+                $"{kind}:{payload?.Deserialize<UpdateTracksNotification>(DawJson.Options)?.Tracks.Count}");
+
+            await openutau.SendNotificationAsync(DawMessageKind.UpdateTracks, new UpdateTracksNotification {
+                Tracks = new List<DawTrackInfo> { new DawTrackInfo { Name = "Track1" } },
+            });
+
+            Assert.Equal($"{DawMessageKind.UpdateTracks}:1", await seen.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+
+        [Fact]
+        public async Task UnknownNotificationIsSurvivedNotFatal() {
+            var (openutau, plugin) = await PairAsync();
+            plugin.RequestHandler = request => request.RespondAsync(DawResult.Ok());
+
+            // §10: a newer plugin may send kinds this build has never heard of.
+            await openutau.SendNotificationAsync("somethingFromTheFuture", new DawEmptyPayload());
+            var result = await openutau.SendRequestAsync(DawMessageKind.Init, new DawEmptyPayload());
+
+            Assert.True(result.Success);
+            Assert.True(openutau.IsConnected);
+        }
+
+        [Fact]
+        public async Task AudioFrameSurvivesNewlinesInThePayload() {
+            var (openutau, plugin) = await PairAsync();
+            // Every byte value, so the payload contains 0x0A and 0x0D. A line-oriented reader that
+            // did not honour the length prefix would cut the frame here.
+            byte[] pcm = Enumerable.Range(0, 4096).Select(i => (byte)(i % 256)).ToArray();
+            string hash = DawAudio.FormatHash(DawAudio.Hash(pcm));
+            plugin.RequestHandler = request => request.RespondWithAudioAsync(
+                request.ReadPayload<GetAudioRequest>().Hash, pcm);
+
+            byte[] received = await openutau.GetAudioAsync(hash);
+
+            Assert.Equal(pcm, received);
+        }
+
+        [Fact]
+        public async Task ControlLineFollowingAFrameIsNotLost() {
+            var (openutau, plugin) = await PairAsync();
+            byte[] pcm = Enumerable.Range(0, 8192).Select(i => (byte)(i % 256)).ToArray();
+            string hash = DawAudio.FormatHash(DawAudio.Hash(pcm));
+            var pinged = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            openutau.Notification += (kind, _) => pinged.TrySetResult(kind);
+            plugin.RequestHandler = async request => {
+                await request.RespondWithAudioAsync(request.ReadPayload<GetAudioRequest>().Hash, pcm);
+                // Arrives in the same read buffer as the tail of the frame.
+                await plugin.SendNotificationAsync(DawMessageKind.Ping, new DawEmptyPayload());
+            };
+
+            Assert.Equal(pcm, await openutau.GetAudioAsync(hash));
+            Assert.Equal(DawMessageKind.Ping, await pinged.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+
+        [Fact]
+        public async Task RequestTimeoutIsReported() {
+            var (openutau, plugin) = await PairAsync();
+            // A handler that never answers is exactly the §8 case: the peer is wedged.
+            plugin.RequestHandler = _ => new TaskCompletionSource<bool>().Task;
+
+            await Assert.ThrowsAsync<TimeoutException>(() => openutau.SendRequestAsync(
+                DawMessageKind.Init, new DawEmptyPayload(), TimeSpan.FromMilliseconds(150)));
+        }
+
+        [Fact]
+        public async Task UnhandledRequestIsRefusedRatherThanIgnored() {
+            var (openutau, plugin) = await PairAsync();
+            plugin.RequestHandler = null;
+
+            // A silent drop would cost the caller a full 10 s timeout instead of an answer.
+            // The refusal is immediate, but on loaded CI the transport pumps may lag;
+            // a generous budget keeps the assertion about refusal semantics, not timing.
+            var result = await openutau.SendRequestAsync(
+                DawMessageKind.Init, new DawEmptyPayload(), TimeSpan.FromSeconds(30));
+
+            Assert.False(result.Success);
+            Assert.NotNull(result.Error);
+        }
+
+        [Fact]
+        public async Task RefusedAudioPullFailsWithoutWaitingForTheTimeout() {
+            var (openutau, plugin) = await PairAsync();
+            plugin.RequestHandler = request => request.RespondAsync(DawResult.Fail("no such hash"));
+
+            // The reply is an envelope, not a frame, so the hash-keyed wait must not hang.
+            var error = await Assert.ThrowsAsync<DawProtocolException>(
+                () => openutau.GetAudioAsync("42", TimeSpan.FromSeconds(5)));
+
+            Assert.Contains("no such hash", error.Message);
+        }
+
+        [Fact]
+        public async Task BareCloseEndsTheConnection() {
+            var (openutau, plugin) = await PairAsync();
+            var ended = new TaskCompletionSource<DawDisconnectReason>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            openutau.Disconnected += (reason, _) => ended.TrySetResult(reason);
+
+            await plugin.CloseAsync();
+
+            Assert.Equal(DawDisconnectReason.PluginClosed, await ended.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.False(openutau.IsConnected);
+        }
+
+        [Fact]
+        public async Task SilentPeerIsDeclaredDeadAfterTheHeartbeatThreshold() {
+            var clock = new Clock(T0);
+            var options = new DawTransportOptions {
+                HeartbeatPollInterval = TimeSpan.FromMilliseconds(20),
+                HeartbeatDeadThreshold = TimeSpan.FromMilliseconds(100),
+            };
+            var (openutau, _) = await PairAsync(options, clock.Read, DawTransportOptions.Default);
+            var ended = new TaskCompletionSource<DawDisconnectReason>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            openutau.Disconnected += (reason, _) => ended.TrySetResult(reason);
+
+            // §3: no ping for longer than the threshold means the plugin is gone, even though the
+            // socket itself is still open.
+            clock.Now = T0.AddSeconds(30);
+
+            Assert.Equal(
+                DawDisconnectReason.HeartbeatTimeout, await ended.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+
+        [Fact]
+        public async Task TrafficKeepsTheConnectionAlive() {
+            var clock = new Clock(T0);
+            var options = new DawTransportOptions {
+                HeartbeatPollInterval = TimeSpan.FromMilliseconds(20),
+                HeartbeatDeadThreshold = TimeSpan.FromMilliseconds(100),
+            };
+            var (openutau, plugin) = await PairAsync(options, clock.Read, DawTransportOptions.Default);
+
+            for (int tick = 0; tick < 6; tick++) {
+                clock.Now = T0.AddMilliseconds(80 * (tick + 1));
+                await plugin.SendNotificationAsync(DawMessageKind.Ping, new DawEmptyPayload());
+                await Task.Delay(30);
+            }
+
+            Assert.True(openutau.IsConnected);
+        }
+
+        [Fact]
+        public async Task DeadConnectionFailsEveryOutstandingWait() {
+            var (openutau, plugin) = await PairAsync();
+            plugin.RequestHandler = _ => new TaskCompletionSource<bool>().Task;
+            var pending = openutau.SendRequestAsync(
+                DawMessageKind.Init, new DawEmptyPayload(), TimeSpan.FromSeconds(30));
+
+            plugin.Dispose();
+
+            // No caller may hang on a socket that has gone away.
+            await Assert.ThrowsAnyAsync<Exception>(() => pending);
+            Assert.False(openutau.IsConnected);
+        }
+    }
+}

--- a/OpenUtau.Test/Core/DawIntegration/DawTransportTest.cs
+++ b/OpenUtau.Test/Core/DawIntegration/DawTransportTest.cs
@@ -158,9 +158,41 @@ namespace OpenUtau.Core.DawIntegration {
             var (openutau, plugin) = await PairAsync();
             // A handler that never answers is exactly the §8 case: the peer is wedged.
             plugin.RequestHandler = _ => new TaskCompletionSource<bool>().Task;
+            var ended = new TaskCompletionSource<DawDisconnectReason>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            openutau.Disconnected += (reason, _) => ended.TrySetResult(reason);
 
             await Assert.ThrowsAsync<TimeoutException>(() => openutau.SendRequestAsync(
                 DawMessageKind.Init, new DawEmptyPayload(), TimeSpan.FromMilliseconds(150)));
+
+            // §8: a wedged peer can keep pinging forever, so the transport must not stay
+            // connected after a request timeout — reconnect handling has to start now.
+            Assert.Equal(DawDisconnectReason.RequestTimeout, await ended.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.False(openutau.IsConnected);
+        }
+
+        [Fact]
+        public async Task AudioFrameWithMismatchedHashIsRejected() {
+            var (openutau, plugin) = await PairAsync();
+            byte[] pcm = Enumerable.Range(0, 1024).Select(i => (byte)(i % 256)).ToArray();
+            var ended = new TaskCompletionSource<DawDisconnectReason>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            openutau.Disconnected += (reason, _) => ended.TrySetResult(reason);
+            // §5.2: the header must name the hash of the payload that follows. The plugin answers
+            // with a header hash that does not describe the bytes it sends — a lying peer that
+            // would otherwise poison the audio cache with unrelated bytes.
+            string wrongHash = DawAudio.FormatHash(DawAudio.Hash(pcm) ^ 0x5a5a5a5aUL);
+            plugin.RequestHandler = request => request.RespondWithAudioAsync(
+                request.ReadPayload<GetAudioRequest>().Hash, pcm);
+
+            // The read loop rejects the frame before completing the waiter and stops the
+            // transport, so the caller observes the stop — either as the protocol detail or as
+            // the shutdown, depending on which wins the race — never a completed pull.
+            await Assert.ThrowsAnyAsync<DawProtocolException>(
+                () => openutau.GetAudioAsync(wrongHash, TimeSpan.FromSeconds(5)));
+
+            // A framing-level lie is a protocol error, not something to keep the socket open for.
+            Assert.Equal(DawDisconnectReason.ProtocolError, await ended.Task.WaitAsync(TimeSpan.FromSeconds(5)));
         }
 
         [Fact]


### PR DESCRIPTION
## What

A localhost-only API between OpenUtau and DAW plugins, plus its formal specification and a full test suite. A plugin instance listens on `127.0.0.1`, advertises itself through a discovery file under `%TEMP%/OpenUtau/PluginServers/`, and OpenUtau connects as a TCP client to synchronize the project document, track configuration and rendered part audio into the DAW, while the DAW feeds transport position, playing state and tempo back.

## Shape of the API

- **JSON control plane** (`init`, `updateUstx`, `updatePartLayout`, `updateTracks`, `updateProjectInfo`; `playhead`, `bpm`, `playbackStarted`, `ping`) plus a **binary data plane** for audio: `getAudio` is answered with raw `float32` 44.1 kHz stereo frames, pulled by XXH64 content hash — serialized as decimal strings everywhere (safe-integer limits), with a 256 MiB frame bound.
- **Incremental by default:** debounced updates, playback flush, hash-deduped audio pulls, heartbeat and reconnect backoff. The wire audio is pre-fader with a constant √0.5 per-channel trim so the DAW owns the mixer.
- **Minimal core footprint:** everything lives in one self-contained directory, `OpenUtau.Core/DawIntegration/` (`DawMessages`, `DawTransport`, `DawServerFinder`, `DawAudio`, `DawManager`), plus `API.md` — the formal specification (message reference, versioning policy, security model, plugin-author checklist, conformance strategy).
- The server half ships as an **independent plugin project** ([KakaruHayate/openutau-vst-bridge](https://github.com/KakaruHayate/openutau-vst-bridge), VST3/CLAP) and is deliberately not part of this repository. The API here ships dormant — no application UI is wired in this change; a follow-up will expose it.

## Tests

`OpenUtau.Test/Core/DawIntegration/` adds unit tests for framing, transport, discovery and audio, and a conformance suite that drives the real `DawManager` against a loopback test plugin through a real discovery directory. One opt-in test (`DawRealPluginTest`) integrates with a real external plugin when `OPENUTAU_BRIDGE_DISCOVERY` points at its discovery directory; CI is unaffected when the variable is unset.

## Lineage

This supersedes the approach of #2187: the discovery-file pattern, hash-deduped incremental sync, heartbeat/backoff and playback-flush ideas are kept, while audio-in-JSON and the single-repo plugin footprint are not. Details in `API.md` Appendix B.