### PR TITLE
Add scroll wheel functionality to BPM controls

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -232,7 +232,7 @@
                   </TextBlock.Text>
                 </TextBlock>
                 <TextBlock Width="42" HorizontalAlignment="Right"
-                            Background="Transparent" PointerPressed="OnEditBpm">
+                            Background="Transparent" PointerPressed="OnEditBpm" PointerWheelChanged="OnEditBpmScroll">
                   <TextBlock.Text>
                     <MultiBinding StringFormat="{}{0:#0.00}">
                       <Binding Path="PlaybackViewModel.Bpm"/>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -144,6 +144,11 @@ namespace OpenUtau.App.Views {
             var dialog = new TypeInDialog();
             dialog.Title = "BPM";
             dialog.SetText(project.tempos[0].bpm.ToString());
+            dialog.TextBox.AddHandler(PointerWheelChangedEvent, (s, e) => {
+                if (double.TryParse(dialog.TextBox.Text, out double bpm)) {
+                    dialog.SetText(HandleBpmScroll(bpm, e).ToString());
+                }
+            });
             dialog.onFinish = s => {
                 if (double.TryParse(s, out double bpm)) {
                     viewModel.PlaybackViewModel.SetBpm(bpm);
@@ -154,12 +159,51 @@ namespace OpenUtau.App.Views {
             args.Pointer.Capture(null);
         }
 
+        void OnEditBpmScroll(object sender, PointerWheelEventArgs args) {
+            if (!viewModel.PlaybackViewModel.IsPlaying) viewModel.PlaybackViewModel.SetBpm(HandleBpmScroll(viewModel.PlaybackViewModel.Bpm, args));
+        }
+
+        private double HandleBpmScroll(double bpm, PointerWheelEventArgs args, int decimals = 2) {
+            var multiplier = 1f;
+
+            if (args.KeyModifiers != KeyModifiers.None) {
+                if (args.KeyModifiers.HasFlag(KeyModifiers.Shift)) {
+                    multiplier *= 2f;
+                }
+
+                if (args.KeyModifiers.HasFlag(KeyModifiers.Control)) {
+                    multiplier *= 0.1f;
+                } else if (args.KeyModifiers.HasFlag(KeyModifiers.Alt)) {
+                    multiplier *= 0.01f;
+                }
+            } else {
+                multiplier = 1f;
+            }
+
+            if (args.Delta.Y > 0) {
+                bpm += multiplier;
+            } else if (args.Delta.Y < 0) {
+                bpm -= multiplier;
+            }
+
+            if (decimals != -1) {
+                bpm = double.Round(bpm, decimals);
+            }
+
+            return bpm;
+        }
+        
         private void AddTempoChange(int tick) {
             var project = DocManager.Inst.Project;
             var dialog = new TypeInDialog {
                 Title = "BPM"
             };
             dialog.SetText(project.tempos[0].bpm.ToString());
+            dialog.TextBox.AddHandler(PointerWheelChangedEvent, (s, e) => {
+                if (double.TryParse(dialog.TextBox.Text, out double bpm)) {
+                    dialog.SetText(HandleBpmScroll(bpm, e).ToString());
+                }
+            });
             dialog.onFinish = s => {
                 if (double.TryParse(s, out double bpm)) {
                     DocManager.Inst.StartUndoGroup("command.project.tempo");


### PR DESCRIPTION
# Summary
Adds scroll functionality to the BPM textbox in Main Window and BPM Dialog Boxes.

# Details
Hover over the BPM control in the Main Window, or the BPM textbox in Dialog Boxes.
Scroll up to raise the BPM, scroll down to lower the BPM.
Holding Shift doubles scroll modifier, while holding Control changes modifier by 0.1, and holding Alt changes modifier by 0.01. 

Using the scroll wheel to change the BPM will round the BPM to two decimal places to fix floating point precision.
Scroll wheel will disable when song is playing.