### PR TITLE
Added new scale selection highlighting in piano roll + refactored music theory utils 

### DIFF
--- a/OpenUtau.Core/Commands/ProjectCommands.cs
+++ b/OpenUtau.Core/Commands/ProjectCommands.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util.MusicTheory;
 
 namespace OpenUtau.Core {
     public abstract class ProjectCommand : UCommand {
@@ -140,16 +141,29 @@ namespace OpenUtau.Core {
         }
     }
 
+    // TODO mutualize with mode
     public class KeyCommand : ProjectCommand{
-        public readonly int oldKey;
-        public readonly int newKey;
-        public KeyCommand(UProject project, int key) : base(project) {
+        public readonly Note oldKey;
+        public readonly Note newKey;
+        public KeyCommand(UProject project, Note key) : base(project) {
             oldKey = project.key;
             newKey = key;
         }
         public override string ToString() => $"Change key from {oldKey} to {newKey}";
         public override void Execute() => project.key = newKey;
         public override void Unexecute() => project.key = oldKey;
+    }
+
+    public class ModeCommand : ProjectCommand{
+        public readonly Mode oldMode;
+        public readonly Mode newMode;
+        public ModeCommand(UProject project, Mode key) : base(project) {
+            oldMode = project.mode;
+            newMode = key;
+        }
+        public override string ToString() => $"Change mode from {oldMode} to {newMode}";
+        public override void Execute() => project.mode = newMode;
+        public override void Unexecute() => project.mode = oldMode;
     }
 
     public class ConfigureExpressionsCommand : ProjectCommand {

--- a/OpenUtau.Core/Commands/ProjectCommands.cs
+++ b/OpenUtau.Core/Commands/ProjectCommands.cs
@@ -141,7 +141,6 @@ namespace OpenUtau.Core {
         }
     }
 
-    // TODO mutualize with mode
     public class KeyCommand : ProjectCommand{
         public readonly Note oldKey;
         public readonly Note newKey;

--- a/OpenUtau.Core/Format/USTx.cs
+++ b/OpenUtau.Core/Format/USTx.cs
@@ -128,7 +128,6 @@ namespace OpenUtau.Core.Format {
             }
         }
 
-        // TODO check save and load compatibility with former projects
         public static UProject Load(string filePath) {
             string text = File.ReadAllText(filePath, Encoding.UTF8);
             UProject project = Yaml.DefaultDeserializer.Deserialize<UProject>(text);

--- a/OpenUtau.Core/Format/USTx.cs
+++ b/OpenUtau.Core/Format/USTx.cs
@@ -128,6 +128,7 @@ namespace OpenUtau.Core.Format {
             }
         }
 
+        // TODO check save and load compatibility with former projects
         public static UProject Load(string filePath) {
             string text = File.ReadAllText(filePath, Encoding.UTF8);
             UProject project = Yaml.DefaultDeserializer.Deserialize<UProject>(text);

--- a/OpenUtau.Core/Ustx/UProject.cs
+++ b/OpenUtau.Core/Ustx/UProject.cs
@@ -50,8 +50,8 @@ namespace OpenUtau.Core.Ustx {
         public string[] expSelectors = new string[] { Format.Ustx.DYN, Format.Ustx.PITD, Format.Ustx.CLR, Format.Ustx.ENG, Format.Ustx.VEL, Format.Ustx.VOL, Format.Ustx.ATK, Format.Ustx.DEC, Format.Ustx.GEN, Format.Ustx.BRE };
         public int expPrimary = 0;
         public int expSecondary = 1;
-        public Note key = Note.C;
-        public Mode mode = Mode.Ionian;
+        public Note key = Scale.Default().Tonic;
+        public Mode mode = Scale.Default().Mode;
         public List<UTimeSignature> timeSignatures;
         public List<UTempo> tempos;
         public List<UTrack> tracks;

--- a/OpenUtau.Core/Ustx/UProject.cs
+++ b/OpenUtau.Core/Ustx/UProject.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Core.Util;
+using OpenUtau.Core.Util.MusicTheory;
 using SharpCompress;
 using YamlDotNet.Serialization;
 
@@ -49,7 +50,8 @@ namespace OpenUtau.Core.Ustx {
         public string[] expSelectors = new string[] { Format.Ustx.DYN, Format.Ustx.PITD, Format.Ustx.CLR, Format.Ustx.ENG, Format.Ustx.VEL, Format.Ustx.VOL, Format.Ustx.ATK, Format.Ustx.DEC, Format.Ustx.GEN, Format.Ustx.BRE };
         public int expPrimary = 0;
         public int expSecondary = 1;
-        public int key = 0;//Music key of the project, 0 = C, 1 = C#, 2 = D, ..., 11 = B
+        public Note key = Note.C;
+        public Mode mode = Mode.Ionian;
         public List<UTimeSignature> timeSignatures;
         public List<UTempo> tempos;
         public List<UTrack> tracks;

--- a/OpenUtau.Core/Util/MusicMath.cs
+++ b/OpenUtau.Core/Util/MusicMath.cs
@@ -5,6 +5,7 @@ namespace OpenUtau.Core {
     public static class MusicMath {
         private static readonly double a = Math.Pow(2, 1.0 / 12);
 
+        // TODO move all the harmonics to MusicTheory namespace and refactor
         public enum KeyColor { White, Black }
 
         public static readonly Tuple<string, KeyColor>[] KeysInOctave = {
@@ -47,21 +48,6 @@ namespace OpenUtau.Core {
             "ti",
         };
 
-        public static readonly string[] NumberedNotations = {
-            "1",
-            "",
-            "2",
-            "",
-            "3",
-            "4",
-            "",
-            "5",
-            "",
-            "6",
-            "",
-            "7",
-        };
-
         public static string GetToneName(int noteNum) {
             return noteNum < 0 ? string.Empty : KeysInOctave[noteNum % 12].Item1 + (noteNum / 12 - 1).ToString();
         }
@@ -79,14 +65,6 @@ namespace OpenUtau.Core {
                 return -1;
             }
             return 12 * (octave + 1) + inOctave;
-        }
-
-        public static bool IsBlackKey(int noteNum) {
-            return KeysInOctave[noteNum % 12].Item2 == KeyColor.Black;
-        }
-
-        public static bool IsCenterKey(int noteNum) {
-            return noteNum % 12 == 0;
         }
 
         public static double[] zoomRatios = { 4.0, 2.0, 1.0, 1.0 / 2, 1.0 / 4, 1.0 / 8, 1.0 / 16, 1.0 / 32, 1.0 / 64 };

--- a/OpenUtau.Core/Util/MusicMath.cs
+++ b/OpenUtau.Core/Util/MusicMath.cs
@@ -33,21 +33,6 @@ namespace OpenUtau.Core {
             { "B", 11 },
         };
 
-        public static readonly string[] Solfeges = { 
-            "do",
-            "",
-            "re",
-            "",
-            "mi",
-            "fa",
-            "",
-            "sol",
-            "",
-            "la",
-            "",
-            "ti",
-        };
-
         public static string GetToneName(int noteNum) {
             return noteNum < 0 ? string.Empty : KeysInOctave[noteNum % 12].Item1 + (noteNum / 12 - 1).ToString();
         }

--- a/OpenUtau.Core/Util/MusicTheory/Mode.cs
+++ b/OpenUtau.Core/Util/MusicTheory/Mode.cs
@@ -1,0 +1,13 @@
+namespace OpenUtau.Core.Util.MusicTheory
+{
+    public enum Mode
+    {
+        Lydian,
+        Ionian,
+        Mixolydian,
+        Dorian,
+        Aeolian,
+        Phrygian,
+        Locrian,
+    }
+}

--- a/OpenUtau.Core/Util/MusicTheory/Note.cs
+++ b/OpenUtau.Core/Util/MusicTheory/Note.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace OpenUtau.Core.Util.MusicTheory;
+
+public enum Note
+{
+    C,
+    Csharp,
+    D,
+    Dsharp,
+    E,
+    F,
+    Fsharp,
+    G,
+    Gsharp,
+    A,
+    Asharp,
+    B,
+}
+
+
+
+public static class NoteHelper
+{
+    public static Note CastNote(int note)
+    {
+        note %= Enum.GetValues<Note>().Length;
+        if (note < 0)
+            return Note.C;
+        else
+            return (Note)note;
+    }
+
+    public static string StringifyNote(Note note)
+    {
+        return note.ToString().Replace("sharp", "#");
+    }
+}

--- a/OpenUtau.Core/Util/MusicTheory/Scale.cs
+++ b/OpenUtau.Core/Util/MusicTheory/Scale.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenUtau.Core.Util.MusicTheory;
+
+public class Scale
+{
+    public readonly Mode Mode;
+    private readonly List<Note> _scale;
+    public Note Tonic => _scale[0];
+
+    private Scale(List<Note> notes, Mode mode)
+    {
+        _scale = notes;
+        Mode = mode;
+    }
+
+    public bool IsOutOfScale(Note note)
+    {
+        return _scale.Contains(note) == false;
+    }
+
+    public bool IsTonic(Note note)
+    {
+        return Tonic.Equals(note);
+    }
+
+    public int? Interval(Note note)
+    {
+        int index = _scale.IndexOf(note);
+        return index >= 0 ? index + 1 : null;
+    }
+
+    public static Scale Build(Note tonic, Mode mode)
+    {
+        int tonicValue = (int)tonic;
+        int[] intervals = mode switch
+        {
+            Mode.Lydian => [0, 2, 4, 6, 7, 9, 11],
+            Mode.Ionian => [0, 2, 4, 5, 7, 9, 11],
+            Mode.Mixolydian => [0, 2, 4, 5, 7, 9, 10],
+            Mode.Dorian => [0, 2, 3, 5, 7, 9, 10],
+            Mode.Aeolian => [0, 2, 3, 5, 7, 8, 10],
+            Mode.Phrygian => [0, 1, 3, 5, 7, 8, 10],
+            Mode.Locrian => [0, 1, 3, 5, 6, 8, 10],
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
+        };
+
+        var notes = intervals.Select(interval => NoteHelper.CastNote(tonicValue + interval)).ToList();
+
+        return new Scale(notes, mode);
+    }
+
+    public static Scale Default()
+    {
+        return Build(Note.C, Mode.Ionian);
+    }
+}

--- a/OpenUtau.Core/Util/MusicTheory/Scale.cs
+++ b/OpenUtau.Core/Util/MusicTheory/Scale.cs
@@ -32,6 +32,29 @@ public class Scale
         return index >= 0 ? index + 1 : null;
     }
 
+    public string? SolfegeIntervalName(Note note)
+    {
+        if (IsOutOfScale(note))
+            return null;
+
+        return note switch
+        {
+            Note.C => "do",
+            Note.Csharp => "do#",
+            Note.D => "re",
+            Note.Dsharp => "re#",
+            Note.E => "mi",
+            Note.F => "fa",
+            Note.Fsharp => "fa#",
+            Note.G => "sol",
+            Note.Gsharp => "sol#",
+            Note.A => "la",
+            Note.Asharp => "la#",
+            Note.B => "ti",
+            _ => null,
+        };
+    }
+
     public static Scale Build(Note tonic, Mode mode)
     {
         int tonicValue = (int)tonic;
@@ -47,7 +70,9 @@ public class Scale
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
         };
 
-        var notes = intervals.Select(interval => NoteHelper.CastNote(tonicValue + interval)).ToList();
+        var notes = intervals
+            .Select(interval => NoteHelper.CastNote(tonicValue + interval))
+            .ToList();
 
         return new Scale(notes, mode);
     }

--- a/OpenUtau.Test/Core/Util/MusicTheory/NoteTest.cs
+++ b/OpenUtau.Test/Core/Util/MusicTheory/NoteTest.cs
@@ -1,0 +1,32 @@
+using Xunit;
+
+namespace OpenUtau.Core.Util.MusicTheory;
+
+public class NoteTest
+{
+    public class CastNote
+    {
+        [Fact]
+        public void BelowZeroReturnsC() => Assert.Equal(Note.C, NoteHelper.CastNote(-1));
+
+        [Fact]
+        public void ZeroReturnsC() => Assert.Equal(Note.C, NoteHelper.CastNote(0));
+
+        [Fact]
+        public void AboveTwelveReturnsModuloNoteIndex() =>
+            Assert.Equal(Note.Csharp, NoteHelper.CastNote(25));
+
+        [Fact]
+        public void ElseReturnsNoteIndex() => Assert.Equal(Note.G, NoteHelper.CastNote(7));
+    }
+
+    public class StringifyNote
+    {
+        [Fact]
+        public void PlainNoteDoesNotChange() => Assert.Equal("G", NoteHelper.StringifyNote(Note.G));
+
+        [Fact]
+        public void SharpIsStringifiedDoesNotChange() =>
+            Assert.Equal("G#", NoteHelper.StringifyNote(Note.Gsharp));
+    }
+}

--- a/OpenUtau.Test/Core/Util/MusicTheory/ScaleTest.cs
+++ b/OpenUtau.Test/Core/Util/MusicTheory/ScaleTest.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Internal;
+
+namespace OpenUtau.Core.Util.MusicTheory;
+
+public class ScaleTest
+{
+    public class Default
+    {
+        [Fact]
+        public void TonicIsC()
+        {
+            Assert.Equal(Note.C, Scale.Default().Tonic);
+        }
+
+        [Fact]
+        public void ModeIsIonian()
+        {
+            Assert.Equal(Mode.Ionian, Scale.Default().Mode);
+        }
+    }
+
+    public class Build
+    {
+        private static void AssertScaleIsCorrect(Note tonic, Mode mode, List<Note> expectedNotes)
+        {
+            var scale = Scale.Build(tonic, mode);
+
+            Assert.Equal(tonic, scale.Tonic);
+            Assert.Equal(mode, scale.Mode);
+            foreach (var note in Enum.GetValues<Note>())
+            {
+                Assert.Equal(!expectedNotes.Contains(note), scale.IsOutOfScale(note));
+            }
+            Assert.Equal(Note.C, Scale.Default().Tonic);
+        }
+
+        [Fact]
+        public void CLydian() =>
+            AssertScaleIsCorrect(
+                Note.C,
+                Mode.Lydian,
+                [Note.C, Note.D, Note.E, Note.Fsharp, Note.G, Note.A, Note.B]
+            );
+
+        [Fact]
+        public void CIonian() =>
+            AssertScaleIsCorrect(
+                Note.C,
+                Mode.Ionian,
+                [Note.C, Note.D, Note.E, Note.F, Note.G, Note.A, Note.B]
+            );
+
+        [Fact]
+        public void CMixolydian() =>
+            AssertScaleIsCorrect(
+                Note.C,
+                Mode.Mixolydian,
+                [Note.C, Note.D, Note.E, Note.F, Note.G, Note.A, Note.Asharp]
+            );
+
+        [Fact]
+        public void CDorian() =>
+            AssertScaleIsCorrect(
+                Note.C,
+                Mode.Dorian,
+                [Note.C, Note.D, Note.Dsharp, Note.F, Note.G, Note.A, Note.Asharp]
+            );
+
+        [Fact]
+        public void CAeolian() =>
+            AssertScaleIsCorrect(
+                Note.C,
+                Mode.Aeolian,
+                [Note.C, Note.D, Note.Dsharp, Note.F, Note.G, Note.Gsharp, Note.Asharp]
+            );
+
+        [Fact]
+        public void CPhrygian() =>
+            AssertScaleIsCorrect(
+                Note.C,
+                Mode.Phrygian,
+                [Note.C, Note.Csharp, Note.Dsharp, Note.F, Note.G, Note.Gsharp, Note.Asharp]
+            );
+
+        [Fact]
+        public void CLocrian() =>
+            AssertScaleIsCorrect(
+                Note.C,
+                Mode.Locrian,
+                [Note.C, Note.Csharp, Note.Dsharp, Note.F, Note.Fsharp, Note.Gsharp, Note.Asharp]
+            );
+
+        [Fact]
+        public void ALydian() =>
+            AssertScaleIsCorrect(
+                Note.A,
+                Mode.Lydian,
+                [Note.A, Note.B, Note.Csharp, Note.Dsharp, Note.E, Note.Fsharp, Note.Gsharp]
+            );
+
+        [Fact]
+        public void AIonian() =>
+            AssertScaleIsCorrect(
+                Note.A,
+                Mode.Ionian,
+                [Note.A, Note.B, Note.Csharp, Note.D, Note.E, Note.Fsharp, Note.Gsharp]
+            );
+
+        [Fact]
+        public void AMixolydian() =>
+            AssertScaleIsCorrect(
+                Note.A,
+                Mode.Mixolydian,
+                [Note.A, Note.B, Note.Csharp, Note.D, Note.E, Note.Fsharp, Note.G]
+            );
+
+        [Fact]
+        public void ADorian() =>
+            AssertScaleIsCorrect(
+                Note.A,
+                Mode.Dorian,
+                [Note.A, Note.B, Note.C, Note.D, Note.E, Note.Fsharp, Note.G]
+            );
+
+        [Fact]
+        public void AAeolian() =>
+            AssertScaleIsCorrect(
+                Note.A,
+                Mode.Aeolian,
+                [Note.A, Note.B, Note.C, Note.D, Note.E, Note.F, Note.G]
+            );
+
+        [Fact]
+        public void APhrygian() =>
+            AssertScaleIsCorrect(
+                Note.A,
+                Mode.Phrygian,
+                [Note.A, Note.Asharp, Note.C, Note.D, Note.E, Note.F, Note.G]
+            );
+
+        [Fact]
+        public void ALocrian() =>
+            AssertScaleIsCorrect(
+                Note.A,
+                Mode.Locrian,
+                [Note.A, Note.Asharp, Note.C, Note.D, Note.Dsharp, Note.F, Note.G]
+            );
+    }
+
+    public class IsTonic
+    {
+        [Fact]
+        public void DIsTheOnlyTonic()
+        {
+            var scale = Scale.Build(Note.D, Mode.Ionian);
+            Assert.True(scale.IsTonic(Note.D));
+            Enum.GetValues<Note>()
+                .Where(note => !note.Equals(Note.D))
+                .ForEach(note =>
+                {
+                    Assert.False(scale.IsTonic(note));
+                });
+        }
+    }
+
+    public class Interval
+    {
+        private readonly Scale _cIonian = Scale.Build(Note.C, Mode.Ionian);
+
+        [Fact]
+        public void CIsFirstInCIonian() => Assert.Equal(1, _cIonian.Interval(Note.C));
+
+        [Fact]
+        public void CsharpIsOutOfScaleInCIonian() => Assert.Null(_cIonian.Interval(Note.Csharp));
+
+        [Fact]
+        public void DIsSecondInCIonian() => Assert.Equal(2, _cIonian.Interval(Note.D));
+
+        [Fact]
+        public void DsharpIsOutOfScaleInCIonian() => Assert.Null(_cIonian.Interval(Note.Dsharp));
+
+        [Fact]
+        public void EIsThirdInCIonian() => Assert.Equal(3, _cIonian.Interval(Note.E));
+
+        [Fact]
+        public void FIsFourthInCIonian() => Assert.Equal(4, _cIonian.Interval(Note.F));
+
+        [Fact]
+        public void FsharpIsOutOfScaleInCIonian() => Assert.Null(_cIonian.Interval(Note.Fsharp));
+
+        [Fact]
+        public void GIsFifthInCIonian() => Assert.Equal(5, _cIonian.Interval(Note.G));
+
+        [Fact]
+        public void GsharpIsOutOfScaleInCIonian() => Assert.Null(_cIonian.Interval(Note.Gsharp));
+
+        [Fact]
+        public void AIsSixthInCIonian() => Assert.Equal(6, _cIonian.Interval(Note.A));
+
+        [Fact]
+        public void AsharpIsOutOfScaleInCIonian() => Assert.Null(_cIonian.Interval(Note.Asharp));
+
+        [Fact]
+        public void BIsSeventhInCIonian() => Assert.Equal(7, _cIonian.Interval(Note.B));
+
+        private readonly Scale _aAeolian = Scale.Build(Note.A, Mode.Aeolian);
+
+        [Fact]
+        public void AIsFirstInAAeolian() => Assert.Equal(1, _aAeolian.Interval(Note.A));
+
+        [Fact]
+        public void AsharpIsOutOfScaleInAAeolian() => Assert.Null(_aAeolian.Interval(Note.Asharp));
+
+        
+        [Fact]
+        public void EIsFifthInAAeolian() => Assert.Equal(5, _aAeolian.Interval(Note.E));
+    }
+}

--- a/OpenUtau/Controls/PianoRoll.axaml
+++ b/OpenUtau/Controls/PianoRoll.axaml
@@ -2,8 +2,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:vm="using:OpenUtau.App.ViewModels"
-        xmlns:api="using:OpenUtau.Api"
         xmlns:c="clr-namespace:OpenUtau.App.Controls"
         mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="650"
         x:Class="OpenUtau.App.Controls.PianoRoll" Focusable="True"
@@ -57,7 +55,7 @@
                          DataContext="{Binding NotesViewModel}"
                          TrackHeight="{Binding TrackHeight}"
                          TrackOffset="{Binding TrackOffset}"
-                         Key="{Binding Key}"
+                         Scale="{Binding Scale}"
                          PointerWheelChanged="KeyboardPointerWheelChanged"
                          PointerPressed="KeyboardPointerPressed"
                          PointerMoved="KeyboardPointerMoved"
@@ -117,11 +115,13 @@
               Fill="{DynamicResource NeutralAccentBrushSemi}"
               Data="M -6.5 0 L 6.5 0 L 6.5 3 L 0 9 L -6.5 3 Z"/>
       </Canvas>
+      <!-- TODO change according to scale -->
       <!-- Notes backgrounds -->
       <c:TrackBackground Grid.Row="3" Grid.Column="1" IsHitTestVisible="False"
                          Foreground="{DynamicResource TrackBackgroundAltBrush}"
                          DataContext="{Binding NotesViewModel}"
                          Bounds="{Binding Bounds, Mode=OneWayToSource}"
+                         Scale="{Binding Scale}"
                          TrackHeight="{Binding TrackHeight}"
                          TrackOffset="{Binding TrackOffset}" IsPianoRoll="True"/>
       <c:TickBackground Grid.Row="2" Grid.RowSpan="2" Grid.Column="1" IsHitTestVisible="False"
@@ -527,6 +527,7 @@
                              ItemsSource="{Binding NotesViewModel.SnapDivs}" KeyDown="OnSnapDivKeyDown"/>
               </Button.ContextMenu>
             </Button>
+            <!-- Tonic selection -->
             <Button Margin="0" Padding="0,1" Height="20" Width="40" Background="Transparent" Click="OnKeyMenuButton"
               ToolTip.Tip="{DynamicResource pianoroll.key}">
               <TextBlock Grid.Column="0" Text="{Binding NotesViewModel.KeyText}"
@@ -534,9 +535,21 @@
                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
               <Button.ContextMenu>
                 <ContextMenu Name="KeyMenu" Classes="WithCommand" Placement="BottomEdgeAlignedLeft"
-                             ItemsSource="{Binding NotesViewModel.Keys}" KeyDown="OnKeyKeyDown"/>
+                             ItemsSource="{Binding NotesViewModel.Keys}" KeyDown="OnScaleKeyDown"/>
               </Button.ContextMenu>
             </Button>
+            <!-- Mode selection -->
+            <Button Margin="0" Padding="0,1" Height="20" Width="70" Background="Transparent" Click="OnModeMenuButton"
+              ToolTip.Tip="{DynamicResource pianoroll.key}">
+              <TextBlock Grid.Column="0" Text="{Binding NotesViewModel.ModeText}"
+                          TextAlignment="Right" FontSize="10" FontFamily="monospace"
+                          Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+              <Button.ContextMenu>
+                <ContextMenu Name="ModeMenu" Classes="WithCommand" Placement="BottomEdgeAlignedLeft"
+                             ItemsSource="{Binding NotesViewModel.Modes}" KeyDown="OnScaleKeyDown"/>
+              </Button.ContextMenu>
+            </Button>
+
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.LivePitchNormal}"
                           IsVisible="{Binding NotesViewModel.IsDiffSinger}"
                           ToolTip.Tip="{DynamicResource pianoroll.toggle.livepitch.normal}">

--- a/OpenUtau/Controls/PianoRoll.axaml
+++ b/OpenUtau/Controls/PianoRoll.axaml
@@ -115,7 +115,6 @@
               Fill="{DynamicResource NeutralAccentBrushSemi}"
               Data="M -6.5 0 L 6.5 0 L 6.5 3 L 0 9 L -6.5 3 Z"/>
       </Canvas>
-      <!-- TODO change according to scale -->
       <!-- Notes backgrounds -->
       <c:TrackBackground Grid.Row="3" Grid.Column="1" IsHitTestVisible="False"
                          Foreground="{DynamicResource TrackBackgroundAltBrush}"
@@ -530,12 +529,12 @@
             <!-- Tonic selection -->
             <Button Margin="0" Padding="0,1" Height="20" Width="40" Background="Transparent" Click="OnKeyMenuButton"
               ToolTip.Tip="{DynamicResource pianoroll.key}">
-              <TextBlock Grid.Column="0" Text="{Binding NotesViewModel.KeyText}"
+              <TextBlock Grid.Column="0" Text="{Binding NotesViewModel.TonicText}"
                           TextAlignment="Right" FontSize="10" FontFamily="monospace"
                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
               <Button.ContextMenu>
                 <ContextMenu Name="KeyMenu" Classes="WithCommand" Placement="BottomEdgeAlignedLeft"
-                             ItemsSource="{Binding NotesViewModel.Keys}" KeyDown="OnScaleKeyDown"/>
+                             ItemsSource="{Binding NotesViewModel.Tonics}" KeyDown="OnScaleKeyDown"/>
               </Button.ContextMenu>
             </Button>
             <!-- Mode selection -->

--- a/OpenUtau/Controls/PianoRoll.axaml.cs
+++ b/OpenUtau/Controls/PianoRoll.axaml.cs
@@ -1417,6 +1417,11 @@ namespace OpenUtau.App.Controls {
             KeyMenu.Open();
         }
 
+        public void OnModeMenuButton(object sender, RoutedEventArgs args) {
+            ModeMenu.PlacementTarget = sender as Button;
+            ModeMenu.Open();
+        }
+
         bool MoveToNextPart(bool next) {
             var notesVm = ViewModel.NotesViewModel;
             var playVm = ViewModel.PlaybackViewModel;
@@ -1446,7 +1451,7 @@ namespace OpenUtau.App.Controls {
             return true;
         }
 
-        void OnKeyKeyDown(object sender, KeyEventArgs e) {
+        void OnScaleKeyDown(object sender, KeyEventArgs e) {
             if (e.Key == Key.Enter && e.KeyModifiers == KeyModifiers.None) {
                 if (sender is ContextMenu menu && menu.SelectedItem is MenuItemViewModel item) {
                     item.Command?.Execute(item.CommandParameter);

--- a/OpenUtau/Controls/TrackBackground.cs
+++ b/OpenUtau/Controls/TrackBackground.cs
@@ -92,22 +92,7 @@ namespace OpenUtau.App.Controls {
             }
             int track = (int)TrackOffset;
             double top = TrackHeight * (track - TrackOffset);
-            // TODO refactor notes display style should be last step
-            // TODO interval notations has to do with scales not absolute notes, both should coexist
-            string[] degreeNames; 
 
-            switch (Preferences.Default.DegreeStyle)
-            {
-                case 1:
-                    degreeNames = MusicMath.Solfeges;
-                    break;
-                // case 2:
-                    // degreeNames = MusicMath.NumberedNotations;
-                    // break;
-                default:
-                    degreeNames = Enumerable.Repeat("", 12).ToArray();
-                    break;
-            }
             while (top < Bounds.Height)
             {
                 bool isAltTrack = IsOutOfScale(track) ^ (ThemeManager.IsDarkMode && !IsKeyboard);
@@ -144,11 +129,15 @@ namespace OpenUtau.App.Controls {
                     {
                         toneTextLayout.Draw(context, new Point());
                     }
-                    //scale degree display
-                    // TODO refactor
 
-                    // TODO re-support solfege
-                    string degreeName = Scale.Interval(NoteHelper.CastNote(tone)).ToString() ?? "";
+                    // TODO interval notations has nothing to do with scales, both should coexist : if solfege notation then all the app should turn C into Do etc
+                    string degreeName = Preferences.Default.DegreeStyle switch
+                    {
+                        1 => Scale.SolfegeIntervalName(NoteHelper.CastNote(tone))?.ToString() ?? "",
+                        2 => Scale.Interval(NoteHelper.CastNote(tone)).ToString() ?? "",
+                        _ => ""
+                    };
+
                     var degreeTextLayout = TextLayoutCache.Get(degreeName, brush, 12);
                     var degreeTextPosition = new Point(
                         4,

--- a/OpenUtau/Controls/TrackBackground.cs
+++ b/OpenUtau/Controls/TrackBackground.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using OpenUtau.Core;
 using OpenUtau.Core.Util;
+using OpenUtau.Core.Util.MusicTheory;
 using ReactiveUI;
 using ReactiveUI.Primitives;
 
@@ -30,12 +31,15 @@ namespace OpenUtau.App.Controls {
             AvaloniaProperty.RegisterDirect<TrackBackground, bool>(
                 nameof(IsKeyboard),
                 o => o.IsKeyboard,
-                (o, v) => o.IsKeyboard = v);
-        public static readonly DirectProperty<TrackBackground, int> KeyProperty =
-            AvaloniaProperty.RegisterDirect<TrackBackground, int>(
-                nameof(Key),
-                o => o.Key,
-                (o, v) => o.Key = v);
+                (o, v) => o.IsKeyboard = v
+            );
+
+        public static readonly DirectProperty<TrackBackground, Scale> ScaleProperty =
+            AvaloniaProperty.RegisterDirect<TrackBackground, Scale>(
+                nameof(Scale),
+                o => o.Scale,
+                (o, v) => o.Scale = v
+            );
 
         public double TrackHeight {
             get => _trackHeight;
@@ -53,16 +57,17 @@ namespace OpenUtau.App.Controls {
             get => _isKeyboard;
             set => SetAndRaise(IsPianoRollProperty, ref _isKeyboard, value);
         }
-        public int Key {
+        public Scale Scale
+        {
             get => _key;
-            set => SetAndRaise(KeyProperty, ref _key, value);
+            set => SetAndRaise(ScaleProperty, ref _key, value);
         }
 
         private double _trackHeight;
         private double _trackOffset;
         private bool _isPianoRoll;
         private bool _isKeyboard;
-        private int _key;
+        private Scale _key = Scale.Default();
 
         public TrackBackground() {
             MessageBus.Current.Listen<ThemeChangedEvent>()
@@ -74,60 +79,87 @@ namespace OpenUtau.App.Controls {
             if (change.Property == TrackHeightProperty ||
                 change.Property == TrackOffsetProperty ||
                 change.Property == ForegroundProperty ||
-                change.Property == KeyProperty) {
+                change.Property == ScaleProperty) {
                 InvalidateVisual();
             }
         }
 
-        int mod(int a, int b){
-            return (a % b + b) % b;
-        }
-
-        public override void Render(DrawingContext context) {
-            if (TrackHeight == 0) {
+        public override void Render(DrawingContext context)
+        {
+            if (TrackHeight == 0)
+            {
                 return;
             }
             int track = (int)TrackOffset;
             double top = TrackHeight * (track - TrackOffset);
-            string[] degreeNames;
-            switch(Preferences.Default.DegreeStyle){
+            // TODO refactor notes display style should be last step
+            // TODO interval notations has to do with scales not absolute notes, both should coexist
+            string[] degreeNames; 
+
+            switch (Preferences.Default.DegreeStyle)
+            {
                 case 1:
                     degreeNames = MusicMath.Solfeges;
                     break;
-                case 2:
-                    degreeNames = MusicMath.NumberedNotations;
-                    break;
+                // case 2:
+                    // degreeNames = MusicMath.NumberedNotations;
+                    // break;
                 default:
                     degreeNames = Enumerable.Repeat("", 12).ToArray();
                     break;
             }
-            while (top < Bounds.Height) {
-                bool isAltTrack = IsAltTrack(track) ^ (ThemeManager.IsDarkMode && !IsKeyboard);
-                bool isCenterKey = IsKeyboard && IsCenterKey(track);
-                var brush = isCenterKey ? ThemeManager.CenterKeyBrush
-                    : IsKeyboard ? (isAltTrack ? ThemeManager.BlackKeyBrush : ThemeManager.WhiteKeyBrush)
-                    : isAltTrack ? Foreground : Background;
+            while (top < Bounds.Height)
+            {
+                bool isAltTrack = IsOutOfScale(track) ^ (ThemeManager.IsDarkMode && !IsKeyboard);
+                bool isCenterKey = IsKeyboard && IsTonic(track);
+                var brush =
+                    isCenterKey ? ThemeManager.CenterKeyBrush
+                    : IsKeyboard
+                        ? (isAltTrack ? ThemeManager.BlackKeyBrush : ThemeManager.WhiteKeyBrush)
+                    : isAltTrack ? Foreground
+                    : Background;
                 context.DrawRectangle(
                     brush,
                     null,
-                    new Rect(0, (int)top, Bounds.Width, TrackHeight));
-                if (IsKeyboard && TrackHeight >= 12) {
-                    brush = isCenterKey ? ThemeManager.CenterKeyNameBrush
+                    new Rect(0, (int)top, Bounds.Width, TrackHeight)
+                );
+                if (IsKeyboard && TrackHeight >= 12)
+                {
+                    brush =
+                        isCenterKey ? ThemeManager.CenterKeyNameBrush
                         : isAltTrack ? ThemeManager.BlackKeyNameBrush
-                            : ThemeManager.WhiteKeyNameBrush;
+                        : ThemeManager.WhiteKeyNameBrush;
                     int tone = ViewConstants.MaxTone - 1 - track;
                     string toneName = MusicMath.GetToneName(tone);
                     var toneTextLayout = TextLayoutCache.Get(toneName, brush, 12);
-                    var toneTextPosition = new Point(Bounds.Width - 4 - (int)toneTextLayout.Width, (int)(top + (TrackHeight - toneTextLayout.Height) / 2));
-                    using (var state = context.PushTransform(Matrix.CreateTranslation(toneTextPosition))) {
+                    var toneTextPosition = new Point(
+                        Bounds.Width - 4 - (int)toneTextLayout.Width,
+                        (int)(top + (TrackHeight - toneTextLayout.Height) / 2)
+                    );
+                    using (
+                        var state = context.PushTransform(
+                            Matrix.CreateTranslation(toneTextPosition)
+                        )
+                    )
+                    {
                         toneTextLayout.Draw(context, new Point());
                     }
                     //scale degree display
-                    int degree = mod(tone - Key, 12);
-                    string degreeName = degreeNames[degree];
+                    // TODO refactor
+
+                    // TODO re-support solfege
+                    string degreeName = Scale.Interval(NoteHelper.CastNote(tone)).ToString() ?? "";
                     var degreeTextLayout = TextLayoutCache.Get(degreeName, brush, 12);
-                    var degreeTextPosition = new Point(4, (int)(top + (TrackHeight - degreeTextLayout.Height) / 2));
-                    using (var state = context.PushTransform(Matrix.CreateTranslation(degreeTextPosition))) {
+                    var degreeTextPosition = new Point(
+                        4,
+                        (int)(top + (TrackHeight - degreeTextLayout.Height) / 2)
+                    );
+                    using (
+                        var state = context.PushTransform(
+                            Matrix.CreateTranslation(degreeTextPosition)
+                        )
+                    )
+                    {
                         degreeTextLayout.Draw(context, new Point());
                     }
                 }
@@ -136,20 +168,21 @@ namespace OpenUtau.App.Controls {
             }
         }
 
-        private bool IsAltTrack(int track) {
-            if (!IsPianoRoll) {
+        private bool IsOutOfScale(int track)
+        {
+            if (!IsPianoRoll)
                 return track % 2 == 1;
-            }
+
             int tone = ViewConstants.MaxTone - 1 - track;
-            if (tone < 0) {
+            if (tone < 0)
                 return false;
-            }
-            return MusicMath.IsBlackKey(tone);
+            return Scale.IsOutOfScale(NoteHelper.CastNote(tone));
         }
 
-        private bool IsCenterKey(int track) {
+        private bool IsTonic(int track)
+        {
             int tone = ViewConstants.MaxTone - 1 - track;
-            return MusicMath.IsCenterKey(tone);
+            return Scale.IsTonic(NoteHelper.CastNote(tone));
         }
     }
 }

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -15,6 +15,7 @@ using OpenUtau.App.Views;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
+using OpenUtau.Core.Util.MusicTheory;
 using OpenUtau.ViewModels;
 using ReactiveUI;
 using ReactiveUI.Primitives;
@@ -46,7 +47,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public partial double TickOffset { get; set; }
         [Reactive] public partial double TrackOffset { get; set; }
         [Reactive] public partial int SnapDiv { get; set; }
-        [Reactive] public partial int Key { get; set; }
+        [Reactive] public partial Scale Scale { get; set; } = Scale.Default();
         public ObservableCollectionExtended<int> SnapTicks { get; } = new ObservableCollectionExtended<int>();
         [Reactive] public partial double PlayPosX { get; set; }
         [Reactive] public partial double PlayPosHighlightX { get; set; }
@@ -70,7 +71,8 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public partial bool ShowExpressions { get; set; }
         [Reactive] public partial bool IsSnapOn { get; set; }
         [Reactive] public partial string SnapDivText { get; set; }
-        [Reactive] public partial string KeyText { get; set; }
+        [Reactive] public partial string KeyText { get; set; } = string.Empty;
+        [Reactive] public partial string ModeText { get; set; } = string.Empty;
         [Reactive] public partial Rect ExpBounds { get; set; }
         [Reactive] public partial string PrimaryKey { get; set; }
         [Reactive] public partial bool PrimaryKeyNotSupported { get; set; }
@@ -94,10 +96,14 @@ namespace OpenUtau.App.ViewModels {
         public double VScrollBarMax => Math.Max(0, TrackCount - ViewportTracks);
         public UProject Project => DocManager.Inst.Project;
         [Reactive] public partial List<MenuItemViewModel> SnapDivs { get; set; }
-        [Reactive] public partial List<MenuItemViewModel> Keys { get; set; }
+
+        // TODO Keys -> Tonics
+        [Reactive] public partial List<MenuItemViewModel> Keys { get; set; } = new List<MenuItemViewModel>();
+        [Reactive] public partial List<MenuItemViewModel> Modes { get; set; } = new List<MenuItemViewModel>();
 
         public ReactiveCommand<int, RxVoid> SetSnapUnitCommand { get; set; }
-        public ReactiveCommand<int, RxVoid> SetKeyCommand { get; set; }
+        public ReactiveCommand<Note, RxVoid> SetKeyCommand { get; set; }
+        public ReactiveCommand<Mode, RxVoid> SetModeCommand { get; set; }
 
         // See the comments on TracksViewModel.playPosXToTickOffset
         private double playPosXToTickOffset => Bounds.Width != 0 ? ViewportTicks / Bounds.Width : 0;
@@ -117,7 +123,6 @@ namespace OpenUtau.App.ViewModels {
         private string? portraitSource;
         private readonly object portraitLock = new object();
         private int userSnapDiv = -2;
-        private int userKey => Project.key;
 
         public NotesViewModel() {
             SnapDivs = new List<MenuItemViewModel>();
@@ -126,12 +131,17 @@ namespace OpenUtau.App.ViewModels {
                 UpdateSnapDiv();
             });
 
-            Keys = new List<MenuItemViewModel>();
-            SetKeyCommand = ReactiveCommand.Create<int>(key => {
+            SetKeyCommand = ReactiveCommand.Create<Note>(key => {
                 DocManager.Inst.StartUndoGroup("command.project.key");
                 DocManager.Inst.ExecuteCmd(new KeyCommand(Project, key));
                 DocManager.Inst.EndUndoGroup();
-                UpdateKey();
+                UpdateScale();
+            });
+            SetModeCommand = ReactiveCommand.Create<Mode>(mode => {
+                DocManager.Inst.StartUndoGroup("command.project.mode");
+                DocManager.Inst.ExecuteCmd(new ModeCommand(Project, mode));
+                DocManager.Inst.EndUndoGroup();
+                UpdateScale();
             });
 
             viewportTicks = this.WhenAnyValue(x => x.Bounds, x => x.TickWidth)
@@ -212,18 +222,24 @@ namespace OpenUtau.App.ViewModels {
                             CommandParameter = div,
                         }));
                     Keys.Clear();
-                    Keys.AddRange(MusicMath.KeysInOctave
-                        .Select((key, index) => new MenuItemViewModel {
-                            Header = $"1={key.Item1}",
+                    Keys.AddRange(
+                        Enum.GetValues<Note>().Select((key, index) => new MenuItemViewModel {
+                            Header = $"1={NoteHelper.StringifyNote(key)}",
                             Command = SetKeyCommand,
-                            CommandParameter = index,
+                            CommandParameter = key,
+                        }));
+                    Modes.Clear();
+                    Modes.AddRange(
+                        Enum.GetValues<Mode>().Select((key, index) => new MenuItemViewModel {
+                            Header = key.ToString(),
+                            Command = SetModeCommand,
+                            CommandParameter = key,
                         }));
                 });
 
             ShowTips = Preferences.Default.ShowTips;
             IsSnapOn = true;
             SnapDivText = string.Empty;
-            KeyText = string.Empty;
 
             PlayTone = Preferences.Default.PlayTone;
             this.WhenAnyValue(x => x.PlayTone)
@@ -367,9 +383,12 @@ namespace OpenUtau.App.ViewModels {
             SnapDivText = $"(1/{div})";
         }
 
-        private void UpdateKey() {
-            Key = userKey;
-            KeyText = "1=" + MusicMath.KeysInOctave[userKey].Item1;
+        // TODO
+        private void UpdateScale() {
+            // TODO rename key to scale
+            Scale = Scale.Build(Project.key, Project.mode);
+            KeyText = "1=" + NoteHelper.StringifyNote(Scale.Tonic);
+            ModeText = Scale.Mode.ToString();
         }
 
         public void OnXZoomed(Point position, double delta) {
@@ -489,7 +508,7 @@ namespace OpenUtau.App.ViewModels {
             LoadPortrait(part, project);
             LoadWindowTitle(part, project);
             LoadTrackColor(part, project);
-            UpdateKey();
+            UpdateScale();
         }
 
         //If PortraitHeight is 0, the default behaviour is resizing any image taller than 800px to 800px,

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -129,9 +129,9 @@ namespace OpenUtau.App.ViewModels {
                 UpdateSnapDiv();
             });
 
-            SetKeyCommand = ReactiveCommand.Create<Note>(key => {
+            SetKeyCommand = ReactiveCommand.Create<Note>(tonic => {
                 DocManager.Inst.StartUndoGroup("command.project.key");
-                DocManager.Inst.ExecuteCmd(new KeyCommand(Project, key));
+                DocManager.Inst.ExecuteCmd(new KeyCommand(Project, tonic));
                 DocManager.Inst.EndUndoGroup();
                 UpdateScale();
             });
@@ -221,17 +221,17 @@ namespace OpenUtau.App.ViewModels {
                         }));
                     Tonics.Clear();
                     Tonics.AddRange(
-                        Enum.GetValues<Note>().Select((key, index) => new MenuItemViewModel {
-                            Header = $"1={NoteHelper.StringifyNote(key)}",
+                        Enum.GetValues<Note>().Select((tonic) => new MenuItemViewModel {
+                            Header = $"1={NoteHelper.StringifyNote(tonic)}",
                             Command = SetKeyCommand,
-                            CommandParameter = key,
+                            CommandParameter = tonic,
                         }));
                     Modes.Clear();
                     Modes.AddRange(
-                        Enum.GetValues<Mode>().Select((key, index) => new MenuItemViewModel {
-                            Header = key.ToString(),
+                        Enum.GetValues<Mode>().Select((mode) => new MenuItemViewModel {
+                            Header = mode.ToString(),
                             Command = SetModeCommand,
-                            CommandParameter = key,
+                            CommandParameter = mode,
                         }));
                 });
 

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -71,7 +71,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public partial bool ShowExpressions { get; set; }
         [Reactive] public partial bool IsSnapOn { get; set; }
         [Reactive] public partial string SnapDivText { get; set; }
-        [Reactive] public partial string KeyText { get; set; } = string.Empty;
+        [Reactive] public partial string TonicText { get; set; } = string.Empty;
         [Reactive] public partial string ModeText { get; set; } = string.Empty;
         [Reactive] public partial Rect ExpBounds { get; set; }
         [Reactive] public partial string PrimaryKey { get; set; }
@@ -96,9 +96,7 @@ namespace OpenUtau.App.ViewModels {
         public double VScrollBarMax => Math.Max(0, TrackCount - ViewportTracks);
         public UProject Project => DocManager.Inst.Project;
         [Reactive] public partial List<MenuItemViewModel> SnapDivs { get; set; }
-
-        // TODO Keys -> Tonics
-        [Reactive] public partial List<MenuItemViewModel> Keys { get; set; } = new List<MenuItemViewModel>();
+        [Reactive] public partial List<MenuItemViewModel> Tonics { get; set; } = new List<MenuItemViewModel>();
         [Reactive] public partial List<MenuItemViewModel> Modes { get; set; } = new List<MenuItemViewModel>();
 
         public ReactiveCommand<int, RxVoid> SetSnapUnitCommand { get; set; }
@@ -221,8 +219,8 @@ namespace OpenUtau.App.ViewModels {
                             Command = SetSnapUnitCommand,
                             CommandParameter = div,
                         }));
-                    Keys.Clear();
-                    Keys.AddRange(
+                    Tonics.Clear();
+                    Tonics.AddRange(
                         Enum.GetValues<Note>().Select((key, index) => new MenuItemViewModel {
                             Header = $"1={NoteHelper.StringifyNote(key)}",
                             Command = SetKeyCommand,
@@ -383,11 +381,9 @@ namespace OpenUtau.App.ViewModels {
             SnapDivText = $"(1/{div})";
         }
 
-        // TODO
         private void UpdateScale() {
-            // TODO rename key to scale
             Scale = Scale.Build(Project.key, Project.mode);
-            KeyText = "1=" + NoteHelper.StringifyNote(Scale.Tonic);
+            TonicText = "1=" + NoteHelper.StringifyNote(Scale.Tonic);
             ModeText = Scale.Mode.ToString();
         }
 

--- a/OpenUtau/ViewModels/PlaybackViewModel.cs
+++ b/OpenUtau/ViewModels/PlaybackViewModel.cs
@@ -12,7 +12,6 @@ namespace OpenUtau.App.ViewModels {
         public int BeatPerBar => Project.timeSignatures[0].beatPerBar;
         public int BeatUnit => Project.timeSignatures[0].beatUnit;
         public double Bpm => Project.tempos[0].bpm;
-        // TODO refactor the file
         public Note Key => Project.key;
         public string KeyName => MusicMath.KeysInOctave[(int) Key].Item1;
         public int Resolution => Project.resolution;

--- a/OpenUtau/ViewModels/PlaybackViewModel.cs
+++ b/OpenUtau/ViewModels/PlaybackViewModel.cs
@@ -2,6 +2,7 @@
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
+using OpenUtau.Core.Util.MusicTheory;
 using ReactiveUI;
 
 namespace OpenUtau.App.ViewModels {
@@ -11,8 +12,9 @@ namespace OpenUtau.App.ViewModels {
         public int BeatPerBar => Project.timeSignatures[0].beatPerBar;
         public int BeatUnit => Project.timeSignatures[0].beatUnit;
         public double Bpm => Project.tempos[0].bpm;
-        public int Key => Project.key;
-        public string KeyName => MusicMath.KeysInOctave[Key].Item1;
+        // TODO refactor the file
+        public Note Key => Project.key;
+        public string KeyName => MusicMath.KeysInOctave[(int) Key].Item1;
         public int Resolution => Project.resolution;
         public int PlayPosTick => DocManager.Inst.playPosTick;
         public TimeSpan PlayPosTime => TimeSpan.FromMilliseconds((int)Project.timeAxis.TickPosToMsPos(DocManager.Inst.playPosTick));
@@ -84,7 +86,7 @@ namespace OpenUtau.App.ViewModels {
             DocManager.Inst.EndUndoGroup();
         }
 
-        public void SetKey(int key) {
+        public void SetKey(Note key) {
             if (key == DocManager.Inst.Project.key) {
                 return;
             }


### PR DESCRIPTION
(first dev on any open source project, I'm new so I don't know the process and all)

Following this feature request : [https://github.com/openutau/OpenUtau/issues/2005](https://github.com/openutau/OpenUtau/issues/2005)

# Behavior comparison

Default scale is C Ionian or C major (this did not change), users can still select the Key (aka tonic)

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/98f471be-b859-4041-9177-a5331dc6f88b" />

Users can now also select the mode out of the main ones, here we can for example have A minor (relative of C major) which was not possible before :

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/0be55ede-9910-4090-91a4-c810e84ed387" />

Before that, we could only have C major for the proper notes but the wrong degree intervals if we wanted A minor.

Also the notes highlighting (black and white keys) only followed a traditionnal piano, now the highlighting clearly follows the scale that you play in. The selected tonic is now highlighted in light blue whereas only the C note was before.

If users wish to keep the traditionnal piano highlighting, they can keep C major as the scale.

# Implementation details

Uproject now has a new field : "mode" which is reflected by the dropdown menu shown above. Everything related to music theory AND required for this feature has been moved to this namespace : "OpenUtau.Core.Util.MusicTheory".


<img width="1129" height="808" alt="image" src="https://github.com/user-attachments/assets/a4250190-6493-49dd-9beb-57a0f80eeed2" />