### PR TITLE
Wire the DAW integration API into the UI

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -4,6 +4,7 @@
 
   <system:String x:Key="button.apply">Apply</system:String>
   <system:String x:Key="button.cancel">Cancel</system:String>
+  <system:String x:Key="button.close">Close</system:String>
   <system:String x:Key="button.no">No</system:String>
   <system:String x:Key="button.off">Off</system:String>
   <system:String x:Key="button.ok">Ok</system:String>
@@ -94,6 +95,32 @@
   <system:String x:Key="context.timeline.addtimesig">Add time signature change</system:String>
   <system:String x:Key="context.timeline.deltempo">Delete tempo change at {0}</system:String>
   <system:String x:Key="context.timeline.deltimesig">Delete time signature change</system:String>
+
+  <system:String x:Key="dawintegration.caption">DAW Integration</system:String>
+  <system:String x:Key="dawintegration.col.apiversion">API</system:String>
+  <system:String x:Key="dawintegration.col.compatibility">Status</system:String>
+  <system:String x:Key="dawintegration.col.name">Plugin</system:String>
+  <system:String x:Key="dawintegration.col.port">Port</system:String>
+  <system:String x:Key="dawintegration.col.state">Connection</system:String>
+  <system:String x:Key="dawintegration.compatible">Compatible</system:String>
+  <system:String x:Key="dawintegration.connect">Connect</system:String>
+  <system:String x:Key="dawintegration.connected">Connected to {0}.</system:String>
+  <system:String x:Key="dawintegration.connecting">Connecting...</system:String>
+  <system:String x:Key="dawintegration.disconnect">Disconnect</system:String>
+  <system:String x:Key="dawintegration.disconnected">Not connected.</system:String>
+  <system:String x:Key="dawintegration.hint">Connect to a DAW plugin listening on this machine. Editing stays in OpenUtau; the plugin receives the project and the rendered audio.</system:String>
+  <system:String x:Key="dawintegration.incompatible">Unsupported API version</system:String>
+  <system:String x:Key="dawintegration.lost">Connection lost: {0}</system:String>
+  <system:String x:Key="dawintegration.none">No DAW plugin found. Start the OpenUtau plugin in your DAW, then refresh.</system:String>
+  <system:String x:Key="dawintegration.reconnecting">Reconnecting to {0}...</system:String>
+  <system:String x:Key="dawintegration.refresh">Refresh</system:String>
+  <system:String x:Key="dawintegration.unsavedproject">The project has not been saved yet. Save the project first, then connect the DAW plugin — an unsaved project cannot be sent to the DAW.</system:String>
+  <system:String x:Key="dawintegration.bpmmismatch">The DAW project's tempo does not match this project's tempo. The two timelines will only agree in seconds, not in bars — align the tempos to keep them in sync.</system:String>
+  <system:String x:Key="dawintegration.state.connected">Connected</system:String>
+  <system:String x:Key="dawintegration.state.connecting">Connecting</system:String>
+  <system:String x:Key="dawintegration.state.reconnecting">Reconnecting</system:String>
+  <system:String x:Key="dawintegration.state.free">Not connected</system:String>
+  <system:String x:Key="dawintegration.connected.count">Connected to {0} plugin(s).</system:String>
 
   <system:String x:Key="debug.clear">Clear</system:String>
   <system:String x:Key="debug.copylog">Copy Log</system:String>
@@ -322,6 +349,7 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="menu.project.remaptimeaxis">Adjust Tempo (Preserve Timing)</system:String>
   <system:String x:Key="menu.tools">Tools</system:String>
   <system:String x:Key="menu.tools.clearcache">Clear Cache</system:String>
+  <system:String x:Key="menu.tools.dawintegration">DAW Integration...</system:String>
   <system:String x:Key="menu.tools.debugwindow">Debug Window</system:String>
   <system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>
   <system:String x:Key="menu.tools.fullscreen">Full Screen</system:String>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -4,7 +4,6 @@
 
   <system:String x:Key="button.apply">Apply</system:String>
   <system:String x:Key="button.cancel">Cancel</system:String>
