### PR TITLE
diffsinger: always retake pitch locally; remove the LocalRetaking option

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -533,24 +533,20 @@ namespace OpenUtau.Core.DiffSinger {
         }
 
         public RenderPitchResult LoadRenderedPitch(RenderPhrase phrase, HashSet<int> selectedNotePositions) {
-            return LoadRenderedPitch(phrase, selectedNotePositions, pitchSteps: null, fastRealtime: false, forceLocalRetake: false);
+            return LoadRenderedPitch(phrase, selectedNotePositions, pitchSteps: null, fastRealtime: false);
         }
 
         /// <summary>Live pitch: partial retake for changed notes with fast sampling settings.</summary>
         internal RenderPitchResult LoadRenderedPitchLive(
             RenderPhrase phrase, HashSet<int> selectedNotePositions, double pitchSteps, bool fastRealtime) {
-            return LoadRenderedPitch(phrase, selectedNotePositions, pitchSteps, fastRealtime, forceLocalRetake: true);
+            return LoadRenderedPitch(phrase, selectedNotePositions, pitchSteps, fastRealtime);
         }
 
         RenderPitchResult LoadRenderedPitch(
             RenderPhrase phrase,
             HashSet<int> selectedNotePositions,
             double? pitchSteps,
-            bool fastRealtime,
-            bool forceLocalRetake) {
-            if (!forceLocalRetake && !Preferences.Default.DiffSingerLocalRetaking) {
-                return LoadRenderedPitch(phrase, pitchSteps, fastRealtime);
-            }
+            bool fastRealtime) {
             DiffSingerSinger singer = (DiffSingerSinger) phrase.singer;
             if (!singer.HasPitchPredictor) {
                 throw new Exception("This singer has no pitch predictor.");

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -193,7 +193,6 @@ namespace OpenUtau.Core.Util {
             public bool DiffSingerTensorCache = true;
             public bool DiffSingerVarianceLocalPitchPatch = false;
             public bool DiffSingerLangCodeHide = false;
-            public bool DiffSingerLocalRetaking = false;
             public bool Metronome = false;
             public bool SkipRenderingMutedTracks = false;
             public string Language = string.Empty;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -709,7 +709,6 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerpitchlocalretaking">DiffSinger Pitch Local Retaking</system:String>
   <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>
   <system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -138,7 +138,6 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public partial bool DiffSingerTensorCache { get; set; }
         [Reactive] public partial bool DiffSingerVarianceLocalPitchPatch { get; set; }
         [Reactive] public partial bool DiffSingerLangCodeHide { get; set; }
-        [Reactive] public partial bool DiffSingerLocalRetaking { get; set; }
 
         // Advanced
         [Reactive] public partial bool RememberMid { get; set; }
@@ -222,7 +221,6 @@ namespace OpenUtau.App.ViewModels {
             DiffSingerTensorCache = Preferences.Default.DiffSingerTensorCache;
             DiffSingerVarianceLocalPitchPatch = Preferences.Default.DiffSingerVarianceLocalPitchPatch;
             DiffSingerLangCodeHide = Preferences.Default.DiffSingerLangCodeHide;
-            DiffSingerLocalRetaking = Preferences.Default.DiffSingerLocalRetaking;
             SkipRenderingMutedTracks = Preferences.Default.SkipRenderingMutedTracks;
             ThemeName = Preferences.Default.ThemeName;
             DegreeStyle = Preferences.Default.DegreeStyle;
@@ -447,8 +445,6 @@ namespace OpenUtau.App.ViewModels {
                 value => Preferences.Default.DiffSingerVarianceLocalPitchPatch = value);
             PersistOn(this.WhenAnyValue(vm => vm.DiffSingerLangCodeHide),
                 value => Preferences.Default.DiffSingerLangCodeHide = value);
-            PersistOn(this.WhenAnyValue(vm => vm.DiffSingerLocalRetaking),
-                value => Preferences.Default.DiffSingerLocalRetaking = value);
             PersistOn(this.WhenAnyValue(vm => vm.SkipRenderingMutedTracks),
                 skipRenderingMutedTracks => Preferences.Default.SkipRenderingMutedTracks = skipRenderingMutedTracks);
         }

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -391,10 +391,6 @@
             <TextBlock Text="{DynamicResource prefs.appearance.diffsingerlangcodehide}" HorizontalAlignment="Left" />
             <ToggleSwitch IsChecked="{Binding DiffSingerLangCodeHide}" />
           </Grid>
-          <Grid Margin="0,5,0,0">
-            <TextBlock Text="{DynamicResource prefs.rendering.diffsingerpitchlocalretaking}" HorizontalAlignment="Left" />
-            <ToggleSwitch IsChecked="{Binding DiffSingerLocalRetaking}" />
-          </Grid>
         </StackPanel>
 
         <!-- Advanced -->


### PR DESCRIPTION
## What and why

"Load rendered pitch" (the batch edit behind `pianoroll.menu.notes.loadrenderedpitch`) calls `DiffSingerRenderer`'s selected-notes overload. Until now that overload only performed local retaking when the `DiffSingerLocalRetaking` preference was enabled; by default it fell back to re-predicting the whole phrase and ignored the selection.

Local retaking is what the edit's name implies, and what the live path (`LoadRenderedPitchLive`) already does unconditionally — it bypasses the preference. So the option added a second, mutually exclusive behaviour to the same operation and made the default the less useful one.

This removes the option and always retakes locally:

* with a selection, only the selected notes are re-predicted and spliced into the existing pitch curve;
* with no selection (or a selection covering the phrase), all notes are re-predicted — unchanged;
* playback and the regular render path go through the single-phrase overload and are unaffected.

The preference, its UI toggle in the preferences dialog, the view-model wiring and its string are removed. Existing preferences files that still contain the key are ignored by the JSON deserializer.

## Verification

| | |
|---|---|
| `dotnet build` with the patch | 0 errors, 0 warnings |
| `dotnet test` full suite | 238 passed, 0 failed — identical to the baseline |
| `forceLocalRetake` references on master | exactly the 4 removed by this patch |

The retake logic itself is covered by the existing `BuildRetakeFrameMask_*` / `GetRetakeFrameRanges_*` tests; this PR changes no retake behaviour.
