### PR TITLE
Output 0 instead of blank in Oto

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -527,29 +527,7 @@ namespace OpenUtau.Classic {
                         writer.Write('\n');
                         continue;
                     }
-                    writer.Write(oto.Wav);
-                    writer.Write('=');
-                    writer.Write(oto.Alias);
-                    writer.Write(',');
-                    if (oto.Offset != 0) {
-                        writer.Write(oto.Offset);
-                    }
-                    writer.Write(',');
-                    if (oto.Consonant != 0) {
-                        writer.Write(oto.Consonant);
-                    }
-                    writer.Write(',');
-                    if (oto.Cutoff != 0) {
-                        writer.Write(oto.Cutoff);
-                    }
-                    writer.Write(',');
-                    if (oto.Preutter != 0) {
-                        writer.Write(oto.Preutter);
-                    }
-                    writer.Write(',');
-                    if (oto.Overlap != 0) {
-                        writer.Write(oto.Overlap);
-                    }
+                    writer.Write($"{oto.Wav}={oto.Alias},{oto.Offset},{oto.Consonant},{oto.Cutoff},{oto.Preutter},{oto.Overlap}");
                     writer.Write('\n');
                 }
                 writer.Flush();

--- a/OpenUtau.Test/Classic/VoicebankLoaderTest.cs
+++ b/OpenUtau.Test/Classic/VoicebankLoaderTest.cs
@@ -24,17 +24,17 @@ aoieu.wav=i e,,100,150,,,
 aoieu.wav=e u,20,
 aoieu.wav=u R,5,,33,44,,
 ".Replace("\r\n", "\n");
-            string expected = @"a.wav=a,,,,,
-a.wav=- a,,,,,
-a.wav=a R,500,,,,
+            string expected = @"a.wav=a,0,0,0,0,0
+a.wav=- a,0,0,0,0,0
+a.wav=a R,500,0,0,0,0
 !@#$!@#$
-aoieu.wav=- a,,,,,
+aoieu.wav=- a,0,0,0,0,0
 
-aoieu.wav=a o,,,,,
-aoieu.wav=o i,,,,,
-aoieu.wav=i e,,100,150,,
-aoieu.wav=e u,20,,,,
-aoieu.wav=u R,5,,33,44,
+aoieu.wav=a o,0,0,0,0,0
+aoieu.wav=o i,0,0,0,0,0
+aoieu.wav=i e,0,100,150,0,0
+aoieu.wav=e u,20,0,0,0,0
+aoieu.wav=u R,5,0,33,44,0
 ".Replace("\r\n", "\n");
 
             using (MemoryStream stream = new MemoryStream(Encoding.ASCII.GetBytes(text))) {


### PR DESCRIPTION
In previous versions, when the parameter value is 0, a blank value is output instead, which can cause plugins and related tools to malfunction.
Since the original UTAU outputs 0 rather than a blank value, I believe OU should also output 0.