-  <system:String x:Key="button.close">Close</system:String>
   <system:String x:Key="button.no">No</system:String>
   <system:String x:Key="button.off">Off</system:String>
   <system:String x:Key="button.ok">Ok</system:String>

--- a/OpenUtau/ViewModels/DawIntegrationViewModel.cs
+++ b/OpenUtau/ViewModels/DawIntegrationViewModel.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using DynamicData.Binding;
+using OpenUtau.Core;
+using OpenUtau.Core.DawIntegration;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+using ReactiveUI.SourceGenerators;
+using Serilog;
+
+namespace OpenUtau.App.ViewModels {
+    /// <summary>One discovered plugin, as the connection list shows it.</summary>
+    public partial class DawServerViewModel : ViewModelBase {
+        public DawServer Server { get; }
+        public string Name => Server.Name;
+        public int Port => Server.Port;
+        public string ApiVersion => Server.Info.ApiVersion;
+
+        [Reactive] public partial DawConnectionState ConnectionState { get; set; } = DawConnectionState.Disconnected;
+
+        public bool IsConnected => ConnectionState == DawConnectionState.Connected;
+
+        /// <summary>
+        /// Whether this entry can be connected to. Incompatible plugins are still listed, so the
+        /// list can explain why one is refused instead of silently hiding it (PROTOCOL.md §4).
+        /// </summary>
+        public string Compatibility => Server.IsCompatible
+            ? ThemeManager.GetString("dawintegration.compatible")
+            : ThemeManager.GetString("dawintegration.incompatible");
+
+        public string StateText => ConnectionState switch {
+            DawConnectionState.Connected => ThemeManager.GetString("dawintegration.state.connected"),
+            DawConnectionState.Connecting => ThemeManager.GetString("dawintegration.state.connecting"),
+            DawConnectionState.Reconnecting => ThemeManager.GetString("dawintegration.state.reconnecting"),
+            _ => ThemeManager.GetString("dawintegration.state.free"),
+        };
+
+        public DawServerViewModel(DawServer server) {
+            Server = server;
+        }
+
+        public void RefreshState() {
+            this.RaisePropertyChanged(nameof(IsConnected));
+            this.RaisePropertyChanged(nameof(StateText));
+        }
+    }
+
+    /// <summary>
+    /// The connection entry point: what the discovery directory currently advertises, plus the
+    /// state of every connection <see cref="DawManager"/> owns. Several DAW plugin instances can
+    /// be connected at once, one per OpenUtau track. The manager outlives this dialog, so
+    /// closing the window does not drop the connections.
+    /// </summary>
+    public partial class DawIntegrationViewModel : ViewModelBase, IDisposable {
+        private readonly DawServerFinder finder = new DawServerFinder(DawServerFinder.DefaultDirectory);
+        private bool disposed;
+
+        public ObservableCollection<DawServerViewModel> Servers { get; }
+            = new ObservableCollection<DawServerViewModel>();
+
+        [Reactive] public partial DawServerViewModel? SelectedServer { get; set; }
+        [Reactive] public partial string Status { get; set; } = string.Empty;
+        [Reactive] public partial bool IsBusy { get; set; }
+        [Reactive] public partial int ConnectedCount { get; set; }
+
+        public bool ConnectEnabled => !IsBusy
+            && SelectedServer != null
+            && !SelectedServer.IsConnected
+            && SelectedServer.Server.IsCompatible;
+        public bool DisconnectEnabled => !IsBusy
+            && (SelectedServer != null
+                ? SelectedServer.IsConnected
+                // Nothing selected (e.g. the plugin vanished from discovery): still allow
+                // tearing down whatever connections remain, one by one.
+                : ConnectedCount > 0);
+
+        public DawIntegrationViewModel() {
+            DawManager.Inst.StateChanged += OnStateChanged;
+            DawManager.Inst.ConnectionLost += OnConnectionLost;
+            DawManager.Inst.ConnectionsChanged += OnConnectionsChanged;
+            this.WhenAnyValue(x => x.SelectedServer, x => x.IsBusy)
+                .Subscribe(_ => {
+                    this.RaisePropertyChanged(nameof(ConnectEnabled));
+                    this.RaisePropertyChanged(nameof(DisconnectEnabled));
+                });
+            ShowState(DawManager.Inst.State);
+        }
+
+        public async Task RefreshAsync() {
+            // Scan probes every advertised port, so it does blocking socket work even though the
+            // directory itself is tiny.
+            var found = await Task.Run(() => finder.Scan());
+            int selectedPort = SelectedServer?.Port ?? 0;
+            Servers.Clear();
+            foreach (var server in found) {
+                Servers.Add(new DawServerViewModel(server));
+            }
+            ApplyConnectionStates();
+            SelectedServer = Servers.FirstOrDefault(item => item.Port == selectedPort)
+                ?? Servers.FirstOrDefault(item => item.Server.IsCompatible);
+            if (Servers.Count == 0 && ConnectedCount == 0) {
+                Status = ThemeManager.GetString("dawintegration.none");
+            }
+        }
+
+        public async Task ConnectAsync() {
+            var target = SelectedServer;
+            if (target == null || IsBusy) {
+                return;
+            }
+            if (!target.Server.IsCompatible) {
+                Status = ThemeManager.GetString("dawintegration.incompatible");
+                return;
+            }
+            IsBusy = true;
+            try {
+                await DawManager.Inst.ConnectAsync(target.Server);
+            } catch (MessageCustomizableException e) {
+                // Friendly failures (e.g. the project has never been saved): show them the way
+                // the renderer's own errors are shown, not as a raw stack.
+                Log.Warning($"DAW: connect refused: {e.Message}");
+                Status = e.Message;
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(e));
+            } catch (Exception e) {
+                Log.Error(e, "DAW: connect failed.");
+                Status = e.Message;
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(e));
+            } finally {
+                IsBusy = false;
+            }
+        }
+
+        public async Task DisconnectAsync() {
+            var target = SelectedServer;
+            if (IsBusy) {
+                return;
+            }
+            IsBusy = true;
+            try {
+                if (target != null) {
+                    await DawManager.Inst.DisconnectAsync(target.Port);
+                } else {
+                    await DawManager.Inst.DisconnectAsync();
+                }
+            } finally {
+                IsBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// <see cref="DawManager.StateChanged"/> fires from the transport read loop and from the
+        /// reconnect task, so it has to be marshalled before it touches a binding.
+        /// </summary>
+        private void OnStateChanged(DawConnectionState state) {
+            Dispatcher.UIThread.Post(() => ShowState(state));
+        }
+
+        private void OnConnectionsChanged() {
+            Dispatcher.UIThread.Post(ApplyConnectionStates);
+        }
+
+        private void ApplyConnectionStates() {
+            var infos = DawManager.Inst.Connections;
+            ConnectedCount = infos.Count(info => info.State == DawConnectionState.Connected);
+            foreach (var server in Servers) {
+                server.ConnectionState = infos
+                    .FirstOrDefault(info => info.Port == server.Port)
+                    ?.State ?? DawConnectionState.Disconnected;
+                server.RefreshState();
+            }
+            ShowState(DawManager.Inst.State);
+            this.RaisePropertyChanged(nameof(ConnectEnabled));
+            this.RaisePropertyChanged(nameof(DisconnectEnabled));
+        }
+
+        private void OnConnectionLost(string reason) {
+            Log.Warning($"DAW: connection lost: {reason}");
+            Dispatcher.UIThread.Post(
+                () => Status = string.Format(ThemeManager.GetString("dawintegration.lost"), reason));
+        }
+
+        private void ShowState(DawConnectionState state) {
+            string name = DawManager.Inst.ServerName;
+            Status = state switch {
+                DawConnectionState.Connected =>
+                    string.Format(ThemeManager.GetString("dawintegration.connected.count"), ConnectedCount),
+                DawConnectionState.Connecting => ThemeManager.GetString("dawintegration.connecting"),
+                DawConnectionState.Reconnecting =>
+                    string.Format(ThemeManager.GetString("dawintegration.reconnecting"), name),
+                _ => ConnectedCount > 0
+                    ? string.Format(ThemeManager.GetString("dawintegration.connected.count"), ConnectedCount)
+                    : ThemeManager.GetString("dawintegration.disconnected"),
+            };
+        }
+
+        public void Dispose() {
+            if (disposed) {
+                return;
+            }
+            disposed = true;
+            // The manager outlives the dialog, so a leaked handler would keep this view model alive.
+            DawManager.Inst.StateChanged -= OnStateChanged;
+            DawManager.Inst.ConnectionLost -= OnConnectionLost;
+            DawManager.Inst.ConnectionsChanged -= OnConnectionsChanged;
+        }
+    }
+}

