### PR TITLE
Fix Singer Selector Errors

### DIFF
--- a/OpenUtau/Controls/TrackHeader.axaml.cs
+++ b/OpenUtau/Controls/TrackHeader.axaml.cs
@@ -109,13 +109,13 @@ namespace OpenUtau.App.Controls {
 
         async void SingerButtonClicked(object sender, RoutedEventArgs args) {
             args.Handled = true;
-            if (SingerManager.Inst.Singers.Count > 0) {
+            try {
                 if (ViewModel != null) {
                     await ViewModel.RefreshSingersAsync();
                 }
                 SingersMenu.Open();
-            } else {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("There is no singer."));
+            } catch (Exception e) {
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(e));
             }
         }
 

--- a/OpenUtau/ViewModels/MenuItemViewModel.cs
+++ b/OpenUtau/ViewModels/MenuItemViewModel.cs
@@ -41,6 +41,7 @@ namespace OpenUtau.App.ViewModels {
             set {
                 if (CommandParameter is USinger singer) {
                     singer.IsFavourite = value;
+                    TrackHeaderViewModel.InvalidateSingerMenuCache();
                 }
             }
         }

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Media;
@@ -262,6 +262,7 @@ namespace OpenUtau.App.ViewModels {
                     Preferences.Default.RecentSingers.RemoveRange(
                         16, Preferences.Default.RecentSingers.Count - 16);
                 }
+                InvalidateSingerMenuCache();
             }
         }
 
@@ -293,16 +294,15 @@ namespace OpenUtau.App.ViewModels {
             singersMenuDirty = true;
         }
 
-        public async System.Threading.Tasks.Task RefreshSingersAsync() {
+        public async Task RefreshSingersAsync() {
             // Skip rebuild if cache is still valid
             if (!singersMenuDirty && SingerMenuItems != null && SingerMenuItems.Count > 0) {
                 return;
             }
-
             var allSingers = SingerManager.Inst.Singers;
 
             // Move the menu tree creation off the UI thread
-            var items = await System.Threading.Tasks.Task.Run(() => {
+            var items = await Task.Run(() => {
                 var list = new List<MenuItemViewModel>();
 
                 if (allSingers.Count > 0) {


### PR DESCRIPTION
Fixed bugs that occurred in #2348:
- Fixed bug where singer selector menu did not open and displayed an error dialog when no singers exist. Even when there are no singers, this menu will now be displayed, allowing users to manually copy or reload singers.
- Fixed bug where Recent Singers list was not refreshed when a singer was selected, causing the same singer to appear again next time.
- Fixed bug where Favorite Singers list was not refreshed when a singer was favorited, causing the same singer to appear again next time.