### PR TITLE
DiffSinger: don't write PITD points for unvoiced padding and gap frames

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -126,6 +126,9 @@ namespace OpenUtau.Core.DiffSinger
             var tokens = segments.Select(x => (Int64)PhonemeTokenize(x.Phoneme)).ToArray();
             var ph_dur = DiffSingerUtils.PaddedPhoneDurations(phrase, frameMs, headFrames, tailFrames);
             int totalFrames = ph_dur.Sum();
+            // Head/tail padding and inter-phoneme gaps are silence: whatever the
+            // pitch model emits for those frames must not become curve points.
+            var voicedFrames = DiffSingerUtils.PaddedVoicedMask(segments, ph_dur);
             linguisticInputs.Add(NamedOnnxValue.CreateFromTensor("tokens",
                 new DenseTensor<Int64>(tokens, new int[] { tokens.Length }, false)
                 .Reshape(new int[] { 1, tokens.Length })));
@@ -330,6 +333,9 @@ namespace OpenUtau.Core.DiffSinger
                     .ToArray(),
                     tones = pitch_out.Append(pitch_out[^1]).ToArray(),
                     retakeMask = retakeNoteIndexes != null ? retake.Append(retake[^1]).ToArray() : null,
+                    voiced = voicedFrames.Length > 0
+                        ? voicedFrames.Append(voicedFrames[^1]).ToArray()
+                        : voicedFrames,
                 };
             }else{
                 return new RenderPitchResult{
@@ -338,6 +344,7 @@ namespace OpenUtau.Core.DiffSinger
                     .ToArray(),
                     tones = pitch_out,
                     retakeMask = retakeNoteIndexes != null ? retake : null,
+                    voiced = voicedFrames,
                 };
             }
         }

--- a/OpenUtau.Core/DiffSinger/DiffSingerUtils.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerUtils.cs
@@ -90,6 +90,30 @@ namespace OpenUtau.Core.DiffSinger {
                 frameMs);
         }
 
