### PR TITLE
Fix ClassicSinger `FreeMemory()` falsely retaining the `loaded` state

### DIFF
--- a/OpenUtau.Core/Api/Phonemizer.cs
+++ b/OpenUtau.Core/Api/Phonemizer.cs
@@ -298,8 +298,8 @@ namespace OpenUtau.Api {
             if (project != null && track != null) {
                 if (track.TryGetExpDescriptor(project, Core.Format.Ustx.CLR, out var trackCLR)) {
                     int index = (int)trackCLR.CustomDefaultValue;
-                    if (index >= 0 && index < track.VoiceColorExp.options.Length) {
-                        return track.VoiceColorExp.options[index];
+                    if (index >= 0 && index < trackCLR.options.Length) {
+                        return trackCLR.options[index];
                     }
                 }
             }

--- a/OpenUtau.Core/Classic/ClassicSinger.cs
+++ b/OpenUtau.Core/Classic/ClassicSinger.cs
@@ -176,6 +176,7 @@ namespace OpenUtau.Classic {
                 otos.Clear();
                 otoMap.Clear();
                 errors.Clear();
+                loaded = false;
             }
         }
 


### PR DESCRIPTION
## Summary

Switching a track's classic UTAU voicebank away from and back to a singer sometimes breaks phonemizer for that track, throwing an error and leaving synthesis unusable until the app is restarted.
Fixed the `FreeMemory()` method to reset the `loaded` state so that freeing resources of the previous voicebank will correctly flag the track's singer as unloaded, ensuring the next singer is properly loaded.

## Problem

https://discord.com/channels/551606189386104834/801525671775043625/1546899924208066632
> OpenUtau 570.2 alpha EN C+V phonemizer doesn't work when switching a track's singer to another singer, which is not an EN C+V vb, and back, even when refreshing the Singer's page

https://discord.com/channels/551606189386104834/801525671775043625/1546925146068222032
> Adding to this, basically undoing to switch back to previous singer makes the phonemizer not work...

https://discord.com/channels/551606189386104834/801525671775043625/1548514203399360632 (after 1.570.3-alpha)
> The issue still persists! (restarting OU fixes it BUT it is very inconvenient)

Confirmed bug on version 1.570.4-alpha.

## Cause & Fix

`ClassicSinger.FreeMemory()` clears `subbanks`, `otoSets`/`otos`/`otoMap`, and `errors`, the same resources that `Load()` (and by extension `EnsureLoaded()`) is responsible for populating.
However, due to `FreeMemory()` never resetting the `loaded` flag, the `EnsureLoaded()` method falsely skips the initialization of said resources, causing the voice-color data (residing in `subbanks`) to not load for the subsequent singers.
Fixed by setting `loaded = false` in `FreeMemory()`, so a freed singer correctly reloads its resources the next time it's used.

Also fixed a related null-reference hazard in `Phonemizer.GetParentVoiceColor()`: it looked up the track's voice-color descriptor via `TryGetExpDescriptor` (which safely null-checks and captures it locally), but then re-read the live `track.VoiceColorExp` property again afterward instead of using the captured value.
Since phonemization runs on a background thread while singer switches happen on the UI thread (which can null out `VoiceColorExp` mid-switch), that second read could race and throw.
