### PR TITLE
Fix for crashes when selecting a singer

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -134,6 +134,14 @@ namespace OpenUtau.Core.Util {
                         Default.PreferPortAudio = null;
                     }
                     Default.MigrateRealTimePitchMode();
+                    Default.RecentSingers = Default.RecentSingers?
+                        .Where(s => !string.IsNullOrWhiteSpace(s))
+                        .ToList()
+                        ?? new List<string>();
+                    Default.FavoriteSingers = Default.FavoriteSingers?
+                        .Where(s => !string.IsNullOrWhiteSpace(s))
+                        .ToList()
+                        ?? new List<string>();
                 } else {
                     Reset();
                 }

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -307,13 +307,13 @@ namespace OpenUtau.App.ViewModels {
 
                 if (allSingers.Count > 0) {
                     foreach (var id in Preferences.Default.RecentSingers) {
-                        if (allSingers.TryGetValue(id, out var singer) && singer != null) {
+                        if (!string.IsNullOrWhiteSpace(id) && allSingers.TryGetValue(id, out var singer) && singer != null) {
                             list.Add(CreateSingerMenuItem(singer));
                         }
                     }
                     var favList = new List<USinger>();
                     foreach (var id in Preferences.Default.FavoriteSingers) {
-                        if (allSingers.TryGetValue(id, out var singer) && singer != null) {
+                        if (!string.IsNullOrWhiteSpace(id) && allSingers.TryGetValue(id, out var singer) && singer != null) {
                             favList.Add(singer);
                         }
                     }


### PR DESCRIPTION
If, for some reason, the preferences contain a null value, the app will crash when you try to select a singer.