### PR TITLE
Surface hidden failures: out-of-order phonemes and unhandled exceptions

### DIFF
--- a/OpenUtau.Core/Ustx/UPart.cs
+++ b/OpenUtau.Core/Ustx/UPart.cs
@@ -282,8 +282,8 @@ namespace OpenUtau.Core.Ustx {
                 for (int i = 0; i < phonemes.Count - 1; ++i) {
                     if (phonemes[i].rawPosition > phonemes[i + 1].rawPosition) {
                         Log.Warning("Out-of-order phonemes in part {Part}: {Phoneme} at {Position} comes after {Next} at {NextPosition}.",
-                            name, phonemes[i].phoneme, phonemes[i].rawPosition,
-                            phonemes[i + 1].phoneme, phonemes[i + 1].rawPosition);
+                            name, phonemes[i].rawPhoneme, phonemes[i].rawPosition,
+                            phonemes[i + 1].rawPhoneme, phonemes[i + 1].rawPosition);
                         break;
                     }
                 }

--- a/OpenUtau.Core/Ustx/UPart.cs
+++ b/OpenUtau.Core/Ustx/UPart.cs
@@ -275,6 +275,18 @@ namespace OpenUtau.Core.Ustx {
                         phoneme.releaseTimeDelta = o.releaseTimeDelta;
                     }
                 }
+                // A phonemizer is expected to return positions in order. Report it when that did
+                // not happen, instead of letting the safety treatment below repair it silently.
+                // rawPosition is the phonemizer output before user phoneme overrides are applied,
+                // so this only fires for the phonemizer itself, not for edited offsets.
+                for (int i = 0; i < phonemes.Count - 1; ++i) {
+                    if (phonemes[i].rawPosition > phonemes[i + 1].rawPosition) {
+                        Log.Warning("Out-of-order phonemes in part {Part}: {Phoneme} at {Position} comes after {Next} at {NextPosition}.",
+                            name, phonemes[i].phoneme, phonemes[i].rawPosition,
+                            phonemes[i + 1].phoneme, phonemes[i + 1].rawPosition);
+                        break;
+                    }
+                }
                 // Safety treatment after phonemizer output and phoneme overrides.
                 for (int i = phonemes.Count - 2; i >= 0; --i) {
                     phonemes[i].position = Math.Min(phonemes[i].position, phonemes[i + 1].position - 10);

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -44,7 +44,19 @@ namespace OpenUtau.App {
         // Both are logged and surfaced instead of taking the whole application down.
         void RegisterUnhandledExceptionHandlers() {
             TaskScheduler.UnobservedTaskException += (sender, args) => {
-                Log.Error(args.Exception, "Unobserved task exception");
+                // Cancellation is normal control flow here: renders and phonemization are
+                // cancelled all the time, and those exceptions are not failures.
+                var cancelled = args.Exception.InnerExceptions.All(e => e is OperationCanceledException);
+                if (cancelled) {
+                    Log.Debug("Unobserved task exception (cancellation).");
+                } else {
+                    Log.Error(args.Exception, "Unobserved task exception");
+                    try {
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(args.Exception));
+                    } catch (Exception e) {
+                        Log.Error(e, "Failed to report an unobserved task exception");
+                    }
+                }
                 args.SetObserved();
             };
 

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -3,13 +3,16 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using OpenUtau.App.Views;
 using OpenUtau.Colors;
+using OpenUtau.Core;
 using Serilog;
 
 namespace OpenUtau.App {
@@ -27,11 +30,33 @@ namespace OpenUtau.App {
 
         public override void OnFrameworkInitializationCompleted() {
             Log.Information("Framework initialization completed.");
+            RegisterUnhandledExceptionHandlers();
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
                 desktop.MainWindow = new SplashWindow();
             }
 
             base.OnFrameworkInitializationCompleted();
+        }
+
+        // Program.InitLogging() only hooks AppDomain.UnhandledException, which can log but can not
+        // keep the process alive. The two hooks below cover the cases a user actually hits: an
+        // exception escaping an async void UI handler, and a faulted Task nobody awaited.
+        // Both are logged and surfaced instead of taking the whole application down.
+        void RegisterUnhandledExceptionHandlers() {
+            TaskScheduler.UnobservedTaskException += (sender, args) => {
+                Log.Error(args.Exception, "Unobserved task exception");
+                args.SetObserved();
+            };
+
+            Dispatcher.UIThread.UnhandledException += (sender, args) => {
+                Log.Error(args.Exception, "Unhandled UI exception");
+                args.Handled = true;
+                try {
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(args.Exception));
+                } catch (Exception e) {
+                    Log.Error(e, "Failed to report an unhandled UI exception");
+                }
+            };
         }
 
         public void InitializeCulture() {


### PR DESCRIPTION
Two small, unrelated changes that make hidden failures visible. Kept as two commits so they can be split into two PRs if you prefer.

## 1. `ustx: log when a phonemizer returns out-of-order phonemes`

`UPart.Update` silently repairs out-of-order phoneme positions:

```csharp
// Safety treatment after phonemizer output and phoneme overrides.
for (int i = phonemes.Count - 2; i >= 0; --i) {
    phonemes[i].position = Math.Min(phonemes[i].position, phonemes[i + 1].position - 10);
}
```

That repair covers two very different causes:

* a user dragging a phoneme offset past its neighbour — legitimate, and the reason the code exists;
* a phonemizer returning positions out of order — a bug.

Because the repair is silent, the second case is invisible: the part just renders slightly odd. No test can see it either, because the test harness calls `Phonemizer.Process` directly and never reaches this code path.

The patch adds a read-only ordering check on `rawPosition`, which holds the phonemizer output **before** user overrides are applied, so only the phonemizer case is reported. One warning per part; the repair itself is unchanged.

I measured the built-in phonemizers through the test harness and found no violations across 598 phonemes / 318 note groups, so this should normally stay quiet — silence is the useful signal here.

## 2. `app: also handle unobserved task and unhandled UI exceptions`

`Program.InitLogging` registers `AppDomain.CurrentDomain.UnhandledException`, which can log an exception but **cannot keep the process alive**. Nothing is registered for the two cases users actually hit:

* `TaskScheduler.UnobservedTaskException` — a faulted `Task` that nobody awaited is dropped until finalization, and then ignored.
* `Dispatcher.UIThread.UnhandledException` — this code base has 47 `async void` methods, 31 of them menu/button handlers. An exception escaping one reaches the dispatcher, nothing marks it handled, and the process exits: the window simply disappears.

Both hooks are registered in `OnFrameworkInitializationCompleted`, where Avalonia is up and we are on the UI thread. Exceptions are logged and surfaced through the existing `ErrorMessageNotification` path.

**This does not fix any root cause.** A null reference still has to be fixed where it is thrown (as #2390 did). It only turns "process gone" into "error reported", so an unforeseen exception costs the user a dialog instead of their session.

## Verification

| | |
|---|---|
| `dotnet build` with both patches applied | 0 errors, 0 warnings |
| `dotnet test` full suite | 238 passed, 0 failed — identical to the baseline before the change |

Neither change alters behaviour for the existing suite; the App-level one only changes behaviour in cases that would otherwise terminate the process.

Happy to adjust or drop either part — for example lowering the new log to `Debug`, or splitting this into two PRs.
