### PR TITLE
Fix JSON deserialization error in NotePresets

### DIFF
--- a/OpenUtau.Core/Util/NotePresets.cs
+++ b/OpenUtau.Core/Util/NotePresets.cs
@@ -104,6 +104,8 @@ namespace OpenUtau.Core.Util {
             public float VibratoDrift = 0;
             public float VibratoVolLink = 0;
 
+            public VibratoPreset() { }
+
             public VibratoPreset(string name, float length, float period, float depth, float fadein, float fadeout, float shift, float drift, float volLink) {
                 Name = name;
                 VibratoLength = length;


### PR DESCRIPTION
## Summary

Due to the migration from `Newtonsoft.Json` to `System.Text.Json` for JSON manipulation, the `NotePresets` deserialization of `notepresets.json` was throwing an error, causing the note properties panel to fail to load portamento & vibrato presets.
Added a parameter-less constructor for `VibratoPreset` for the deserializer to bind to field names directly.