### PR TITLE
Piano roll: keep the real curve's fill anchored to the canvas bottom

### DIFF
--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -262,17 +262,21 @@ namespace OpenUtau.App.Controls {
                             continue;
                         }
                         var geometry = new PathGeometry();
+                        // allinone: #2148 moved this fill's anchor from the canvas bottom to the
+                        // default-value line together with the new envelope fill. The envelope fill
+                        // is intended upstream behavior and stays; the real curve's own fill keeps
+                        // its pre-#2148 shape (curve down to the bottom of the canvas).
                         var figure = new PathFigure {
-                            IsClosed = true
+                            IsClosed = false
                         };
                         for (int i = start; i < end; ++i) {
                             float tick = curve.realXs[i];
                             float value = curve.realYs[i];
                             double x = viewModel.TickToneToPoint(tick, 0).X;
                             double y = Bounds.Height * (1 - value / 1000.0);
-                            
+
                             if (i == start) {
-                                figure.StartPoint = new Point(x, defaultHeight);
+                                figure.StartPoint = new Point(x, Bounds.Height);
                             }
                             figure.Segments!.Add(new LineSegment {
                                 Point = new Point(x, y),
@@ -280,7 +284,7 @@ namespace OpenUtau.App.Controls {
                             });
                             if (i == end - 1) {
                                 figure.Segments!.Add(new LineSegment {
-                                    Point = new Point(x, defaultHeight),
+                                    Point = new Point(x, Bounds.Height),
                                     IsStroked = false
                                 });
                             }

--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -262,10 +262,6 @@ namespace OpenUtau.App.Controls {
                             continue;
                         }
                         var geometry = new PathGeometry();
-                        // allinone: #2148 moved this fill's anchor from the canvas bottom to the
-                        // default-value line together with the new envelope fill. The envelope fill
-                        // is intended upstream behavior and stays; the real curve's own fill keeps
-                        // its pre-#2148 shape (curve down to the bottom of the canvas).
                         var figure = new PathFigure {
                             IsClosed = false
                         };


### PR DESCRIPTION
Follow-up to #2148.

#2148 introduced the expression display modes (`ExpDisMode`) and the new fill between the editable envelope curve and the default-value line — that behavior is intentional and **untouched** by this commit.

As a side effect of the same rework, the **real (rendered) curve's** fill also moved its anchor from the canvas bottom to the default-value line (`StartPoint`/`LineSegment` closing point changed from `Bounds.Height` to `defaultHeight`, `IsClosed` `false` → `true`). On DiffSinger tracks the actual-parameter fill therefore no longer shows the area under the curve; instead it reads as a band between the envelope/default line and the curve, which changes the meaning of `RealCurveFillBrush`.

This PR restores only the real curve's own pre-#2148 fill shape:

- real-curve figure starts and closes at `Bounds.Height` again, `IsClosed = false`
- the envelope fill, the value-rectangle opacity tiers (`overriden ? 0.20 : 0.10`) and `ExpDisMode` stay exactly as #2148 shipped them

No functional code paths besides the real-curve geometry are modified.