+        /// <summary>
+        /// Per-frame voiced flag for the padded frame layout. Segments that are
+        /// not real phonemes (head "SP", inter-phoneme gap "SP", tail "SP") are
+        /// unvoiced: the pitch model has no ground truth there, and any value it
+        /// returns for those frames is an artifact rather than a curve to follow.
+        /// </summary>
+        public static bool[] PaddedVoicedMask(
+            IReadOnlyList<(string Phoneme, double DurationMs, int PhoneIndex)> segments,
+            IReadOnlyList<int> durations) {
+            int totalFrames = 0;
+            for (int i = 0; i < durations.Count; ++i) {
+                totalFrames += durations[i];
+            }
+            var mask = new bool[totalFrames];
+            int frame = 0;
+            for (int i = 0; i < segments.Count && i < durations.Count; ++i) {
+                bool voiced = segments[i].PhoneIndex >= 0;
+                for (int f = 0; f < durations[i] && frame < mask.Length; ++f) {
+                    mask[frame++] = voiced;
+                }
+            }
+            return mask;
+        }
+
         public static long[] PaddedLanguageIds(
             RenderPhrase phrase, double frameMs, int headFrames, int tailFrames, Func<string, long> langIdByPhoneme) {
             return PaddedSegments(phrase, frameMs, headFrames, tailFrames)

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -526,6 +526,12 @@ namespace OpenUtau.Core.Editing {
                         if (result.tones[i] < 0) {
                             continue;
                         }
+                        // Padding and inter-phoneme gap frames are silence: the
+                        // pitch model's output there is an artifact, and writing
+                        // it back produces a spike at the phrase/gap boundary.
+                        if (result.voiced != null && i < result.voiced.Length && !result.voiced[i]) {
+                            continue;
+                        }
                         int x = phrase.position - part.position + (int)result.ticks[i];
                         if (result.ticks[i] < 0) {
                             if (i + 1 < result.ticks.Length && result.ticks[i + 1] > 0) { } else

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -49,6 +49,15 @@ namespace OpenUtau.Core.Render {
         /// Per-frame mask indicating retaken frames. Null means full retake.
         /// </summary>
         public bool[]? retakeMask;
+
+        /// <summary>
+        /// Per-frame flag: true when the frame belongs to a voiced segment.
+        /// Padding and inter-phoneme gap frames carry no meaningful pitch even
+        /// when the model returns a positive value for them, so callers must
+        /// not turn those frames into curve points. Null means every frame is
+        /// voiced (renderers that do not report rests).
+        /// </summary>
+        public bool[]? voiced;
     }
 
     public class RenderRealCurveResult {

--- a/OpenUtau.Test/Core/DiffSinger/LoadRenderedPitchTest.cs
+++ b/OpenUtau.Test/Core/DiffSinger/LoadRenderedPitchTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -34,6 +35,63 @@ namespace OpenUtau.Core.DiffSinger {
                 new[] { false, false, false }, 3).ToArray();
 
             Assert.Empty(ranges);
+        }
+
+        [Fact]
+        public void PaddedVoicedMask_MarksOnlyRealPhonemes() {
+            // head SP, "a" (2 frames), "i" (1 frame), tail SP
+            var segments = new List<(string, double, int)> {
+                ("SP", 0, -1), ("a", 0, 0), ("i", 0, 1), ("SP", 0, -1),
+            };
+            var durations = new[] { 2, 3, 2, 2 };
+
+            var mask = DiffSingerUtils.PaddedVoicedMask(segments, durations);
+
+            Assert.Equal(
+                new[] { false, false, true, true, true, true, true, false, false },
+                mask);
+        }
+
+        [Fact]
+        public void PaddedVoicedMask_MarksInterPhonemeGapAsUnvoiced() {
+            // Merged phrase: head SP, "a", gap SP, "i", tail SP.
+            var segments = new List<(string, double, int)> {
+                ("SP", 0, -1), ("a", 0, 0), ("SP", 0, -1), ("i", 0, 1), ("SP", 0, -1),
+            };
+            var durations = new[] { 2, 4, 3, 4, 2 };
+
+            var mask = DiffSingerUtils.PaddedVoicedMask(segments, durations);
+
+            // Frames 6..8 are the inter-phoneme gap and must not be voiced.
+            Assert.Equal(
+                new[] {
+                    false, false,
+                    true, true, true, true,
+                    false, false, false,
+                    true, true, true, true,
+                    false, false,
+                },
+                mask);
+        }
+
+        [Fact]
+        public void PaddedVoicedMask_ZeroDurationSegmentsAreDropped() {
+            var segments = new List<(string, double, int)> {
+                ("SP", 0, -1), ("a", 0, 0), ("SP", 0, -1),
+            };
+            var durations = new[] { 2, 3, 0 };
+
+            var mask = DiffSingerUtils.PaddedVoicedMask(segments, durations);
+
+            Assert.Equal(new[] { false, false, true, true, true }, mask);
+        }
+
+        [Fact]
+        public void PaddedVoicedMask_EmptyDurationsReturnsEmptyMask() {
+            var mask = DiffSingerUtils.PaddedVoicedMask(
+                new List<(string, double, int)>(), new int[0]);
+
+            Assert.Empty(mask);
         }
     }
 }


### PR DESCRIPTION
## Problem

When phrase merging bridges two notes separated by a short rest, that rest becomes an `SP` segment inside one merged phrase. The pitch predictor still produces pitch values for those frames, and `NoteBatchEdits.LoadRenderedPitch` wrote every frame with `tones[i] >= 0` back into the PITD curve.

Those frames were converted with `y = tones[i] * 100 - phrase.pitchesBeforeDeviation[...]`. In the gap that baseline holds the **following** note's pitch: `RenderPhrase`'s flat pitch fill only tests `note.End` and never resets its index per note, so the gap is filled with the next note's tone. The model, meanwhile, is still ramping up from the previous note. So the written deviation is off by the interval between the two notes, and it lands right at the end of the previous note.

Measured on a merged two-note phrase — note A 62 semitones ending at tick 270, note B 69 semitones starting at tick 420, 150 tick rest:

| frame | tick | model tones | voiced | baseline | written y |
|---|---|---|---|---|---|
| 31 | 256 | 61.827 | yes | 6200 | -17 |
| 32 | 267 | 61.838 | yes | 6200 | -16 |
| 33 | 279 | 62.232 | **no** | **6900** | **-676** |
| 40 | 357 | 66.636 | no | 6900 | -236 |
| 44 | 401 | 68.967 | no | 6900 | -3 |
| 46 | 424 | 69.208 | yes | 6900 | +20 |

The gap frames were written at up to **-676 cents (6.7 semitones)** below the note, which draws a near-vertical spike at the end of the previous note.

## Fix

Do not decide whether a frame should be written from the sign of the model output. `PaddedSegments` already distinguishes real phonemes from padding and gap `SP` segments via `PhoneIndex == -1`; that information just never left the pitch predictor.

- `IRenderer.cs` — add `bool[]? voiced` to `RenderPitchResult`. `null` means "every frame is voiced", so renderers that do not report rests (Classic, Enunu) keep their behaviour.
- `DiffSingerUtils.cs` — add `PaddedVoicedMask(segments, durations)`, expanding `PhoneIndex >= 0` to one flag per frame. Its length equals `ph_dur.Sum()`, the frame layout `tones`/`ticks` use, and `DurationsMsToFrames` emits exactly one entry per input segment, so the indices stay aligned.
- `DiffSingerPitch.cs` — compute the mask and return it from both branches.
- `NoteBatchEdits.cs` — skip unvoiced frames when writing the curve.

Head and tail padding are unvoiced too, so they no longer overwrite the region just outside the phrase.

`lastX`/`lastY` are deliberately kept across a skipped run: `UCurve.Set` takes the `DeleteBetweenExclusive(lastX, x)` path when `x > lastX`, so the first voiced frame after a gap removes the points previously written inside that gap and then spans it. Clearing them would take the `x == lastX` branch, which only inserts a point and samples the existing curve — leaving any stale gap points in place. This was raised in review on the fork and left as is for that reason.

## Tests

Four cases in `OpenUtau.Test/Core/DiffSinger/LoadRenderedPitchTest.cs`: a plain phrase, a merged phrase with an inter-phoneme gap, a zero-duration trailing segment, and an empty input.

```
dotnet test OpenUtau.Test/OpenUtau.Test.csproj --filter "FullyQualifiedName~DiffSinger"
Passed! - Failed: 0, Passed: 37, Skipped: 0, Total: 37
```

Full suite: 416 passed, 0 failed, 1 skipped (the skip is pre-existing).

`OpenUtau.sln` builds clean in both Debug and Release.

## Known limitation (not addressed here)

For very short rests the model can compress the entire pitch transition into the last frame of the previous note, so that single frame carries a roughly semitone-scale excursion of its own. That is a model-side coarticulation transient, not a writeback error, and it is out of scope for this change. The gap-frame artifact above is the dominant one.