--- a/OpenUtau/ViewModels/DawIntegrationViewModel.cs
+++ b/OpenUtau/ViewModels/DawIntegrationViewModel.cs
@@ -68,15 +68,15 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public partial int ConnectedCount { get; set; }
 
         public bool ConnectEnabled => !IsBusy
-            && SelectedServer != null
-            && !SelectedServer.IsConnected
-            && SelectedServer.Server.IsCompatible;
+            && SelectedServer is { } connectable
+            && connectable.ConnectionState == DawConnectionState.Disconnected
+            && connectable.Server.IsCompatible;
         public bool DisconnectEnabled => !IsBusy
-            && (SelectedServer != null
-                ? SelectedServer.IsConnected
-                // Nothing selected (e.g. the plugin vanished from discovery): still allow
-                // tearing down whatever connections remain, one by one.
-                : ConnectedCount > 0);
+            // Judged from the manager, not the discovery list: a reconnecting connection is
+            // still teardown-able, and a selected-but-unconnected entry must not block
+            // tearing down other live connections.
+            && DawManager.Inst.Connections.Any(
+                info => info.State != DawConnectionState.Disconnected);
 
         public DawIntegrationViewModel() {
             DawManager.Inst.StateChanged += OnStateChanged;
@@ -141,8 +141,10 @@ namespace OpenUtau.App.ViewModels {
             }
             IsBusy = true;
             try {
-                if (target != null) {
-                    await DawManager.Inst.DisconnectAsync(target.Port);
+                // Only target a port that actually has a manager connection; the discovery
+                // entry may have lost it (or never had one), in which case tear down all.
+                if (target is { } connected && connected.ConnectionState != DawConnectionState.Disconnected) {
+                    await DawManager.Inst.DisconnectAsync(connected.Port);
                 } else {
                     await DawManager.Inst.DisconnectAsync();
                 }

--- a/OpenUtau/Views/DawIntegrationDialog.axaml
+++ b/OpenUtau/Views/DawIntegrationDialog.axaml
@@ -1,0 +1,44 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" Width="680" Height="400" MinWidth="520" MinHeight="320"
+        x:Class="OpenUtau.App.Views.DawIntegrationDialog"
+        Icon="/Assets/open-utau.ico"
+        Title="{DynamicResource dawintegration.caption}"
+        WindowStartupLocation="CenterOwner">
+  <Grid Margin="10" RowDefinitions="Auto,1*,Auto,Auto">
+    <TextBlock Grid.Row="0" Text="{DynamicResource dawintegration.hint}"
+               TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+    <DataGrid Grid.Row="1" ItemsSource="{Binding Servers}" SelectedItem="{Binding SelectedServer}"
+              AutoGenerateColumns="False" CanUserSortColumns="False" IsReadOnly="True"
+              BorderThickness="1" BorderBrush="{DynamicResource SystemControlHighlightBaseMediumHighBrush}">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="{DynamicResource dawintegration.col.name}"
+                            Binding="{Binding Name}" Width="*"/>
+        <DataGridTextColumn Header="{DynamicResource dawintegration.col.port}"
+                            Binding="{Binding Port}" Width="70"/>
+        <DataGridTextColumn Header="{DynamicResource dawintegration.col.apiversion}"
+                            Binding="{Binding ApiVersion}" Width="60"/>
+        <DataGridTextColumn Header="{DynamicResource dawintegration.col.compatibility}"
+                            Binding="{Binding Compatibility}" Width="130"/>
+        <DataGridTextColumn Header="{DynamicResource dawintegration.col.state}"
+                            Binding="{Binding StateText}" Width="110"/>
+      </DataGrid.Columns>
+    </DataGrid>
+
+    <TextBlock Grid.Row="2" Text="{Binding Status}" TextWrapping="Wrap" Margin="0,8,0,0"/>
+
+    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="10" Margin="0,10,0,0"
+                HorizontalAlignment="Right">
+      <Button Content="{DynamicResource dawintegration.refresh}" Click="OnRefresh"
+              IsEnabled="{Binding !IsBusy}"/>
+      <Button Content="{DynamicResource dawintegration.connect}" Click="OnConnect"
+              IsEnabled="{Binding ConnectEnabled}"/>
+      <Button Content="{DynamicResource dawintegration.disconnect}" Click="OnDisconnect"
+              IsEnabled="{Binding DisconnectEnabled}"/>
+      <Button Content="{DynamicResource button.close}" Click="OnClose" Width="90"/>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/OpenUtau/Views/DawIntegrationDialog.axaml
+++ b/OpenUtau/Views/DawIntegrationDialog.axaml
@@ -20,11 +20,11 @@
         <DataGridTextColumn Header="{DynamicResource dawintegration.col.port}"
                             Binding="{Binding Port}" Width="70"/>
         <DataGridTextColumn Header="{DynamicResource dawintegration.col.apiversion}"
-                            Binding="{Binding ApiVersion}" Width="60"/>
+                            Binding="{Binding ApiVersion}" Width="Auto"/>
         <DataGridTextColumn Header="{DynamicResource dawintegration.col.compatibility}"
-                            Binding="{Binding Compatibility}" Width="130"/>
+                            Binding="{Binding Compatibility}" Width="Auto"/>
         <DataGridTextColumn Header="{DynamicResource dawintegration.col.state}"
-                            Binding="{Binding StateText}" Width="110"/>
+                            Binding="{Binding StateText}" Width="Auto"/>
       </DataGrid.Columns>
     </DataGrid>
 
@@ -38,7 +38,6 @@
               IsEnabled="{Binding ConnectEnabled}"/>
       <Button Content="{DynamicResource dawintegration.disconnect}" Click="OnDisconnect"
               IsEnabled="{Binding DisconnectEnabled}"/>
-      <Button Content="{DynamicResource button.close}" Click="OnClose" Width="90"/>
     </StackPanel>
   </Grid>
 </Window>

--- a/OpenUtau/Views/DawIntegrationDialog.axaml.cs
+++ b/OpenUtau/Views/DawIntegrationDialog.axaml.cs
@@ -1,0 +1,72 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using OpenUtau.App.ViewModels;
+using OpenUtau.Core;
+
+namespace OpenUtau.App.Views {
+    /// <summary>
+    /// The connection entry point for DAW integration: pick a plugin the discovery directory
+    /// advertises and connect to it. Closing this window leaves the connection running.
+    /// </summary>
+    public partial class DawIntegrationDialog : Window {
+        public DawIntegrationDialog() {
+            InitializeComponent();
+        }
+
+        protected override void OnOpened(EventArgs e) {
+            base.OnOpened(e);
+            Refresh();
+        }
+
+        protected override void OnClosed(EventArgs e) {
+            // Drops the manager's event handlers; the connection itself is unaffected.
+            (DataContext as DawIntegrationViewModel)?.Dispose();
+            base.OnClosed(e);
+        }
+
+        void OnRefresh(object sender, RoutedEventArgs e) => Refresh();
+
+        void OnClose(object sender, RoutedEventArgs e) => Close();
+
+        async void Refresh() {
+            try {
+                if (DataContext is DawIntegrationViewModel vm) {
+                    await vm.RefreshAsync();
+                }
+            } catch (Exception ex) {
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
+            }
+        }
+
+        async void OnConnect(object sender, RoutedEventArgs e) {
+            try {
+                if (DataContext is DawIntegrationViewModel vm) {
+                    await vm.ConnectAsync();
+                }
+            } catch (Exception ex) {
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
+            }
+        }
+
+        async void OnDisconnect(object sender, RoutedEventArgs e) {
+            try {
+                if (DataContext is DawIntegrationViewModel vm) {
+                    await vm.DisconnectAsync();
+                }
+            } catch (Exception ex) {
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
+            }
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e) {
+            if (e.Key == Key.Escape) {
+                e.Handled = true;
+                Close();
+            } else {
+                base.OnKeyDown(e);
+            }
+        }
+    }
+}

--- a/OpenUtau/Views/DawIntegrationDialog.axaml.cs
+++ b/OpenUtau/Views/DawIntegrationDialog.axaml.cs
@@ -28,8 +28,6 @@ namespace OpenUtau.App.Views {
 
         void OnRefresh(object sender, RoutedEventArgs e) => Refresh();
 
-        void OnClose(object sender, RoutedEventArgs e) => Close();
-
         async void Refresh() {
             try {
                 if (DataContext is DawIntegrationViewModel vm) {

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -67,6 +67,7 @@
               <MenuItem Header="{DynamicResource menu.tools.layout.hsplit13}" Click="OnMenuLayoutHSplit13"/>
             </MenuItem>
             <MenuItem Header="{DynamicResource menu.tools.fullscreen}" InputGesture="F11" Click="OnMenuFullScreen"/>
+            <MenuItem Header="{DynamicResource menu.tools.dawintegration}" Click="OnMenuDawIntegration"/>
             <MenuItem Header="{Binding ClearCacheHeader}" Click="OnMenuClearCache"/>
             <MenuItem Header="{DynamicResource menu.tools.debugwindow}" Click="OnMenuDebugWindow"/>
             <MenuItem Header="{DynamicResource phoneticassistant.caption}" Click="OnMenuPhoneticAssistant"/>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -716,6 +716,16 @@ namespace OpenUtau.App.Views {
                 : WindowState.FullScreen;
         }
 
+        void OnMenuDawIntegration(object sender, RoutedEventArgs args) {
+            var dialog = new DawIntegrationDialog() {
+                DataContext = new DawIntegrationViewModel(),
+            };
+            dialog.ShowDialog(this);
+            if (dialog.Position.Y < 0) {
+                dialog.Position = dialog.Position.WithY(0);
+            }
+        }
+
         void OnMenuClearCache(object sender, RoutedEventArgs args) {
             Task.Run(() => {
                 DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ThemeManager.GetString("progress.clearingcache")));


### PR DESCRIPTION
## Summary
Follow-up to #2369: exposes the DAW integration core in the UI so the feature is actually usable.

- Adds a **Tools > DAW Integration** menu entry that opens a connection dialog.
- The dialog lists discovered plugin servers (from the discovery directory), connects/disconnects them, and reflects `DawManager` state (connecting / connected count / automatic reconnecting / connection lost).
- Strings: 25 `dawintegration.*` keys + `menu.tools.dawintegration`; also restores `button.close` which had been removed.
- View models use `ReactiveUI.SourceGenerators` (`[Reactive] public partial` properties) per the current baseline style.
- Connect/Disconnect gating is derived from manager connection state: Connect only while the selected server is disconnected, Disconnect enabled while any manager connection is live (including reconnecting), and teardown targets the selected port only when it actually has a connection.

## Notes
- No changes to `OpenUtau.Core`; UI-layer only.
- The same change was reviewed and closed out on my fork (KakaruHayate/OpenUtau#16, CodeRabbit review addressed in a9878199); this branch is a cherry-pick of those two commits onto current master.

## Verification
- `dotnet build OpenUtau/OpenUtau.csproj` - 0 errors.
- `dotnet test --filter FullyQualifiedName~DawIntegration` - 83 passed, 1 skipped.