### PR TITLE
Fix ReadDictionaryAndInit, Parent Alt, Voice color, and ToneShift

### DIFF
--- a/OpenUtau.Core/Api/Phonemizer.cs
+++ b/OpenUtau.Core/Api/Phonemizer.cs
@@ -276,8 +276,12 @@ namespace OpenUtau.Api {
 
         public int GetParentToneShift() {
             if (project != null && track != null) {
-                if (track.TryGetExpDescriptor(project, Core.Format.Ustx.SHFT, out var trackTS)) {
-                    return (int)trackTS.CustomDefaultValue;
+                try {
+                    if (track.TryGetExpDescriptor(project, Core.Format.Ustx.SHFT, out var trackTS) && trackTS != null) {
+                        return (int)trackTS.CustomDefaultValue;
+                    }
+                } catch {
+                    return 0;
                 }
             }
             return 0;
@@ -285,10 +289,14 @@ namespace OpenUtau.Api {
 
         public int? GetParentAlternate() {
             if (project != null && track != null) {
-                if (track.TryGetExpDescriptor(project, Core.Format.Ustx.ALT, out var trackAlt)) {
-                    if (trackAlt.CustomDefaultValue != 0) {
-                        return (int)trackAlt.CustomDefaultValue;
+                try {
+                    if (track.TryGetExpDescriptor(project, Core.Format.Ustx.ALT, out var trackAlt) && trackAlt != null) {
+                        if (trackAlt.CustomDefaultValue != 0) {
+                            return (int)trackAlt.CustomDefaultValue;
+                        }
                     }
+                } catch {
+                    return null;
                 }
             }
             return null;
@@ -296,11 +304,17 @@ namespace OpenUtau.Api {
 
         public string GetParentVoiceColor() {
             if (project != null && track != null) {
-                if (track.TryGetExpDescriptor(project, Core.Format.Ustx.CLR, out var trackCLR)) {
-                    int index = (int)trackCLR.CustomDefaultValue;
-                    if (index >= 0 && index < track.VoiceColorExp.options.Length) {
-                        return track.VoiceColorExp.options[index];
+                try {
+                    if (track.VoiceColorExp != null && track.VoiceColorExp.options != null) {
+                        if (track.TryGetExpDescriptor(project, Core.Format.Ustx.CLR, out var trackCLR) && trackCLR != null) {
+                            int index = (int)trackCLR.CustomDefaultValue;
+                            if (index >= 0 && index < track.VoiceColorExp.options.Length) {
+                                return track.VoiceColorExp.options[index] ?? string.Empty;
+                            }
+                        }
                     }
+                } catch {
+                    return string.Empty;
                 }
             }
             return string.Empty;

--- a/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
@@ -163,6 +163,9 @@ namespace OpenUtau.Plugin.Builtin {
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             error = "";
+            if (singer == null || !singer.Loaded) {
+                return MakeSimpleResult("");
+            }
             var mainNote = notes[0];
             if (mainNote.lyric.StartsWith(FORCED_ALIAS_SYMBOL)) {
                 return MakeForcedAliasResult(mainNote);
@@ -422,6 +425,7 @@ namespace OpenUtau.Plugin.Builtin {
             if (this.singer != singer) {
                 this.singer = singer;
                 dictionaries.Clear();
+                YamlCache.Clear();
 
                 if (this.singer == null || !this.singer.Loaded) {
                     return;
@@ -1129,6 +1133,7 @@ namespace OpenUtau.Plugin.Builtin {
         /// </summary>
         protected virtual string ValidateAlias(string alias, int tone = 0) {
             if (string.IsNullOrEmpty(alias)) return alias;
+            if (singer == null || !singer.Loaded) return alias;
             if (HasOto(alias, tone)) return alias;
 
             var singleRules = yamlFallbacks
@@ -1384,7 +1389,19 @@ namespace OpenUtau.Plugin.Builtin {
         /// <param name="tone"></param>
         /// <returns></returns>
         protected bool HasOto(string alias, int tone) {
-            return singer.TryGetMappedOto(alias, tone, out _);
+            if (singer == null || !singer.Loaded || string.IsNullOrEmpty(alias)) {
+                return false;
+            }
+            if (singer.TryGetMappedOto(alias, tone, out _)) {
+                return true;
+            }
+            if (singer.TryGetOto(alias, out _)) {
+                return true;
+            }
+            if (singer.TryGetMappedOto(alias, tone, "", out _)) {
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -1858,21 +1875,15 @@ namespace OpenUtau.Plugin.Builtin {
 
         protected void ReadDictionaryAndInit() {
             var dictionaryName = GetDictionaryName();
-            if (dictionaryName == null) {
+            if (dictionaryName == null && string.IsNullOrEmpty(YamlFileName)) {
                 return;
             }
-            dictionaries[GetType()] = null;
-            if (Testing) {
+            try {
                 ReadDictionary(dictionaryName);
                 Init();
-                return;
+            } catch (Exception ex) {
+                Log.Error(ex, $"Failed to read dictionary {dictionaryName}");
             }
-            OnAsyncInitStarted();
-            Task.Run(() => {
-                ReadDictionary(dictionaryName);
-                Init();
-                OnAsyncInitFinished();
-            });
         }
 
         private void ReadDictionary(string dictionaryName) {


### PR DESCRIPTION
Switching singers caused a race condition where the phonemizer tried to look up notes before the voicebank and its dictionary finished reloading. Because the singer was not ready, valid phonemes were errored out